### PR TITLE
feat(style-set): create common style-set type

### DIFF
--- a/packages/vlossom/src/components/vs-avatar/VsAvatar.css
+++ b/packages/vlossom/src/components/vs-avatar/VsAvatar.css
@@ -1,16 +1,18 @@
 .vs-avatar {
+    --vs-avatar-backgroundColor: initial;
     --vs-avatar-border: initial;
     --vs-avatar-borderRadius: initial;
-    --vs-avatar-backgroundColor: initial;
-    --vs-avatar-width: initial;
-    --vs-avatar-height: initial;
+    --vs-avatar-opacity: initial;
     --vs-avatar-fontColor: initial;
     --vs-avatar-fontWeight: initial;
     --vs-avatar-fontSize: initial;
+    --vs-avatar-width: initial;
+    --vs-avatar-height: initial;
     --vs-avatar-objectFit: initial;
 
     @apply relative inline-flex items-center justify-center overflow-hidden whitespace-nowrap select-none;
 
+    opacity: var(--vs-avatar-opacity, 1);
     border: var(--vs-avatar-border, 1px solid var(--vs-line-color));
     border-radius: var(--vs-avatar-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius)));
     background-color: var(--vs-avatar-backgroundColor, var(--vs-comp-bg));

--- a/packages/vlossom/src/components/vs-avatar/VsAvatar.css
+++ b/packages/vlossom/src/components/vs-avatar/VsAvatar.css
@@ -19,7 +19,7 @@
     width: var(--vs-avatar-width, 3.6rem);
     height: var(--vs-avatar-height, 3.6rem);
     color: var(--vs-avatar-fontColor, var(--vs-comp-font));
-    font-weight: var(--vs-avatar-fontWeight, 400);
+    font-weight: var(--vs-avatar-fontWeight, --vs-font-weight);
     font-size: var(--vs-avatar-fontSize, var(--vs-font-size));
 
     :deep(img) {

--- a/packages/vlossom/src/components/vs-avatar/__stories__/vs-avatar.chromatic.stories.ts
+++ b/packages/vlossom/src/components/vs-avatar/__stories__/vs-avatar.chromatic.stories.ts
@@ -11,7 +11,7 @@ const meta: Meta<typeof VsAvatar> = {
             return { args };
         },
         template: `
-            <div style="display:flex; align-items:center;">
+            <div class="flex items-center">
                 <vs-avatar v-bind="args">VS</vs-avatar>
 
                 <vs-avatar v-bind="args">

--- a/packages/vlossom/src/components/vs-avatar/types.ts
+++ b/packages/vlossom/src/components/vs-avatar/types.ts
@@ -1,5 +1,5 @@
 import type VsAvatar from './VsAvatar.vue';
-import type { BoxStyleSet, SizeStyleSet, TextStyleSet } from '@/declaration';
+import type { BoxStyleSet, TextStyleSet } from '@/declaration';
 
 declare module 'vue' {
     interface GlobalComponents {
@@ -10,8 +10,7 @@ declare module 'vue' {
 export type { VsAvatar };
 
 export interface VsAvatarStyleSet
-    extends SizeStyleSet,
-        Omit<BoxStyleSet, 'display' | 'padding'>,
+    extends Omit<BoxStyleSet, 'display' | 'padding'>,
         Omit<TextStyleSet, 'whiteSpace' | 'lineHeight'> {
     objectFit?: 'cover' | 'fill' | 'contain' | 'none' | 'scale-down';
 }

--- a/packages/vlossom/src/components/vs-avatar/types.ts
+++ b/packages/vlossom/src/components/vs-avatar/types.ts
@@ -1,4 +1,5 @@
 import type VsAvatar from './VsAvatar.vue';
+import type { BoxStyleSet, SizeStyleSet, TextStyleSet } from '@/declaration';
 
 declare module 'vue' {
     interface GlobalComponents {
@@ -8,14 +9,9 @@ declare module 'vue' {
 
 export type { VsAvatar };
 
-export interface VsAvatarStyleSet {
-    backgroundColor?: string;
-    border?: string;
-    borderRadius?: string;
-    fontColor?: string;
-    fontSize?: string;
-    fontWeight?: string | number;
-    height?: string;
+export interface VsAvatarStyleSet
+    extends SizeStyleSet,
+        Omit<BoxStyleSet, 'display' | 'padding'>,
+        Omit<TextStyleSet, 'whiteSpace' | 'lineHeight'> {
     objectFit?: 'cover' | 'fill' | 'contain' | 'none' | 'scale-down';
-    width?: string;
 }

--- a/packages/vlossom/src/components/vs-bar/VsBar.css
+++ b/packages/vlossom/src/components/vs-bar/VsBar.css
@@ -7,12 +7,14 @@
     --vs-bar-fontSize: initial;
     --vs-bar-fontWeight: initial;
     --vs-bar-height: initial;
+    --vs-bar-lineHeight: initial;
     --vs-bar-padding: initial;
     --vs-bar-position: initial;
     --vs-bar-top: initial;
     --vs-bar-bottom: initial;
     --vs-bar-left: initial;
     --vs-bar-right: initial;
+    --vs-bar-whiteSpace: initial;
     --vs-bar-width: initial;
     --vs-bar-zIndex: initial;
 
@@ -34,6 +36,8 @@
     color: var(--vs-bar-fontColor, var(--vs-comp-font));
     font-weight: var(--vs-bar-fontWeight, 400);
     font-size: var(--vs-bar-fontSize, var(--vs-font-size));
+    line-height: var(--vs-bar-lineHeight, var(--vs-line-height));
+    white-space: var(--vs-bar-whiteSpace, normal);
 
     &.vs-primary {
         border: var(--vs-bar-border, 1px solid var(--vs-primary-comp-bg));

--- a/packages/vlossom/src/components/vs-bar/types.ts
+++ b/packages/vlossom/src/components/vs-bar/types.ts
@@ -1,3 +1,4 @@
+import type { BoxStyleSet, TextStyleSet } from '@/declaration';
 import type VsBar from './VsBar.vue';
 
 declare module 'vue' {
@@ -8,21 +9,12 @@ declare module 'vue' {
 
 export type { VsBar };
 
-export interface VsBarStyleSet {
-    backgroundColor?: string;
-    border?: string;
-    borderRadius?: string;
-    boxShadow?: string;
-    fontColor?: string;
-    fontSize?: string;
-    fontWeight?: string;
-    height?: string;
-    padding?: string;
+export interface VsBarStyleSet extends Omit<BoxStyleSet, 'display' | 'opacity'>, TextStyleSet {
     position?: 'fixed' | 'absolute' | 'relative' | 'sticky' | 'static';
+    boxShadow?: string;
     top?: string | number;
     bottom?: string | number;
     left?: string | number;
     right?: string | number;
-    width?: string;
     zIndex?: string;
 }

--- a/packages/vlossom/src/components/vs-button/VsButton.css
+++ b/packages/vlossom/src/components/vs-button/VsButton.css
@@ -24,10 +24,10 @@
     width: var(--vs-button-width, auto);
     height: var(--vs-button-height, var(--vs-default-comp-height));
     color: var(--vs-button-fontColor, var(--vs-comp-font));
-    font-weight: var(--vs-button-fontWeight, 400);
+    font-weight: var(--vs-button-fontWeight, var(--vs-font-weight));
     font-size: var(--vs-button-fontSize, var(--vs-font-size));
-    line-height: var(--vs-button-lineHeight, 1.6);
-    white-space: var(--vs-button-whiteSpace, normal);
+    line-height: var(--vs-button-lineHeight, var(--vs-line-height));
+    white-space: var(--vs-button-whiteSpace, var(--vs-white-space));
 
     .vs-button-loading {
         @apply absolute flex h-full w-full items-center justify-center;

--- a/packages/vlossom/src/components/vs-button/VsButton.css
+++ b/packages/vlossom/src/components/vs-button/VsButton.css
@@ -1,16 +1,22 @@
 .vs-button {
+    --vs-button-display: initial;
     --vs-button-backgroundColor: initial;
+    --vs-button-padding: initial;
     --vs-button-border: initial;
     --vs-button-borderRadius: initial;
+    --vs-button-opacity: initial;
     --vs-button-fontColor: initial;
     --vs-button-fontSize: initial;
     --vs-button-fontWeight: initial;
-    --vs-button-height: initial;
-    --vs-button-padding: initial;
+    --vs-button-lineHeight: initial;
+    --vs-button-whiteSpace: initial;
     --vs-button-width: initial;
+    --vs-button-height: initial;
 
     @apply relative box-border inline-flex cursor-pointer items-center justify-center overflow-hidden select-none hover:brightness-96 active:brightness-92;
 
+    display: var(--vs-button-display, inline-block);
+    opacity: var(--vs-button-opacity, 1);
     border: var(--vs-button-border, 1px solid var(--vs-line-color));
     border-radius: var(--vs-button-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius)));
     background-color: var(--vs-button-backgroundColor, var(--vs-comp-bg));
@@ -20,6 +26,8 @@
     color: var(--vs-button-fontColor, var(--vs-comp-font));
     font-weight: var(--vs-button-fontWeight, 400);
     font-size: var(--vs-button-fontSize, var(--vs-font-size));
+    line-height: var(--vs-button-lineHeight, 1.6);
+    white-space: var(--vs-button-whiteSpace, normal);
 
     .vs-button-loading {
         @apply absolute flex h-full w-full items-center justify-center;

--- a/packages/vlossom/src/components/vs-button/types.ts
+++ b/packages/vlossom/src/components/vs-button/types.ts
@@ -1,5 +1,6 @@
-import type { VsLoadingStyleSet } from '@/components/vs-loading/types';
 import type VsButton from './VsButton.vue';
+import type { BoxStyleSet, TextStyleSet } from '@/declaration';
+import type { VsLoadingStyleSet } from '@/components/vs-loading/types';
 
 declare module 'vue' {
     interface GlobalComponents {
@@ -9,15 +10,6 @@ declare module 'vue' {
 
 export type { VsButton };
 
-export interface VsButtonStyleSet {
-    backgroundColor?: string;
-    border?: string;
-    borderRadius?: string;
-    fontColor?: string;
-    fontSize?: string;
-    fontWeight?: string | number;
-    height?: string;
-    padding?: string;
-    width?: string;
+export interface VsButtonStyleSet extends BoxStyleSet, TextStyleSet {
     loading?: VsLoadingStyleSet;
 }

--- a/packages/vlossom/src/components/vs-image/VsImage.css
+++ b/packages/vlossom/src/components/vs-image/VsImage.css
@@ -1,16 +1,24 @@
 .vs-image {
+    --vs-image-display: initial;
     --vs-image-width: initial;
     --vs-image-height: initial;
+    --vs-image-backgroundColor: initial;
     --vs-image-border: initial;
     --vs-image-borderRadius: initial;
     --vs-image-objectFit: initial;
+    --vs-image-opacity: initial;
 
     @apply relative;
+
+    display: var(--vs-image-display, inline-block);
+    opacity: var(--vs-image-opacity, 100%);
+    background-color: var(--vs-image-backgroundColor, transparent);
     width: var(--vs-image-width, 100%);
     height: var(--vs-image-height, 100%);
 
     .vs-image-tag {
         @apply relative;
+
         border: var(--vs-image-border, none);
         border-radius: var(--vs-image-borderRadius, 0);
         width: var(--vs-image-width, 100%);
@@ -19,6 +27,7 @@
 
         &.vs-hidden {
             @apply absolute opacity-0;
+
             top: 0;
             left: 0;
         }

--- a/packages/vlossom/src/components/vs-image/types.ts
+++ b/packages/vlossom/src/components/vs-image/types.ts
@@ -1,5 +1,6 @@
-import type { VsSkeletonStyleSet } from '../vs-skeleton/types';
 import type VsImage from './VsImage.vue';
+import type { BoxStyleSet } from '@/declaration';
+import type { VsSkeletonStyleSet } from '../vs-skeleton/types';
 
 declare module 'vue' {
     interface GlobalComponents {
@@ -9,11 +10,7 @@ declare module 'vue' {
 
 export type { VsImage };
 
-export interface VsImageStyleSet {
-    width?: string;
-    height?: string;
-    border?: string;
-    borderRadius?: string;
+export interface VsImageStyleSet extends Omit<BoxStyleSet, 'padding'> {
     objectFit?: string;
     skeleton?: VsSkeletonStyleSet;
 }

--- a/packages/vlossom/src/components/vs-skeleton/VsSkeleton.css
+++ b/packages/vlossom/src/components/vs-skeleton/VsSkeleton.css
@@ -1,38 +1,48 @@
 .vs-skeleton {
     --vs-skeleton-width: initial;
     --vs-skeleton-height: initial;
-    --vs-skeleton-borderRadius: initial;
     --vs-skeleton-backgroundColor: initial;
+    --vs-skeleton-border: initail;
+    --vs-skeleton-borderRadius: initial;
+    --vs-skeleton-padding: initail;
+    --vs-skeleton-fontColor: initial;
     --vs-skeleton-fontSize: initial;
     --vs-skeleton-fontWeight: initial;
+    --vs-skeleton-lineHeight: initial;
     --vs-skeleton-whiteSpace: initial;
-    --vs-skeleton-fontColor: initial;
 
     @apply relative overflow-hidden;
+
+    border: var(--vs-skeleton-border, none);
     border-radius: var(--vs-skeleton-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius-sm)));
     width: var(--vs-skeleton-width, 100%);
     height: var(--vs-skeleton-height, 100%);
 
     .vs-skeleton-bg {
         @apply absolute h-full w-full;
-        animation: skeleton-blink 0.8s infinite alternate;
+
+        animation: skeleton-blink 1s ease infinite alternate;
         background-color: var(--vs-skeleton-backgroundColor, var(--vs-line-color));
     }
+
     .vs-skeleton-inner {
         @apply relative flex h-full w-full items-center justify-center;
+
+        padding: var(--vs-skeleton-padding, 0);
         color: var(--vs-skeleton-fontColor, var(--vs-font-color));
         font-weight: var(--vs-skeleton-fontWeight, var(--vs-font-weight));
         font-size: var(--vs-skeleton-fontSize, var(--vs-font-size));
+        line-height: var(--vs-skeleton-lineHeight, var(--vs-line-height));
         white-space: var(--vs-skeleton-whiteSpace, var(--vs-white-space));
     }
 }
 
 @keyframes skeleton-blink {
     0% {
-        opacity: 0.15;
+        opacity: 0.05;
     }
 
     100% {
-        opacity: 0.3;
+        opacity: 0.25;
     }
 }

--- a/packages/vlossom/src/components/vs-skeleton/types.ts
+++ b/packages/vlossom/src/components/vs-skeleton/types.ts
@@ -1,5 +1,5 @@
-import type { VsTextStyleSet } from '@/declaration';
 import type VsSkeleton from './VsSkeleton.vue';
+import type { BoxStyleSet, TextStyleSet } from '@/declaration';
 
 declare module 'vue' {
     interface GlobalComponents {
@@ -9,9 +9,4 @@ declare module 'vue' {
 
 export type { VsSkeleton };
 
-export interface VsSkeletonStyleSet extends VsTextStyleSet {
-    backgroundColor?: string;
-    borderRadius?: string;
-    height?: string;
-    width?: string;
-}
+export interface VsSkeletonStyleSet extends Omit<BoxStyleSet, 'display' | 'opacity'>, TextStyleSet {}

--- a/packages/vlossom/src/declaration/types.ts
+++ b/packages/vlossom/src/declaration/types.ts
@@ -10,13 +10,6 @@ export type GlobalColorSchemes = { default?: ColorScheme } & { [key in VsCompone
     [key: string]: ColorScheme;
 };
 
-export interface VsTextStyleSet {
-    fontColor?: string;
-    fontSize?: string;
-    fontWeight?: string | number;
-    whiteSpace?: string;
-}
-
 export type GlobalStyleSets = {
     [key: string]: { [key in VsComponent]?: any } & { [key: string]: any };
 };
@@ -29,8 +22,10 @@ export interface VlossomOptions {
     radiusRatio?: number;
 }
 
+export type CssPosition = 'static' | 'relative' | 'absolute' | 'fixed' | 'sticky';
+
 export interface BarLayout {
-    position: 'relative' | 'absolute' | 'fixed' | 'sticky' | 'static';
+    position: CssPosition;
     height: string;
 }
 
@@ -51,4 +46,35 @@ export interface Breakpoints {
     md?: string | number;
     lg?: string | number;
     xl?: string | number;
+}
+
+export interface SizeStyleSet {
+    width?: string;
+    height?: string;
+}
+
+export interface BoxStyleSet {
+    display?: string;
+    backgroundColor?: string;
+    border?: string;
+    borderRadius?: string;
+    padding?: string;
+    opacity?: string | number;
+}
+
+export interface FlexStyleSet {
+    flex?: string;
+    flexDirection?: string;
+    flexWrap?: string;
+    alignItems?: string;
+    justifyContent?: string;
+    gap?: string;
+}
+
+export interface TextStyleSet {
+    fontColor?: string;
+    fontSize?: string;
+    fontWeight?: string | number;
+    lineHeight?: string;
+    whiteSpace?: string;
 }

--- a/packages/vlossom/src/declaration/types.ts
+++ b/packages/vlossom/src/declaration/types.ts
@@ -48,18 +48,23 @@ export interface Breakpoints {
     xl?: string | number;
 }
 
-export interface SizeStyleSet {
-    width?: string;
-    height?: string;
-}
-
 export interface BoxStyleSet {
     display?: string;
+    width?: string;
+    height?: string;
     backgroundColor?: string;
     border?: string;
     borderRadius?: string;
     padding?: string;
     opacity?: string | number;
+}
+
+export interface TextStyleSet {
+    fontColor?: string;
+    fontSize?: string;
+    fontWeight?: string | number;
+    lineHeight?: string;
+    whiteSpace?: string;
 }
 
 export interface FlexStyleSet {
@@ -69,12 +74,4 @@ export interface FlexStyleSet {
     alignItems?: string;
     justifyContent?: string;
     gap?: string;
-}
-
-export interface TextStyleSet {
-    fontColor?: string;
-    fontSize?: string;
-    fontWeight?: string | number;
-    lineHeight?: string;
-    whiteSpace?: string;
 }

--- a/packages/vlossom/src/styles/variables.css
+++ b/packages/vlossom/src/styles/variables.css
@@ -14,6 +14,10 @@
             --vs-dimmed-bg: rgba(0, 0, 0, 0.6);
         }
 
+        --vs-line-height: 1.6;
+        --vs-font-weight: 400;
+        --vs-white-space: normal;
+
         --vs-font-size-xs: 0.8rem;
         --vs-font-size-sm: 0.9rem;
         --vs-font-size: 1rem;


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary
공통 style-set type을 정의합니다

## Description
- style-set의 종류를 크게 3가지로 나눴습니다 (BoxStyleSet, TextStyleSet, FlexStyleSet)
- 기존 공통 style-set은 앞에 Vs prefix가 있었으나 제거 -> 혹시 모를 component style-set과 충돌 방지
```ts
export interface BoxStyleSet {
    display?: string;
    width?: string;
    height?: string;
    backgroundColor?: string;
    border?: string;
    borderRadius?: string;
    padding?: string;
    opacity?: string | number;
}

export interface TextStyleSet {
    fontColor?: string;
    fontSize?: string;
    fontWeight?: string | number;
    lineHeight?: string;
    whiteSpace?: string;
}

// deprecated?
export interface FlexStyleSet {
    flex?: string;
    flexDirection?: string;
    flexWrap?: string;
    alignItems?: string;
    justifyContent?: string;
    gap?: string;
}
```
- 각 style-set의 성격에 따라 가장 많이 쓰고 적용이 잦은 항목들만 추가함. (짜치는 속성 일부러 안 넣음. 그건 사용자가 알아서 할 일)
- 실제 component에서 사용할 때는 모든 속성이 다 필요한건 아니라서 필요없는 속성은 Omit으로 제거해서 사용하도록 함 (예시 코드 있음)
- FlexStyleSet의 경우 꼭 flex를 적용한 공간에서만 사용할 수 있는데 그런 곳이 잘 없고, flex 설정은 class로 사용자가 하는게 더 좋지 않을까 하는 생각이 있음. 그러나 혹시 필요한 곳이 있을 수 있어서 일단 놔뒀는데 다른 컴포넌트 추가하면서 꼭 필요한지 확인 필요

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
