### PR TITLE
chore(prettier): apply prettier plugins that automatically sort and wrap Tailwind CSS classes and CSS

### DIFF
--- a/packages/vlossom/.prettierrc.json
+++ b/packages/vlossom/.prettierrc.json
@@ -8,5 +8,6 @@
     "trailingComma": "all",
     "bracketSpacing": true,
     "arrowParens": "always",
-    "endOfLine": "auto"
+    "endOfLine": "auto",
+    "plugins": ["prettier-plugin-tailwindcss"]
 }

--- a/packages/vlossom/.prettierrc.json
+++ b/packages/vlossom/.prettierrc.json
@@ -9,5 +9,5 @@
     "bracketSpacing": true,
     "arrowParens": "always",
     "endOfLine": "auto",
-    "plugins": ["prettier-plugin-tailwindcss"]
+    "plugins": ["prettier-plugin-tailwindcss", "prettier-plugin-css-order"]
 }

--- a/packages/vlossom/.prettierrc.json
+++ b/packages/vlossom/.prettierrc.json
@@ -9,5 +9,10 @@
     "bracketSpacing": true,
     "arrowParens": "always",
     "endOfLine": "auto",
-    "plugins": ["prettier-plugin-tailwindcss", "prettier-plugin-css-order"]
+    "plugins": [
+        "prettier-plugin-tailwindcss",
+        "prettier-plugin-css-order",
+        "prettier-plugin-classnames",
+        "prettier-plugin-merge"
+    ]
 }

--- a/packages/vlossom/package.json
+++ b/packages/vlossom/package.json
@@ -90,6 +90,7 @@
         "npm-run-all2": "^8.0.4",
         "playwright": "^1.54.1",
         "prettier": "3.5.3",
+        "prettier-plugin-css-order": "^2.1.2",
         "prettier-plugin-tailwindcss": "^0.6.14",
         "rollup-plugin-visualizer": "^6.0.3",
         "sass": "^1.89.2",

--- a/packages/vlossom/package.json
+++ b/packages/vlossom/package.json
@@ -90,6 +90,7 @@
         "npm-run-all2": "^8.0.4",
         "playwright": "^1.54.1",
         "prettier": "3.5.3",
+        "prettier-plugin-tailwindcss": "^0.6.14",
         "rollup-plugin-visualizer": "^6.0.3",
         "sass": "^1.89.2",
         "storybook": "9.0.17",

--- a/packages/vlossom/package.json
+++ b/packages/vlossom/package.json
@@ -92,6 +92,7 @@
         "prettier": "3.5.3",
         "prettier-plugin-classnames": "^0.8.2",
         "prettier-plugin-css-order": "^2.1.2",
+        "prettier-plugin-merge": "^0.8.0",
         "prettier-plugin-tailwindcss": "^0.6.14",
         "rollup-plugin-visualizer": "^6.0.3",
         "sass": "^1.89.2",

--- a/packages/vlossom/package.json
+++ b/packages/vlossom/package.json
@@ -90,6 +90,7 @@
         "npm-run-all2": "^8.0.4",
         "playwright": "^1.54.1",
         "prettier": "3.5.3",
+        "prettier-plugin-classnames": "^0.8.2",
         "prettier-plugin-css-order": "^2.1.2",
         "prettier-plugin-tailwindcss": "^0.6.14",
         "rollup-plugin-visualizer": "^6.0.3",

--- a/packages/vlossom/pnpm-lock.yaml
+++ b/packages/vlossom/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       prettier:
         specifier: 3.5.3
         version: 3.5.3
+      prettier-plugin-tailwindcss:
+        specifier: ^0.6.14
+        version: 0.6.14(prettier@3.5.3)
       rollup-plugin-visualizer:
         specifier: ^6.0.3
         version: 6.0.3(rollup@4.46.1)
@@ -2525,6 +2528,67 @@ packages:
     resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
     engines: {node: '>=6.0.0'}
 
+  prettier-plugin-tailwindcss@0.6.14:
+    resolution: {integrity: sha512-pi2e/+ZygeIqntN+vC573BcW5Cve8zUB0SSAGxqpB4f96boZF4M3phPVoOFCeypwkpRYdi7+jQ5YJJUwrkGUAg==}
+    engines: {node: '>=14.21.3'}
+    peerDependencies:
+      '@ianvs/prettier-plugin-sort-imports': '*'
+      '@prettier/plugin-hermes': '*'
+      '@prettier/plugin-oxc': '*'
+      '@prettier/plugin-pug': '*'
+      '@shopify/prettier-plugin-liquid': '*'
+      '@trivago/prettier-plugin-sort-imports': '*'
+      '@zackad/prettier-plugin-twig': '*'
+      prettier: ^3.0
+      prettier-plugin-astro: '*'
+      prettier-plugin-css-order: '*'
+      prettier-plugin-import-sort: '*'
+      prettier-plugin-jsdoc: '*'
+      prettier-plugin-marko: '*'
+      prettier-plugin-multiline-arrays: '*'
+      prettier-plugin-organize-attributes: '*'
+      prettier-plugin-organize-imports: '*'
+      prettier-plugin-sort-imports: '*'
+      prettier-plugin-style-order: '*'
+      prettier-plugin-svelte: '*'
+    peerDependenciesMeta:
+      '@ianvs/prettier-plugin-sort-imports':
+        optional: true
+      '@prettier/plugin-hermes':
+        optional: true
+      '@prettier/plugin-oxc':
+        optional: true
+      '@prettier/plugin-pug':
+        optional: true
+      '@shopify/prettier-plugin-liquid':
+        optional: true
+      '@trivago/prettier-plugin-sort-imports':
+        optional: true
+      '@zackad/prettier-plugin-twig':
+        optional: true
+      prettier-plugin-astro:
+        optional: true
+      prettier-plugin-css-order:
+        optional: true
+      prettier-plugin-import-sort:
+        optional: true
+      prettier-plugin-jsdoc:
+        optional: true
+      prettier-plugin-marko:
+        optional: true
+      prettier-plugin-multiline-arrays:
+        optional: true
+      prettier-plugin-organize-attributes:
+        optional: true
+      prettier-plugin-organize-imports:
+        optional: true
+      prettier-plugin-sort-imports:
+        optional: true
+      prettier-plugin-style-order:
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
+
   prettier@3.5.3:
     resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
     engines: {node: '>=14'}
@@ -3084,8 +3148,8 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-component-type-helpers@3.0.4:
-    resolution: {integrity: sha512-WtR3kPk8vqKYfCK/HGyT47lK/T3FaVyWxaCNuosaHYE8h9/k0lYRZ/PI/+T/z2wP+uuNKmL6z30rOcBboOu/YA==}
+  vue-component-type-helpers@3.0.5:
+    resolution: {integrity: sha512-uoNZaJ+a1/zppa/Vgmi8zIOP2PHXDN2rT8NyF+zQRK6ZG94lNB9prcV0GdLJbY9i9lrD47JOVIH92SaiA7oJ1A==}
 
   vue-docgen-api@4.79.2:
     resolution: {integrity: sha512-n9ENAcs+40awPZMsas7STqjkZiVlIjxIKgiJr5rSohDP0/JCrD9VtlzNojafsA1MChm/hz2h3PDtUedx3lbgfA==}
@@ -3962,7 +4026,7 @@ snapshots:
       storybook: 9.0.17(@testing-library/dom@10.4.1)(prettier@3.5.3)
       type-fest: 2.19.0
       vue: 3.5.18(typescript@5.8.3)
-      vue-component-type-helpers: 3.0.4
+      vue-component-type-helpers: 3.0.5
 
   '@tailwindcss/node@4.1.11':
     dependencies:
@@ -5610,6 +5674,10 @@ snapshots:
     dependencies:
       fast-diff: 1.3.0
 
+  prettier-plugin-tailwindcss@0.6.14(prettier@3.5.3):
+    dependencies:
+      prettier: 3.5.3
+
   prettier@3.5.3: {}
 
   pretty-format@27.5.1:
@@ -6205,7 +6273,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-component-type-helpers@3.0.4: {}
+  vue-component-type-helpers@3.0.5: {}
 
   vue-docgen-api@4.79.2(vue@3.5.18(typescript@5.8.3)):
     dependencies:

--- a/packages/vlossom/pnpm-lock.yaml
+++ b/packages/vlossom/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       prettier:
         specifier: 3.5.3
         version: 3.5.3
+      prettier-plugin-classnames:
+        specifier: ^0.8.2
+        version: 0.8.2(prettier@3.5.3)
       prettier-plugin-css-order:
         specifier: ^2.1.2
         version: 2.1.2(postcss@8.5.6)(prettier@3.5.3)
@@ -2549,6 +2552,19 @@ packages:
     resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
     engines: {node: '>=6.0.0'}
 
+  prettier-plugin-classnames@0.8.2:
+    resolution: {integrity: sha512-fmYMIIuahJKn7uy8DxMoG1LsB0WOWee1mB6PpHI8SFKSMD5QJEeJx7DppczEKRAtSTHVa58ze/DU+Xq2mLbMVQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      prettier: ^3
+      prettier-plugin-astro: '*'
+      prettier-plugin-svelte: '*'
+    peerDependenciesMeta:
+      prettier-plugin-astro:
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
+
   prettier-plugin-css-order@2.1.2:
     resolution: {integrity: sha512-vomxPjHI6pOMYcBuouSJHxxQClJXaUpU9rsV9IAO2wrSTZILRRlrxAAR8t9UF6wtczLkLfNRFUwM+ZbGXOONUA==}
     engines: {node: '>=16'}
@@ -3318,6 +3334,9 @@ packages:
   yoctocolors@2.1.1:
     resolution: {integrity: sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==}
     engines: {node: '>=18'}
+
+  zod@3.22.4:
+    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
 
 snapshots:
 
@@ -5713,6 +5732,11 @@ snapshots:
     dependencies:
       fast-diff: 1.3.0
 
+  prettier-plugin-classnames@0.8.2(prettier@3.5.3):
+    dependencies:
+      prettier: 3.5.3
+      zod: 3.22.4
+
   prettier-plugin-css-order@2.1.2(postcss@8.5.6)(prettier@3.5.3):
     dependencies:
       css-declaration-sorter: 7.2.0(postcss@8.5.6)
@@ -6461,3 +6485,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors@2.1.1: {}
+
+  zod@3.22.4: {}

--- a/packages/vlossom/pnpm-lock.yaml
+++ b/packages/vlossom/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       prettier-plugin-css-order:
         specifier: ^2.1.2
         version: 2.1.2(postcss@8.5.6)(prettier@3.5.3)
+      prettier-plugin-merge:
+        specifier: ^0.8.0
+        version: 0.8.0(prettier@3.5.3)
       prettier-plugin-tailwindcss:
         specifier: ^0.6.14
         version: 0.6.14(prettier-plugin-css-order@2.1.2(postcss@8.5.6)(prettier@3.5.3))(prettier@3.5.3)
@@ -1643,6 +1646,10 @@ packages:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
     engines: {node: '>=8'}
 
+  diff@5.1.0:
+    resolution: {integrity: sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==}
+    engines: {node: '>=0.3.1'}
+
   doctypes@1.1.0:
     resolution: {integrity: sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ==}
 
@@ -2570,6 +2577,12 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       prettier: 3.x
+
+  prettier-plugin-merge@0.8.0:
+    resolution: {integrity: sha512-4ovlPwwsuKB+NyQNlXrt2P4I/4dx0P2w2iBkYpgjJHFqglMndYbzYWyY5hHTQj0WFhZYeUjsHKRGKxWsf6tvag==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      prettier: ^3
 
   prettier-plugin-tailwindcss@0.6.14:
     resolution: {integrity: sha512-pi2e/+ZygeIqntN+vC573BcW5Cve8zUB0SSAGxqpB4f96boZF4M3phPVoOFCeypwkpRYdi7+jQ5YJJUwrkGUAg==}
@@ -4855,6 +4868,8 @@ snapshots:
 
   detect-libc@2.0.4: {}
 
+  diff@5.1.0: {}
+
   doctypes@1.1.0: {}
 
   dom-accessibility-api@0.5.16: {}
@@ -5745,6 +5760,11 @@ snapshots:
       prettier: 3.5.3
     transitivePeerDependencies:
       - postcss
+
+  prettier-plugin-merge@0.8.0(prettier@3.5.3):
+    dependencies:
+      diff: 5.1.0
+      prettier: 3.5.3
 
   prettier-plugin-tailwindcss@0.6.14(prettier-plugin-css-order@2.1.2(postcss@8.5.6)(prettier@3.5.3))(prettier@3.5.3):
     dependencies:

--- a/packages/vlossom/pnpm-lock.yaml
+++ b/packages/vlossom/pnpm-lock.yaml
@@ -93,9 +93,12 @@ importers:
       prettier:
         specifier: 3.5.3
         version: 3.5.3
+      prettier-plugin-css-order:
+        specifier: ^2.1.2
+        version: 2.1.2(postcss@8.5.6)(prettier@3.5.3)
       prettier-plugin-tailwindcss:
         specifier: ^0.6.14
-        version: 0.6.14(prettier@3.5.3)
+        version: 0.6.14(prettier-plugin-css-order@2.1.2(postcss@8.5.6)(prettier@3.5.3))(prettier@3.5.3)
       rollup-plugin-visualizer:
         specifier: ^6.0.3
         version: 6.0.3(rollup@4.46.1)
@@ -1561,6 +1564,12 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-declaration-sorter@7.2.0:
+    resolution: {integrity: sha512-h70rUM+3PNFuaBDTLe8wF/cdWu+dOZmb7pJt8Z2sedYbAcQVQV/tEchueg3GWxwqS0cxtbxmaHEdkNACqcvsow==}
+    engines: {node: ^14 || ^16 || >=18}
+    peerDependencies:
+      postcss: ^8.0.9
+
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
@@ -2512,6 +2521,18 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  postcss-less@6.0.0:
+    resolution: {integrity: sha512-FPX16mQLyEjLzEuuJtxA8X3ejDLNGGEG503d2YGZR5Ask1SpDN8KmZUMpzCvyalWRywAn1n1VOA5dcqfCLo5rg==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      postcss: ^8.3.5
+
+  postcss-scss@4.0.9:
+    resolution: {integrity: sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.4.29
+
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
     engines: {node: '>=4'}
@@ -2527,6 +2548,12 @@ packages:
   prettier-linter-helpers@1.0.0:
     resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
     engines: {node: '>=6.0.0'}
+
+  prettier-plugin-css-order@2.1.2:
+    resolution: {integrity: sha512-vomxPjHI6pOMYcBuouSJHxxQClJXaUpU9rsV9IAO2wrSTZILRRlrxAAR8t9UF6wtczLkLfNRFUwM+ZbGXOONUA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      prettier: 3.x
 
   prettier-plugin-tailwindcss@0.6.14:
     resolution: {integrity: sha512-pi2e/+ZygeIqntN+vC573BcW5Cve8zUB0SSAGxqpB4f96boZF4M3phPVoOFCeypwkpRYdi7+jQ5YJJUwrkGUAg==}
@@ -4759,6 +4786,10 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-declaration-sorter@7.2.0(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+
   css.escape@1.5.1: {}
 
   cssesc@3.0.0: {}
@@ -5657,6 +5688,14 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
+  postcss-less@6.0.0(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+
+  postcss-scss@4.0.9(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+
   postcss-selector-parser@6.1.2:
     dependencies:
       cssesc: 3.0.0
@@ -5674,9 +5713,20 @@ snapshots:
     dependencies:
       fast-diff: 1.3.0
 
-  prettier-plugin-tailwindcss@0.6.14(prettier@3.5.3):
+  prettier-plugin-css-order@2.1.2(postcss@8.5.6)(prettier@3.5.3):
+    dependencies:
+      css-declaration-sorter: 7.2.0(postcss@8.5.6)
+      postcss-less: 6.0.0(postcss@8.5.6)
+      postcss-scss: 4.0.9(postcss@8.5.6)
+      prettier: 3.5.3
+    transitivePeerDependencies:
+      - postcss
+
+  prettier-plugin-tailwindcss@0.6.14(prettier-plugin-css-order@2.1.2(postcss@8.5.6)(prettier@3.5.3))(prettier@3.5.3):
     dependencies:
       prettier: 3.5.3
+    optionalDependencies:
+      prettier-plugin-css-order: 2.1.2(postcss@8.5.6)(prettier@3.5.3)
 
   prettier@3.5.3: {}
 


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Chore (chore)

## Summary

개발 시 Tailwind 클래스들과 CSS를 자동 정렬 및 줄바꿈할 수 있도록 하는 플러그인들을 설치합니다.

## Description

### 📌 기본

- `prettier-plugin-tailwind`를 통해 `vue` 파일 저장 시 Tailwind 클래스를 자동 정렬할 수 있도록 합니다.
- `prettier-plugin-css-order`를 통해 `css` 파일 저장 시 CSS 코드를 자동 정렬할 수 있도록 합니다.

### 📌 줄바꿈

- 기본적으로 Prettier의 설정 중 하나인 `printWidth`를 통해 코드 한 줄이 일정 길이 이상 넘어갈 경우 자동 줄바꿈되게 포맷팅 가능합니다.
- 하지만 `prettier-plugin-tailwind`만 설치했을 경우 여기에 설정된 값이 지켜지지 않는 문제가 발생해 이를 [`prettier-plugin-classnames`](https://github.com/ony3000/prettier-plugin-classnames)를 설치해 해결했습니다.
- 추가적으로 `prettier-plugin-tailwind`와의 호환을 위해 `prettier-plugin-merge`를 설치했습니다. 이 플러그인은 [여러 개의 Prettier 플러그인이 특정 서식에 대한 텍스트를 처리하려는 상황해서 마지막 플러그인만 사용되는 것을 방지](https://github.com/ony3000/prettier-plugin-classnames?tab=readme-ov-file#compatibility-with-other-prettier-plugins)해줍니다.

이로써 이전에 언급했던 [eslint 플러그인](https://github.com/schoero/eslint-plugin-better-tailwindcss?tab=readme-ov-file)과 거의 동일한 기능들을 Prettier 플러그인만으로 구현했습니다.

### 📌 정렬 순서 커스텀과 관련해서..

- `prettier-plugin-tailwind`의 경우 [커스텀이 불가능](https://tailwindcss.com/blog/automatic-class-sorting-with-prettier#customization)합니다.
- [`Headwind`라는 VsCode 플러그인](https://github.com/heybourn/headwind?tab=readme-ov-file)을 사용하게 될 경우 커스텀이 가능하지만, Cursor 확장 프로그램에 검색 시 뜨지 않아 따로 설치해야 한다는 번거로움이 있습니다.
- Headwind를 어찌저찌 설치하더라도, [Prettier와 충돌하는 사례가 존재](https://stackoverflow.com/questions/71377814/prettier-code-formatting-is-not-splitting-classnames-in-jsx-or-html)하는 것으로 보입니다.

**따라서 정렬 순서 커스텀은 현재로서는 불가능 하다고 판단됩니다.**
<!-- Uncomment below if necessary -->
## Screenshots or Recordings

![class-sort](https://github.com/user-attachments/assets/fbbd8d55-bd4c-4473-bdcd-3b03bc170d43)
![css-sort](https://github.com/user-attachments/assets/ecfe8443-e5c6-4e5a-bfef-cb983fdf4a4e)

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
