### PR TITLE
fix: prevent css variables cascading

### DIFF
--- a/packages/vlossom/src/components/vs-avatar/VsAvatar.css
+++ b/packages/vlossom/src/components/vs-avatar/VsAvatar.css
@@ -1,17 +1,27 @@
 .vs-avatar {
+    --vs-avatar-border: 0.1rem solid var(--vs-line-color);
+    --vs-avatar-borderRadius: calc(var(--vs-radius-ratio) * var(--vs-radius));
+    --vs-avatar-backgroundColor: var(--vs-comp-bg);
+    --vs-avatar-width: 4rem;
+    --vs-avatar-height: 4rem;
+    --vs-avatar-fontColor: var(--vs-comp-font);
+    --vs-avatar-fontWeight: 400;
+    --vs-avatar-fontSize: var(--vs-font-size);
+    --vs-avatar-objectFit: contain;
+
     @apply relative inline-flex items-center justify-center overflow-hidden whitespace-nowrap select-none;
 
-    border: var(--vs-avatar-border, 0.1rem solid var(--vs-line-color));
-    border-radius: var(--vs-avatar-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius)));
-    background-color: var(--vs-avatar-backgroundColor, var(--vs-comp-bg));
-    width: var(--vs-avatar-width, 4rem);
-    height: var(--vs-avatar-height, 4rem);
-    color: var(--vs-avatar-fontColor, var(--vs-comp-font));
-    font-weight: var(--vs-avatar-fontWeight, 400);
-    font-size: var(--vs-avatar-fontSize, var(--vs-font-size));
+    border: var(--vs-avatar-border);
+    border-radius: var(--vs-avatar-borderRadius);
+    background-color: var(--vs-avatar-backgroundColor);
+    width: var(--vs-avatar-width);
+    height: var(--vs-avatar-height);
+    color: var(--vs-avatar-fontColor);
+    font-weight: var(--vs-avatar-fontWeight);
+    font-size: var(--vs-avatar-fontSize);
 
     :deep(img) {
         @apply block w-full h-full;
-        object-fit: var(--vs-avatar-objectFit, contain);
+        object-fit: var(--vs-avatar-objectFit);
     }
 }

--- a/packages/vlossom/src/components/vs-grid/VsGrid.css
+++ b/packages/vlossom/src/components/vs-grid/VsGrid.css
@@ -1,9 +1,16 @@
 .vs-grid {
+    --vs-grid-gridSize: 12;
+    --vs-grid-columnGap: 0;
+    --vs-grid-rowGap: 0;
+    --vs-grid-width: 100%;
+    --vs-grid-height: 100%;
+
     @apply relative grid;
-    grid-template-columns: repeat(var(--vs-grid-gridSize, 12), minmax(0, 1fr));
-    column-gap: var(--vs-grid-columnGap, 0);
-    row-gap: var(--vs-grid-rowGap, 0);
+
+    grid-template-columns: repeat(var(--vs-grid-gridSize), minmax(0, 1fr));
+    column-gap: var(--vs-grid-columnGap);
+    row-gap: var(--vs-grid-rowGap);
     container-type: inline-size;
-    width: var(--vs-grid-width, 100%);
-    height: var(--vs-grid-height, 100%);
+    width: var(--vs-grid-width);
+    height: var(--vs-grid-height);
 }

--- a/packages/vlossom/src/components/vs-loading/VsLoading.css
+++ b/packages/vlossom/src/components/vs-loading/VsLoading.css
@@ -12,17 +12,22 @@
 }
 
 .vs-loading {
+    --vs-loading-width: 8rem;
+    --vs-loading-height: 10rem;
+    --vs-loading-color: var(--vs-primary-comp-bg);
+    --vs-loading-barWidth: 11.11%;
+
     @apply relative inline-flex justify-center items-center m-auto;
 
-    width: var(--vs-loading-width, 8rem);
-    height: var(--vs-loading-height, 10rem);
+    width: var(--vs-loading-width);
+    height: var(--vs-loading-height);
 
     [class^='vs-loading-rect'] {
         @apply inline-block h-full;
 
         animation: vs-loading-animation 1s infinite cubic-bezier(0.25, 0.25, 0.75, 0.75);
-        background-color: var(--vs-loading-color, var(--vs-primary-comp-bg));
-        width: var(--vs-loading-barWidth, 11.11%);
+        background-color: var(--vs-loading-color);
+        width: var(--vs-loading-barWidth);
     }
 
     .vs-loading-rect2 {
@@ -39,6 +44,6 @@
     }
 
     > div ~ div {
-        margin-left: calc((100% - (var(--vs-loading-barWidth, 11.11%) * 5)) / 4);
+        margin-left: calc((100% - (var(--vs-loading-barWidth) * 5)) / 4);
     }
 }

--- a/packages/vlossom/src/components/vs-loading/__tests__/vs-loading.test.ts
+++ b/packages/vlossom/src/components/vs-loading/__tests__/vs-loading.test.ts
@@ -40,17 +40,7 @@ describe('VsLoading', () => {
 
             // then
             expect(wrapper.classes()).toContain('vs-loading');
-            expect(wrapper.classes()).toContain('vs-red');
-        });
-
-        it('colorScheme이 주어지지 않으면 기본 스타일이 적용되어야 한다', () => {
-            // given, when
-            const wrapper = mount(VsLoading);
-
-            // then
-            expect(wrapper.classes()).toContain('vs-loading');
-            expect(wrapper.classes()).not.toContain('vs-red');
-            expect(wrapper.classes()).not.toContain('vs-blue');
+            expect(wrapper.classes()).toContain('vs-color-scheme-red');
         });
     });
 

--- a/packages/vlossom/src/composables/__tests__/color-scheme-composable.test.ts
+++ b/packages/vlossom/src/composables/__tests__/color-scheme-composable.test.ts
@@ -117,10 +117,10 @@ describe('useColorScheme', () => {
             const { colorSchemeClass } = useColorScheme(component, colorScheme);
 
             // then
-            expect(colorSchemeClass.value).toBe('vs-red');
+            expect(colorSchemeClass.value).toBe('vs-color-scheme-red');
         });
 
-        it('colorScheme 값이 없을 때 vs-none 클래스를 생성해야 함', () => {
+        it('colorScheme 값이 없을 때 vs-color-scheme-default 클래스를 생성해야 함', () => {
             // given
             const colorScheme: Ref<ColorScheme | undefined> = ref(undefined);
             const component = VsComponent.VsButton;
@@ -129,7 +129,7 @@ describe('useColorScheme', () => {
             const { colorSchemeClass } = useColorScheme(component, colorScheme);
 
             // then
-            expect(colorSchemeClass.value).toBe('vs-none');
+            expect(colorSchemeClass.value).toBe('vs-color-scheme-default');
         });
 
         it('옵션 스토어의 값으로 CSS 클래스를 생성해야 함', () => {
@@ -144,7 +144,7 @@ describe('useColorScheme', () => {
             const { colorSchemeClass } = useColorScheme(component, colorScheme);
 
             // then
-            expect(colorSchemeClass.value).toBe('vs-emerald');
+            expect(colorSchemeClass.value).toBe('vs-color-scheme-emerald');
         });
 
         it('colorScheme 값 변경 시 CSS 클래스가 반응적으로 업데이트되어야 함', () => {
@@ -154,22 +154,22 @@ describe('useColorScheme', () => {
             const { colorSchemeClass } = useColorScheme(component, colorScheme);
 
             // then
-            expect(colorSchemeClass.value).toBe('vs-none');
+            expect(colorSchemeClass.value).toBe('vs-color-scheme-default');
 
             // when
             colorScheme.value = 'violet';
             // then
-            expect(colorSchemeClass.value).toBe('vs-violet');
+            expect(colorSchemeClass.value).toBe('vs-color-scheme-violet');
 
             // when
             colorScheme.value = 'amber';
             // then
-            expect(colorSchemeClass.value).toBe('vs-amber');
+            expect(colorSchemeClass.value).toBe('vs-color-scheme-amber');
 
             // when
             colorScheme.value = undefined;
             // then
-            expect(colorSchemeClass.value).toBe('vs-none');
+            expect(colorSchemeClass.value).toBe('vs-color-scheme-default');
         });
     });
 
@@ -187,19 +187,19 @@ describe('useColorScheme', () => {
 
             // then
             expect(computedColorScheme.value).toBe('blue');
-            expect(colorSchemeClass.value).toBe('vs-blue');
+            expect(colorSchemeClass.value).toBe('vs-color-scheme-blue');
 
             // when
             colorScheme.value = 'red';
             // then
             expect(computedColorScheme.value).toBe('red');
-            expect(colorSchemeClass.value).toBe('vs-red');
+            expect(colorSchemeClass.value).toBe('vs-color-scheme-red');
 
             // when
             colorScheme.value = undefined;
             // then
             expect(computedColorScheme.value).toBe('blue');
-            expect(colorSchemeClass.value).toBe('vs-blue');
+            expect(colorSchemeClass.value).toBe('vs-color-scheme-blue');
         });
     });
 });

--- a/packages/vlossom/src/composables/color-scheme-composable.ts
+++ b/packages/vlossom/src/composables/color-scheme-composable.ts
@@ -9,7 +9,7 @@ export function useColorScheme(component: VsComponent | string, colorScheme: Ref
         () => colorScheme.value || optionsStore.colorScheme.value[component] || undefined,
     );
 
-    const colorSchemeClass = computed(() => `vs-${computedColorScheme.value || 'none'}`);
+    const colorSchemeClass = computed(() => `vs-color-scheme-${computedColorScheme.value || 'default'}`);
 
     return {
         computedColorScheme,

--- a/packages/vlossom/src/styles/color-scheme.scss
+++ b/packages/vlossom/src/styles/color-scheme.scss
@@ -3,13 +3,7 @@ $colors:
     'purple', 'fuchsia', 'pink', 'rose', 'slate', 'gray', 'zinc', 'neutral', 'stone';
 
 :root {
-    --vs-no-color: var(--vs-white);
-    --vs-no-color-inverse: var(--vs-black);
-
-    --vs-app-bg: #f8f8f8;
-    --vs-dimmed-bg: rgba(0, 0, 0, 0.45);
-
-    .vs-none {
+    .vs-color-scheme-default {
         --vs-comp-font: var(--vs-gray-900);
         --vs-comp-bg: var(--vs-white);
         --vs-comp-shadow: rgba(0, 0, 0, 0.16);
@@ -29,13 +23,7 @@ $colors:
     }
 
     &.vs-dark {
-        --vs-no-color: var(--vs-black);
-        --vs-no-color-inverse: var(--vs-white);
-
-        --vs-app-bg: #14151f;
-        --vs-dimmed-bg: rgba(0, 0, 0, 0.6);
-
-        .vs-none {
+        .vs-color-scheme-default {
             --vs-comp-font: var(--vs-gray-50);
             --vs-comp-bg: var(--vs-black);
             --vs-comp-shadow: rgba(255, 255, 255, 0.25);
@@ -56,7 +44,7 @@ $colors:
     }
 
     @each $color in $colors {
-        .vs-#{$color} {
+        .vs-color-scheme-#{$color} {
             --vs-comp-font: var(--vs-#{$color}-900);
             --vs-comp-bg: var(--vs-#{$color}-100);
             --vs-comp-shadow: rgba(0, 0, 0, 0.25);
@@ -78,7 +66,7 @@ $colors:
 
     &.vs-dark {
         @each $color in $colors {
-            .vs-#{$color} {
+            .vs-color-scheme-#{$color} {
                 --vs-comp-font: var(--vs-#{$color}-200);
                 --vs-comp-bg: var(--vs-#{$color}-900);
                 --vs-comp-shadow: rgba(255, 255, 255, 0.25);

--- a/packages/vlossom/src/styles/variables.css
+++ b/packages/vlossom/src/styles/variables.css
@@ -1,5 +1,19 @@
 @layer base {
     :root {
+        --vs-no-color: var(--vs-white);
+        --vs-no-color-inverse: var(--vs-black);
+
+        --vs-app-bg: #f8f8f8;
+        --vs-dimmed-bg: rgba(0, 0, 0, 0.45);
+
+        @variant dark {
+            --vs-no-color: var(--vs-black);
+            --vs-no-color-inverse: var(--vs-white);
+
+            --vs-app-bg: #14151f;
+            --vs-dimmed-bg: rgba(0, 0, 0, 0.6);
+        }
+
         --vs-radius-ratio: 1;
         --vs-radius-xs: 0.2rem;
         --vs-radius-sm: 0.5rem;


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)


## Summary
CSS 변수가 cascading 되어서 버그를 유발할 수 있는 부분을 고칩니다

## Description
- color-scheme variables
    - 현재 class 기반으로 구현된 방식이 가장 효율적이라서 유지합니다
    - 단, class 이름이 color-scheme class라는 것을 알려주기 위해 변경합니다
        - vs-none -> vs-color-scheme-default
        - vs-red -> vs-color-scheme-red ...
- style-set variables
    - CSS 최상단에 기본 variables 선언부를 둠으로써 상속받는 변수를 차단합니다
    - 변수 사용 시 fallback으로 있던 기본값이 위로 올라왔다고 보면 됨
    - 아래 이미지를 보면 상위에 있는 gridSize가 자식에게 안 내려가는 것을 확인할 수 있음

<img width="635" height="488" alt="스크린샷 2025-08-12 오후 7 08 57" src="https://github.com/user-attachments/assets/f723ffdb-7531-4e6d-9829-4309c128daf6" />


<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
