### PR TITLE
fix(css): fix css cascading bug

### DIFF
--- a/packages/vlossom/src/components/vs-avatar/VsAvatar.css
+++ b/packages/vlossom/src/components/vs-avatar/VsAvatar.css
@@ -1,27 +1,27 @@
 .vs-avatar {
-    --vs-avatar-border: 0.1rem solid var(--vs-line-color);
-    --vs-avatar-borderRadius: calc(var(--vs-radius-ratio) * var(--vs-radius));
-    --vs-avatar-backgroundColor: var(--vs-comp-bg);
-    --vs-avatar-width: 4rem;
-    --vs-avatar-height: 4rem;
-    --vs-avatar-fontColor: var(--vs-comp-font);
-    --vs-avatar-fontWeight: 400;
-    --vs-avatar-fontSize: var(--vs-font-size);
-    --vs-avatar-objectFit: contain;
+    --vs-avatar-border: initial;
+    --vs-avatar-borderRadius: initial;
+    --vs-avatar-backgroundColor: initial;
+    --vs-avatar-width: initial;
+    --vs-avatar-height: initial;
+    --vs-avatar-fontColor: initial;
+    --vs-avatar-fontWeight: initial;
+    --vs-avatar-fontSize: initial;
+    --vs-avatar-objectFit: initial;
 
     @apply relative inline-flex items-center justify-center overflow-hidden whitespace-nowrap select-none;
 
-    border: var(--vs-avatar-border);
-    border-radius: var(--vs-avatar-borderRadius);
-    background-color: var(--vs-avatar-backgroundColor);
-    width: var(--vs-avatar-width);
-    height: var(--vs-avatar-height);
-    color: var(--vs-avatar-fontColor);
-    font-weight: var(--vs-avatar-fontWeight);
-    font-size: var(--vs-avatar-fontSize);
+    border: var(--vs-avatar-border, 1px solid var(--vs-line-color));
+    border-radius: var(--vs-avatar-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius)));
+    background-color: var(--vs-avatar-backgroundColor, var(--vs-comp-bg));
+    width: var(--vs-avatar-width, 3.6rem);
+    height: var(--vs-avatar-height, 3.6rem);
+    color: var(--vs-avatar-fontColor, var(--vs-comp-font));
+    font-weight: var(--vs-avatar-fontWeight, 400);
+    font-size: var(--vs-avatar-fontSize, var(--vs-font-size));
 
     :deep(img) {
-        @apply block w-full h-full;
-        object-fit: var(--vs-avatar-objectFit);
+        @apply block h-full w-full;
+        object-fit: var(--vs-avatar-objectFit, contain);
     }
 }

--- a/packages/vlossom/src/components/vs-grid/VsGrid.css
+++ b/packages/vlossom/src/components/vs-grid/VsGrid.css
@@ -1,16 +1,16 @@
 .vs-grid {
-    --vs-grid-gridSize: 12;
-    --vs-grid-columnGap: 0;
-    --vs-grid-rowGap: 0;
-    --vs-grid-width: 100%;
-    --vs-grid-height: 100%;
+    --vs-grid-gridSize: initial;
+    --vs-grid-columnGap: initial;
+    --vs-grid-rowGap: initial;
+    --vs-grid-width: initial;
+    --vs-grid-height: initial;
 
     @apply relative grid;
 
-    grid-template-columns: repeat(var(--vs-grid-gridSize), minmax(0, 1fr));
-    column-gap: var(--vs-grid-columnGap);
-    row-gap: var(--vs-grid-rowGap);
+    grid-template-columns: repeat(var(--vs-grid-gridSize, 12), minmax(0, 1fr));
+    column-gap: var(--vs-grid-columnGap, 0);
+    row-gap: var(--vs-grid-rowGap, 0);
     container-type: inline-size;
-    width: var(--vs-grid-width);
-    height: var(--vs-grid-height);
+    width: var(--vs-grid-width, 100%);
+    height: var(--vs-grid-height, 100%);
 }

--- a/packages/vlossom/src/components/vs-layout/VsLayout.css
+++ b/packages/vlossom/src/components/vs-layout/VsLayout.css
@@ -1,4 +1,4 @@
 .vs-layout {
-    @apply relative w-full h-full;
+    @apply relative h-full w-full;
     transition: padding 0.3s;
 }

--- a/packages/vlossom/src/components/vs-loading/VsLoading.css
+++ b/packages/vlossom/src/components/vs-loading/VsLoading.css
@@ -12,22 +12,22 @@
 }
 
 .vs-loading {
-    --vs-loading-width: 8rem;
-    --vs-loading-height: 10rem;
-    --vs-loading-color: var(--vs-primary-comp-bg);
-    --vs-loading-barWidth: 11.11%;
+    --vs-loading-width: initial;
+    --vs-loading-height: initial;
+    --vs-loading-color: initial;
+    --vs-loading-barWidth: initial;
 
-    @apply relative inline-flex justify-center items-center m-auto;
+    @apply relative m-auto inline-flex items-center justify-center;
 
-    width: var(--vs-loading-width);
-    height: var(--vs-loading-height);
+    width: var(--vs-loading-width, 8rem);
+    height: var(--vs-loading-height, 10rem);
 
     [class^='vs-loading-rect'] {
         @apply inline-block h-full;
 
         animation: vs-loading-animation 1s infinite cubic-bezier(0.25, 0.25, 0.75, 0.75);
-        background-color: var(--vs-loading-color);
-        width: var(--vs-loading-barWidth);
+        background-color: var(--vs-loading-color, var(--vs-primary-comp-bg));
+        width: var(--vs-loading-barWidth, 11.11%);
     }
 
     .vs-loading-rect2 {
@@ -44,6 +44,6 @@
     }
 
     > div ~ div {
-        margin-left: calc((100% - (var(--vs-loading-barWidth) * 5)) / 4);
+        margin-left: calc((100% - (var(--vs-loading-barWidth, 11.11%) * 5)) / 4);
     }
 }

--- a/packages/vlossom/src/components/vs-responsive/VsResponsive.css
+++ b/packages/vlossom/src/components/vs-responsive/VsResponsive.css
@@ -1,10 +1,10 @@
 .vs-responsive {
-    --vs-grid-xs: 12;
-    --vs-width-xs: 100%;
+    --vs-grid-xs: initial;
+    --vs-width-xs: initial;
 
     @apply relative box-border;
-    grid-column-start: span var(--vs-grid-xs);
-    width: var(--vs-width-xs);
+    grid-column-start: span var(--vs-grid-xs, 12);
+    width: var(--vs-width-xs, 100%);
 
     @container (min-width: 640px) {
         &.vs-width-sm {

--- a/packages/vlossom/src/styles/variables.css
+++ b/packages/vlossom/src/styles/variables.css
@@ -16,10 +16,10 @@
 
         --vs-radius-ratio: 1;
         --vs-radius-xs: 0.2rem;
-        --vs-radius-sm: 0.5rem;
-        --vs-radius: 0.8rem;
-        --vs-radius-lg: 1.2rem;
-        --vs-radius-xl: 1.6rem;
+        --vs-radius-sm: 0.4rem;
+        --vs-radius: 0.6rem;
+        --vs-radius-lg: 0.9rem;
+        --vs-radius-xl: 1.2rem;
 
         --vs-grid-size: 12;
         --vs-grid-xs: 12;


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)


## Summary
cascading을 initial로 reset하도록 변경

## Description
- 상단에서 기본 value를 설정해버리면 하위에서 사용할 때 기본값만 동작하게 되어 의도와 다르게 동작함
- `var()`로 쓰더라도 값이 initial이면 빈 값으로 취급되기 때문에 뒤에 기본값 설정한 부분이 동작

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
