### PR TITLE
chore(prettier): reformat Prettier plugin and normalize Tailwind and CSS ordering

### DIFF
--- a/packages/vlossom/.prettierrc.json
+++ b/packages/vlossom/.prettierrc.json
@@ -10,8 +10,8 @@
     "arrowParens": "always",
     "endOfLine": "auto",
     "plugins": [
-        "prettier-plugin-tailwindcss",
         "prettier-plugin-css-order",
+        "prettier-plugin-tailwindcss",
         "prettier-plugin-classnames",
         "prettier-plugin-merge"
     ]


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Chore (chore)

## Summary

- Tailwind와 CSS 클래스 정렬이 모두 올바르게 작동할 수 있도록 Prettier 플러그인 순서를 수정합니다.

## Description

- Prettier 플러그인 순서를 조정합니다.
- 이제 다음 기능들이 모두 정상 작동 합니다.
    - `.vue` 파일 내에서의 Tailwind 클래스 정렬
    - `.vue` 파일 내에서의 Tailwind 클래스 줄바꿈
    - `.css` 파일 내에서의 Tailwind 클래스 정렬
    - `.css` 파일 내에서의 CSS 클래스 정렬

- Related Issue #70 

