### PR TITLE
build: add sandbox build

### DIFF
--- a/packages/vlossom/.gitignore
+++ b/packages/vlossom/.gitignore
@@ -11,6 +11,7 @@ node_modules
 package-lock.json
 .DS_Store
 dist
+dist-sandbox
 dist-ssr
 coverage
 *.local

--- a/packages/vlossom/.gitignore
+++ b/packages/vlossom/.gitignore
@@ -28,6 +28,6 @@ coverage
 *.sw?
 
 *.tsbuildinfo
-visualizer.html
+visualizer*
 *storybook.log
 storybook-static

--- a/packages/vlossom/.vscode/settings.json
+++ b/packages/vlossom/.vscode/settings.json
@@ -3,7 +3,7 @@
     "explorer.fileNesting.patterns": {
         ".env": ".env*, env.d.ts",
         "tsconfig.json": "tsconfig.*.json",
-        "vite.config.*": "jsconfig*, vitest.*, cypress.config.*, playwright.config.*, visualizer.html",
+        "vite.config.ts": "vite.config.common.ts, vite.config.sandbox.ts, jsconfig*, vitest.*, cypress.config.*, playwright.config.*, visualizer.html",
         "package.json": "package-lock.json, pnpm*, .yarnrc*, yarn*, .eslint*, eslint*, .oxlint*, oxlint*, .prettier*, prettier*, .editorconfig, postcss*, tailwind*"
     },
     "editor.codeActionsOnSave": {

--- a/packages/vlossom/.vscode/settings.json
+++ b/packages/vlossom/.vscode/settings.json
@@ -3,7 +3,7 @@
     "explorer.fileNesting.patterns": {
         ".env": ".env*, env.d.ts",
         "tsconfig.json": "tsconfig.*.json",
-        "vite.config.ts": "vite.config.common.ts, vite.config.sandbox.ts, jsconfig*, vitest.*, cypress.config.*, playwright.config.*, visualizer.html",
+        "vite.config.ts": "vite.config.common.ts, vite.config.sandbox.ts, jsconfig*, vitest.*, cypress.config.*, playwright.config.*, visualizer*",
         "package.json": "package-lock.json, pnpm*, .yarnrc*, yarn*, .eslint*, eslint*, .oxlint*, oxlint*, .prettier*, prettier*, .editorconfig, postcss*, tailwind*"
     },
     "editor.codeActionsOnSave": {

--- a/packages/vlossom/README.md
+++ b/packages/vlossom/README.md
@@ -29,6 +29,14 @@ Vlossom is a vibrant and versatile [Vue](https://vuejs.org/) UI library designed
 pnpm install
 ```
 
+## Configuration Files
+
+This project uses separate Vite configuration files for different build targets:
+
+- `vite.config.common.ts` - Shared configuration for both builds
+- `vite.config.ts` - Library build configuration
+- `vite.config.sandbox.ts` - Sandbox app build configuration
+
 ### Sandbox for Development
 
 ```sh
@@ -39,6 +47,12 @@ pnpm dev
 
 ```sh
 pnpm build
+```
+
+### Build Sandbox as Standalone App
+
+```sh
+pnpm build:sandbox
 ```
 
 ### Storybook

--- a/packages/vlossom/package.json
+++ b/packages/vlossom/package.json
@@ -21,9 +21,11 @@
     "type": "module",
     "scripts": {
         "dev": "vite --port 3000",
+        "type-check": "vue-tsc --build",
         "build": "run-p type-check \"build-only {@}\" --",
         "build-only": "vite build",
-        "type-check": "vue-tsc --build",
+        "build:sandbox": "run-p type-check \"build-only:sandbox {@}\" --",
+        "build-only:sandbox": "vite build --config vite.config.sandbox.ts",
         "test": "vitest run",
         "test:watch": "vitest",
         "test:coverage": "vitest run --coverage",

--- a/packages/vlossom/package.json
+++ b/packages/vlossom/package.json
@@ -20,7 +20,7 @@
     ],
     "type": "module",
     "scripts": {
-        "dev": "vite --port 3000",
+        "dev": "vite",
         "type-check": "vue-tsc --build",
         "build": "run-p type-check \"build-only {@}\" --",
         "build-only": "vite build",

--- a/packages/vlossom/vite.config.common.ts
+++ b/packages/vlossom/vite.config.common.ts
@@ -1,0 +1,14 @@
+import { fileURLToPath, URL } from 'node:url';
+import vue from '@vitejs/plugin-vue';
+import vueDevTools from 'vite-plugin-vue-devtools';
+import tailwindcss from '@tailwindcss/vite';
+
+// 공통 설정
+export const commonConfig = {
+    plugins: [vue(), vueDevTools(), tailwindcss()],
+    resolve: {
+        alias: {
+            '@': fileURLToPath(new URL('./src', import.meta.url)),
+        },
+    },
+};

--- a/packages/vlossom/vite.config.common.ts
+++ b/packages/vlossom/vite.config.common.ts
@@ -11,4 +11,8 @@ export const commonConfig = {
             '@': fileURLToPath(new URL('./src', import.meta.url)),
         },
     },
+    server: {
+        port: 3000,
+        open: true,
+    },
 };

--- a/packages/vlossom/vite.config.sandbox.ts
+++ b/packages/vlossom/vite.config.sandbox.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vite';
+import { fileURLToPath, URL } from 'node:url';
+import { commonConfig } from './vite.config.common';
+
+// https://vite.dev/config/
+export default defineConfig({
+    ...commonConfig,
+    build: {
+        outDir: 'dist-sandbox',
+        rollupOptions: {
+            input: {
+                main: fileURLToPath(new URL('./index.html', import.meta.url)),
+            },
+        },
+    },
+    server: {
+        port: 3000,
+        open: true,
+    },
+});

--- a/packages/vlossom/vite.config.sandbox.ts
+++ b/packages/vlossom/vite.config.sandbox.ts
@@ -13,8 +13,4 @@ export default defineConfig({
             },
         },
     },
-    server: {
-        port: 3000,
-        open: true,
-    },
 });

--- a/packages/vlossom/vite.config.sandbox.ts
+++ b/packages/vlossom/vite.config.sandbox.ts
@@ -1,10 +1,17 @@
 import { defineConfig } from 'vite';
 import { fileURLToPath, URL } from 'node:url';
 import { commonConfig } from './vite.config.common';
+import { visualizer } from 'rollup-plugin-visualizer';
 
 // https://vite.dev/config/
 export default defineConfig({
     ...commonConfig,
+    plugins: [
+        ...commonConfig.plugins,
+        visualizer({
+            filename: 'visualizer-sandbox.html',
+        }),
+    ],
     build: {
         outDir: 'dist-sandbox',
         rollupOptions: {

--- a/packages/vlossom/vite.config.ts
+++ b/packages/vlossom/vite.config.ts
@@ -1,11 +1,9 @@
 /// <reference types="vitest/config" />
 import { defineConfig } from 'vite';
-import vue from '@vitejs/plugin-vue';
-import vueDevTools from 'vite-plugin-vue-devtools';
 import dts from 'vite-plugin-dts';
-import tailwindcss from '@tailwindcss/vite';
 import { visualizer } from 'rollup-plugin-visualizer';
 import { fileURLToPath, URL } from 'node:url';
+import { commonConfig } from './vite.config.common';
 
 // https://vite.dev/config/
 import path from 'node:path';
@@ -14,20 +12,14 @@ const dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(file
 
 // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
 export default defineConfig({
+    ...commonConfig,
     plugins: [
-        vue(),
-        vueDevTools(),
+        ...commonConfig.plugins,
         dts(),
-        tailwindcss(),
         visualizer({
             filename: 'visualizer.html',
         }),
     ],
-    resolve: {
-        alias: {
-            '@': fileURLToPath(new URL('./src', import.meta.url)),
-        },
-    },
     build: {
         lib: {
             entry: fileURLToPath(new URL('./src/main.ts', import.meta.url)),

--- a/packages/vlossom/vite.config.ts
+++ b/packages/vlossom/vite.config.ts
@@ -1,8 +1,8 @@
 /// <reference types="vitest/config" />
 import { defineConfig } from 'vite';
-import dts from 'vite-plugin-dts';
-import { visualizer } from 'rollup-plugin-visualizer';
 import { fileURLToPath, URL } from 'node:url';
+import { visualizer } from 'rollup-plugin-visualizer';
+import dts from 'vite-plugin-dts';
 import { commonConfig } from './vite.config.common';
 
 // https://vite.dev/config/
@@ -17,7 +17,7 @@ export default defineConfig({
         ...commonConfig.plugins,
         dts(),
         visualizer({
-            filename: 'visualizer.html',
+            filename: 'visualizer-vlossom.html',
         }),
     ],
     build: {


### PR DESCRIPTION
## Type of PR (check all applicable)
-   [x] Build (build)

## Summary
Vlossom 라이브러리 build와는 별개로 Sandbox app을 build 할 수 있도록 vite.config를 분리합니다

## Description
- 기존 vite.config.ts에는 vlossom build 설정을 남겨둠
- vite.config.common.ts에 공통 build 설정
- vite.config.sandbox.ts에 sandbox build 설정
- npm script 추가 및 수정
- visualizer 파일 생성 분리 (visualizer-vlossom.html, visualizer-sandbox.html)

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
