### PR TITLE
feat(VsIndexView): create vs-index-view component

### DIFF
--- a/packages/vlossom/sandbox/sandbox.ts
+++ b/packages/vlossom/sandbox/sandbox.ts
@@ -3,7 +3,10 @@ import App from './App.vue';
 import { createVlossom } from '@/framework';
 import { VlossomComponents } from '@/components/component-map';
 
-// this will be replaced with "import 'vlossom/styles'"
+// component type 추론을 위해서 import
+import '@/components/component-types';
+
+// 실제 vlossom 사용할 때는 import 'vlossom/styles';
 import '@/styles/index.css';
 import '@/styles/index.scss';
 

--- a/packages/vlossom/src/components/component-map.ts
+++ b/packages/vlossom/src/components/component-map.ts
@@ -16,6 +16,7 @@ import VsForm from './vs-form/VsForm.vue';
 import VsGrid from './vs-grid/VsGrid.vue';
 import VsHeader from './vs-header/VsHeader.vue';
 import VsImage from './vs-image/VsImage.vue';
+import VsIndexView from './vs-index-view/VsIndexView.vue';
 import VsInnerScroll from './vs-inner-scroll/VsInnerScroll.vue';
 import VsLayout from './vs-layout/VsLayout.vue';
 import VsLoading from './vs-loading/VsLoading.vue';
@@ -36,6 +37,7 @@ export const VlossomComponents = {
     VsGrid,
     VsHeader,
     VsImage,
+    VsIndexView,
     VsInnerScroll,
     VsLayout,
     VsLoading,

--- a/packages/vlossom/src/components/component-types.ts
+++ b/packages/vlossom/src/components/component-types.ts
@@ -9,6 +9,7 @@ export type * from './vs-form/types';
 export type * from './vs-grid/types';
 export type * from './vs-header/types';
 export type * from './vs-image/types';
+export type * from './vs-index-view/types';
 export type * from './vs-inner-scroll/types';
 export type * from './vs-layout/types';
 export type * from './vs-loading/types';

--- a/packages/vlossom/src/components/index.ts
+++ b/packages/vlossom/src/components/index.ts
@@ -11,6 +11,7 @@ export { default as VsForm } from './vs-form/VsForm.vue';
 export { default as VsGrid } from './vs-grid/VsGrid.vue';
 export { default as VsHeader } from './vs-header/VsHeader.vue';
 export { default as VsImage } from './vs-image/VsImage.vue';
+export { default as VsIndexView } from './vs-index-view/VsIndexView.vue';
 export { default as VsInnerScroll } from './vs-inner-scroll/VsInnerScroll.vue';
 export { default as VsLayout } from './vs-layout/VsLayout.vue';
 export { default as VsLoading } from './vs-loading/VsLoading.vue';

--- a/packages/vlossom/src/components/vs-index-view/README.md
+++ b/packages/vlossom/src/components/vs-index-view/README.md
@@ -1,0 +1,91 @@
+# VsIndexView
+
+슬롯 콘텐츠 중 특정 인덱스에 해당하는 항목만 렌더링하는 인덱스 기반 뷰 컴포넌트입니다. v-model을 통해 현재 표시할 인덱스를 제어할 수 있으며, keep-alive 옵션으로 컴포넌트 상태 보존이 가능합니다.
+
+**Available Version**: 2.0.0+
+
+## 기본 사용법
+
+### 기본 인덱스 뷰
+
+```html
+<template>
+    <vs-index-view v-model="currentIndex">
+        <div>첫 번째 콘텐츠</div>
+        <div>두 번째 콘텐츠</div>
+        <div>세 번째 콘텐츠</div>
+    </vs-index-view>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+
+const currentIndex = ref(0);
+</script>
+```
+
+### keep-alive 비활성화
+
+```html
+<template>
+    <vs-index-view v-model="currentIndex" :keep-alive="false">
+        <MyComponent />
+        <AnotherComponent />
+        <ThirdComponent />
+    </vs-index-view>
+</template>
+```
+
+## Props
+
+| Prop         | Type                              | Default | Required | Description                                    |
+| ------------ | --------------------------------- | ------- | -------- | ---------------------------------------------- |
+| `modelValue` | `number`                          | `0`     | -        | 현재 표시할 슬롯의 인덱스 (v-model로 바인딩)   |
+| `keepAlive`  | `boolean`                         | `true`  | -        | 컴포넌트 상태 보존을 위한 keep-alive 사용 여부 |
+| `width`      | `string \| number \| Breakpoints` | -       | -        | 반응형 너비 설정                               |
+| `grid`       | `string \| number \| Breakpoints` | -       | -        | 반응형 그리드 컬럼 수                          |
+
+## Events
+
+| Event               | Payload  | Description                |
+| ------------------- | -------- | -------------------------- |
+| `update:modelValue` | `number` | 인덱스 값이 변경될 때 발생 |
+
+## Methods
+
+| Method        | Parameter | Description                     |
+| ------------- | --------- | ------------------------------- |
+| `updateIndex` | `number`  | 인덱스를 변경하고 이벤트를 emit |
+
+## Types
+
+```typescript
+interface Breakpoints {
+    xs?: string | number; // 0px 이상
+    sm?: string | number; // 640px 이상
+    md?: string | number; // 768px 이상
+    lg?: string | number; // 1024px 이상
+    xl?: string | number; // 1280px 이상
+}
+```
+
+## Slots
+
+| Slot      | Description                                                        |
+| --------- | ------------------------------------------------------------------ |
+| `default` | 인덱스 기반으로 표시할 콘텐츠들. 각 자식 요소가 하나의 인덱스가 됨 |
+
+## 특징
+
+- **v-model 지원**: `modelValue` prop과 `update:modelValue` 이벤트를 통한 양방향 데이터 바인딩
+- **Keep-alive 옵션**: 컴포넌트 상태 보존 가능, 기본값은 `true`
+- **자동 주석 필터링**: HTML 주석과 빈 텍스트 노드는 자동으로 제외되어 정확한 인덱싱 보장
+- **반응형 지원**: `width`와 `grid` props를 통한 반응형 레이아웃 구현
+- **vs-responsive 래핑**: 내부적으로 vs-responsive 컴포넌트로 래핑되어 일관된 반응형 동작 제공
+- **유연한 콘텐츠**: 일반 HTML 요소, Vue 컴포넌트 등 다양한 슬롯 콘텐츠 지원
+
+## 사용 사례
+
+- **탭 인터페이스**: 여러 패널 중 하나만 표시하는 탭 UI
+- **스텝 플로우**: 단계별 프로세스에서 현재 단계만 표시
+- **조건부 렌더링**: 상태에 따라 다른 컨텐츠 표시

--- a/packages/vlossom/src/components/vs-index-view/README.md
+++ b/packages/vlossom/src/components/vs-index-view/README.md
@@ -54,7 +54,7 @@ const currentIndex = ref(0);
 | Prop         | Type                              | Default | Required | Description                                    |
 | ------------ | --------------------------------- | ------- | -------- | ---------------------------------------------- |
 | `modelValue` | `number`                          | `0`     | -        | 현재 표시할 슬롯의 인덱스 (v-model로 바인딩)   |
-| `keepAlive`  | `boolean`                         | `true`  | -        | 컴포넌트 상태 보존을 위한 keep-alive 사용 여부 |
+| `keepAlive`  | `boolean`                         | `false` | -        | 컴포넌트 상태 보존을 위한 keep-alive 사용 여부 |
 | `width`      | `string \| number \| Breakpoints` | -       | -        | 반응형 너비 설정                               |
 | `grid`       | `string \| number \| Breakpoints` | -       | -        | 반응형 그리드 컬럼 수                          |
 
@@ -91,7 +91,7 @@ interface Breakpoints {
 ## 특징
 
 - **v-model 지원**: `modelValue` prop과 `update:modelValue` 이벤트를 통한 양방향 데이터 바인딩
-- **Keep-alive 옵션**: 컴포넌트 상태 보존 가능, 기본값은 `true`
+- **Keep-alive 옵션**: vue 내장 컴포넌트 KeepAlive를 이용해서 view 상태 보존 가능
 - **Fragment 노드 평면화**: `v-for`로 생성된 여러 요소들이 각각 개별 인덱스로 인식
 - **자동 주석 필터링**: HTML 주석과 빈 텍스트 노드는 자동으로 제외되어 정확한 인덱싱 보장
 - **반응형 지원**: `width`와 `grid` props를 통한 반응형 레이아웃 구현

--- a/packages/vlossom/src/components/vs-index-view/README.md
+++ b/packages/vlossom/src/components/vs-index-view/README.md
@@ -36,6 +36,19 @@ const currentIndex = ref(0);
 </template>
 ```
 
+### v-for를 사용한 동적 콘텐츠
+
+```html
+<template>
+    <vs-index-view v-model="currentIndex">
+        <div v-for="item in items" :key="item.id" class="item-card">
+            <h3>{{ item.title }}</h3>
+            <p>{{ item.description }}</p>
+        </div>
+    </vs-index-view>
+</template>
+```
+
 ## Props
 
 | Prop         | Type                              | Default | Required | Description                                    |
@@ -79,6 +92,7 @@ interface Breakpoints {
 
 - **v-model 지원**: `modelValue` prop과 `update:modelValue` 이벤트를 통한 양방향 데이터 바인딩
 - **Keep-alive 옵션**: 컴포넌트 상태 보존 가능, 기본값은 `true`
+- **Fragment 노드 평면화**: `v-for`로 생성된 여러 요소들이 각각 개별 인덱스로 인식
 - **자동 주석 필터링**: HTML 주석과 빈 텍스트 노드는 자동으로 제외되어 정확한 인덱싱 보장
 - **반응형 지원**: `width`와 `grid` props를 통한 반응형 레이아웃 구현
 - **vs-responsive 래핑**: 내부적으로 vs-responsive 컴포넌트로 래핑되어 일관된 반응형 동작 제공

--- a/packages/vlossom/src/components/vs-index-view/VsIndexView.css
+++ b/packages/vlossom/src/components/vs-index-view/VsIndexView.css
@@ -1,0 +1,3 @@
+.vs-index-view {
+    @apply relative w-full;
+}

--- a/packages/vlossom/src/components/vs-index-view/VsIndexView.css
+++ b/packages/vlossom/src/components/vs-index-view/VsIndexView.css
@@ -1,3 +1,7 @@
 .vs-index-view {
     @apply relative w-full;
 }
+
+.vs-index-view-container {
+    @apply relative h-full w-full;
+}

--- a/packages/vlossom/src/components/vs-index-view/VsIndexView.vue
+++ b/packages/vlossom/src/components/vs-index-view/VsIndexView.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { defineComponent, h, KeepAlive, toRefs, Comment, Fragment, type VNode } from 'vue';
+import { defineComponent, h, KeepAlive, toRefs, Comment, Fragment, type VNode, ref, watch } from 'vue';
 import { VsComponent } from '@/declaration';
 import { getResponsiveProps } from '@/props';
 import VsResponsive from '@/components/vs-responsive/VsResponsive.vue';
@@ -17,6 +17,8 @@ export default defineComponent({
     emits: ['update:modelValue'],
     setup(props, { slots, emit, expose }) {
         const { width, grid, modelValue, keepAlive } = toRefs(props);
+
+        const index = ref(modelValue.value);
 
         function flattenNodes(nodes: VNode[]): VNode[] {
             const result: VNode[] = [];
@@ -54,7 +56,15 @@ export default defineComponent({
             emit('update:modelValue', newIndex);
         }
 
-        expose({ updateIndex });
+        watch(modelValue, (newValue) => {
+            index.value = newValue;
+        });
+
+        watch(index, (newValue) => {
+            emit('update:modelValue', newValue);
+        });
+
+        expose({ index, updateIndex });
 
         return () => {
             if (!slots.default) {
@@ -73,7 +83,7 @@ export default defineComponent({
                 return null;
             }
 
-            const currentIndex = modelValue.value || 0;
+            const currentIndex = index.value || 0;
 
             function renderContent() {
                 if (keepAlive.value) {
@@ -81,13 +91,13 @@ export default defineComponent({
                         h(
                             'div',
                             { class: 'vs-index-view-container' },
-                            filteredNodes.map((node, index) =>
+                            filteredNodes.map((node, nodeIndex) =>
                                 h(
                                     'div',
                                     {
-                                        key: index,
+                                        key: nodeIndex,
                                         style: {
-                                            display: index === currentIndex ? 'block' : 'none',
+                                            display: nodeIndex === currentIndex ? 'block' : 'none',
                                         },
                                     },
                                     [node],

--- a/packages/vlossom/src/components/vs-index-view/VsIndexView.vue
+++ b/packages/vlossom/src/components/vs-index-view/VsIndexView.vue
@@ -1,0 +1,80 @@
+<script lang="ts">
+import { defineComponent, h, KeepAlive, toRefs, Comment, type VNode } from 'vue';
+import { VsComponent } from '@/declaration';
+import { getResponsiveProps } from '@/props';
+import VsResponsive from '@/components/vs-responsive/VsResponsive.vue';
+
+const name = VsComponent.VsIndexView;
+
+export default defineComponent({
+    name,
+    props: {
+        ...getResponsiveProps(),
+        keepAlive: { type: Boolean, default: true },
+        // v-model
+        modelValue: { type: Number, default: 0 },
+    },
+    emits: ['update:modelValue'],
+    setup(props, { slots, emit, expose }) {
+        const { width, grid, modelValue, keepAlive } = toRefs(props);
+
+        function filterUselessNodes(nodes: VNode[]): VNode[] {
+            return nodes.filter((node) => {
+                // 주석 노드 제외
+                if (node.type === Comment) {
+                    return false;
+                }
+                // 빈 텍스트 노드도 제외 (공백만 있는 경우)
+                if (typeof node.type === 'symbol' && node.children && typeof node.children === 'string') {
+                    return node.children.trim() !== '';
+                }
+                return true;
+            });
+        }
+
+        function updateIndex(newIndex: number) {
+            emit('update:modelValue', newIndex);
+        }
+
+        expose({ updateIndex });
+
+        return () => {
+            if (!slots.default) {
+                return null;
+            }
+
+            const slotNodes = slots.default();
+            if (!slotNodes || slotNodes.length === 0) {
+                return null;
+            }
+
+            const filteredNodes = filterUselessNodes(slotNodes);
+            if (filteredNodes.length === 0) {
+                return null;
+            }
+
+            const currentIndex = modelValue.value || 0;
+            const currentNode = filteredNodes[currentIndex];
+
+            if (!currentNode) {
+                return null;
+            }
+
+            // keep-alive 적용 여부에 따라 렌더링
+            const content = keepAlive.value ? h(KeepAlive, {}, [currentNode]) : currentNode;
+
+            return h(
+                VsResponsive,
+                {
+                    class: 'vs-index-view',
+                    width: width.value,
+                    grid: grid.value,
+                },
+                () => [content],
+            );
+        };
+    },
+});
+</script>
+
+<style src="./VsIndexView.css" />

--- a/packages/vlossom/src/components/vs-index-view/VsIndexView.vue
+++ b/packages/vlossom/src/components/vs-index-view/VsIndexView.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { defineComponent, h, KeepAlive, toRefs, Comment, type VNode } from 'vue';
+import { defineComponent, h, KeepAlive, toRefs, Comment, Fragment, type VNode } from 'vue';
 import { VsComponent } from '@/declaration';
 import { getResponsiveProps } from '@/props';
 import VsResponsive from '@/components/vs-responsive/VsResponsive.vue';
@@ -17,6 +17,24 @@ export default defineComponent({
     emits: ['update:modelValue'],
     setup(props, { slots, emit, expose }) {
         const { width, grid, modelValue, keepAlive } = toRefs(props);
+
+        function flattenNodes(nodes: VNode[]): VNode[] {
+            const result: VNode[] = [];
+
+            function flatten(nodeList: VNode[]) {
+                for (const node of nodeList) {
+                    // Fragment 노드인 경우 children을 재귀적으로 flatten
+                    if (node.type === Fragment && Array.isArray(node.children)) {
+                        flatten(node.children as VNode[]);
+                    } else {
+                        result.push(node);
+                    }
+                }
+            }
+
+            flatten(nodes);
+            return result;
+        }
 
         function filterUselessNodes(nodes: VNode[]): VNode[] {
             return nodes.filter((node) => {
@@ -48,7 +66,9 @@ export default defineComponent({
                 return null;
             }
 
-            const filteredNodes = filterUselessNodes(slotNodes);
+            // Fragment 노드들을 평면화하고 불필요한 노드들을 제거
+            const flattenedNodes = flattenNodes(slotNodes);
+            const filteredNodes = filterUselessNodes(flattenedNodes);
             if (filteredNodes.length === 0) {
                 return null;
             }

--- a/packages/vlossom/src/components/vs-index-view/VsIndexView.vue
+++ b/packages/vlossom/src/components/vs-index-view/VsIndexView.vue
@@ -54,14 +54,34 @@ export default defineComponent({
             }
 
             const currentIndex = modelValue.value || 0;
-            const currentNode = filteredNodes[currentIndex];
 
-            if (!currentNode) {
-                return null;
+            function renderContent() {
+                if (keepAlive.value) {
+                    return h(KeepAlive, {}, [
+                        h(
+                            'div',
+                            { class: 'vs-index-view-container' },
+                            filteredNodes.map((node, index) =>
+                                h(
+                                    'div',
+                                    {
+                                        key: index,
+                                        style: {
+                                            display: index === currentIndex ? 'block' : 'none',
+                                        },
+                                    },
+                                    [node],
+                                ),
+                            ),
+                        ),
+                    ]);
+                } else {
+                    const currentNode = filteredNodes[currentIndex];
+                    return currentNode || null;
+                }
             }
 
-            // keep-alive 적용 여부에 따라 렌더링
-            const content = keepAlive.value ? h(KeepAlive, {}, [currentNode]) : currentNode;
+            const content = renderContent();
 
             return h(
                 VsResponsive,

--- a/packages/vlossom/src/components/vs-index-view/VsIndexView.vue
+++ b/packages/vlossom/src/components/vs-index-view/VsIndexView.vue
@@ -10,7 +10,7 @@ export default defineComponent({
     name,
     props: {
         ...getResponsiveProps(),
-        keepAlive: { type: Boolean, default: true },
+        keepAlive: { type: Boolean, default: false },
         // v-model
         modelValue: { type: Number, default: 0 },
     },

--- a/packages/vlossom/src/components/vs-index-view/__tests__/vs-index-view.test.ts
+++ b/packages/vlossom/src/components/vs-index-view/__tests__/vs-index-view.test.ts
@@ -1,0 +1,440 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import VsIndexView from './../VsIndexView.vue';
+
+describe('VsIndexView', () => {
+    describe('modelValue prop', () => {
+        it('modelValue가 1이면 두 번째 슬롯 콘텐츠가 표시되어야 한다 (keepAlive: true)', () => {
+            // given, when
+            const wrapper = mount(VsIndexView, {
+                props: {
+                    modelValue: 1,
+                    keepAlive: true,
+                },
+                slots: {
+                    default: ['<div class="item-0">첫 번째</div>', '<div class="item-1">두 번째</div>'],
+                },
+            });
+
+            // then - keepAlive일 때는 모든 요소가 존재하지만 display로 제어
+            expect(wrapper.find('.item-0').exists()).toBe(true);
+            expect(wrapper.find('.item-0').isVisible()).toBe(false); // display: none
+
+            expect(wrapper.find('.item-1').exists()).toBe(true);
+            expect(wrapper.find('.item-1').isVisible()).toBe(true);
+            expect(wrapper.find('.item-1').text()).toBe('두 번째');
+        });
+
+        it('modelValue가 1이면 두 번째 슬롯 콘텐츠만 렌더링되어야 한다 (keepAlive: false)', () => {
+            // given, when
+            const wrapper = mount(VsIndexView, {
+                props: {
+                    modelValue: 1,
+                    keepAlive: false,
+                },
+                slots: {
+                    default: ['<div class="item-0">첫 번째</div>', '<div class="item-1">두 번째</div>'],
+                },
+            });
+
+            // then - keepAlive가 false일 때는 현재 인덱스만 DOM에 존재
+            expect(wrapper.find('.item-0').exists()).toBe(false);
+            expect(wrapper.find('.item-1').exists()).toBe(true);
+            expect(wrapper.find('.item-1').text()).toBe('두 번째');
+        });
+
+        it('modelValue가 슬롯 개수를 초과하면 아무것도 표시되지 않아야 한다', () => {
+            // given, when
+            const wrapper = mount(VsIndexView, {
+                props: {
+                    modelValue: 5,
+                    keepAlive: false, // keepAlive false로 테스트
+                },
+                slots: {
+                    default: ['<div class="item-0">첫 번째</div>', '<div class="item-1">두 번째</div>'],
+                },
+            });
+
+            // then
+            expect(wrapper.find('.item-0').exists()).toBe(false);
+            expect(wrapper.find('.item-1').exists()).toBe(false);
+        });
+    });
+
+    describe('keepAlive prop', () => {
+        it('keepAlive가 true이면 KeepAlive 컴포넌트로 래핑되어야 한다', () => {
+            // given, when
+            const wrapper = mount(VsIndexView, {
+                props: {
+                    keepAlive: true,
+                },
+                slots: {
+                    default: ['<div>첫 번째</div>', '<div>두 번째</div>'],
+                },
+            });
+
+            // then
+            expect(wrapper.findComponent({ name: 'KeepAlive' }).exists()).toBe(true);
+            expect(wrapper.find('.vs-index-view-container').exists()).toBe(true);
+        });
+
+        it('keepAlive가 false이면 KeepAlive 컴포넌트가 없어야 한다', () => {
+            // given, when
+            const wrapper = mount(VsIndexView, {
+                props: {
+                    keepAlive: false,
+                },
+                slots: {
+                    default: ['<div>첫 번째</div>', '<div>두 번째</div>'],
+                },
+            });
+
+            // then
+            expect(wrapper.findComponent({ name: 'KeepAlive' }).exists()).toBe(false);
+            expect(wrapper.find('.vs-index-view-container').exists()).toBe(false);
+        });
+    });
+
+    describe('반응형 props', () => {
+        it('width prop이 주어지면 vs-responsive에 전달되어야 한다', () => {
+            // given, when
+            const wrapper = mount(VsIndexView, {
+                props: {
+                    width: '500px',
+                },
+                slots: {
+                    default: '<div>콘텐츠</div>',
+                },
+            });
+
+            // then
+            const responsive = wrapper.findComponent({ name: 'VsResponsive' });
+            expect(responsive.exists()).toBe(true);
+            expect(responsive.props('width')).toBe('500px');
+        });
+
+        it('grid prop이 주어지면 vs-responsive에 전달되어야 한다', () => {
+            // given, when
+            const wrapper = mount(VsIndexView, {
+                props: {
+                    grid: 6,
+                },
+                slots: {
+                    default: '<div>콘텐츠</div>',
+                },
+            });
+
+            // then
+            const responsive = wrapper.findComponent({ name: 'VsResponsive' });
+            expect(responsive.exists()).toBe(true);
+            expect(responsive.props('grid')).toBe(6);
+        });
+    });
+
+    describe('updateIndex 메서드', () => {
+        it('updateIndex 메서드가 노출되어야 한다', () => {
+            // given, when
+            const wrapper = mount(VsIndexView, {
+                slots: {
+                    default: ['<div>첫 번째</div>', '<div>두 번째</div>'],
+                },
+            });
+
+            // then
+            expect((wrapper.vm as any).updateIndex).toBeDefined();
+            expect(typeof (wrapper.vm as any).updateIndex).toBe('function');
+        });
+
+        it('updateIndex 호출 시 update:modelValue 이벤트가 발생해야 한다', async () => {
+            // given, when
+            const wrapper = mount(VsIndexView, {
+                slots: {
+                    default: ['<div>첫 번째</div>', '<div>두 번째</div>'],
+                },
+            });
+
+            (wrapper.vm as any).updateIndex(1);
+
+            // then
+            expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+            expect(wrapper.emitted('update:modelValue')![0]).toEqual([1]);
+        });
+    });
+
+    describe('Fragment 노드 처리', () => {
+        it('v-for로 생성된 여러 요소들이 각각의 인덱스로 인식되어야 한다 (keepAlive: false)', () => {
+            // given
+            const TestComponent = {
+                template: `
+                    <vs-index-view v-model="currentIndex" :keep-alive="false">
+                        <div v-for="i in 3" :key="i" class="item">{{ i }}</div>
+                    </vs-index-view>
+                `,
+                components: { VsIndexView },
+                data() {
+                    return { currentIndex: 1 };
+                },
+            };
+
+            // when
+            const wrapper = mount(TestComponent);
+
+            // then - keepAlive가 false일 때는 현재 인덱스만 DOM에 존재
+            const items = wrapper.findAll('.item');
+            expect(items).toHaveLength(1); // 현재 인덱스(1)의 아이템만 표시
+            expect(items[0].text()).toBe('2'); // 두 번째 아이템 (인덱스 1 = "2")
+        });
+
+        it('v-for로 생성된 여러 요소들이 모두 렌더링되지만 하나만 표시되어야 한다 (keepAlive: true)', () => {
+            // given
+            const TestComponent = {
+                template: `
+                    <vs-index-view v-model="currentIndex" :keep-alive="true">
+                        <div v-for="i in 3" :key="i" class="item">{{ i }}</div>
+                    </vs-index-view>
+                `,
+                components: { VsIndexView },
+                data() {
+                    return { currentIndex: 1 };
+                },
+            };
+
+            // when
+            const wrapper = mount(TestComponent);
+
+            // then - keepAlive가 true일 때는 모든 요소가 DOM에 존재
+            const items = wrapper.findAll('.item');
+            expect(items).toHaveLength(3); // 모든 아이템이 DOM에 존재
+
+            // 하지만 현재 인덱스(1)만 보임
+            expect(items[0].isVisible()).toBe(false); // 인덱스 0: 숨겨짐
+            expect(items[1].isVisible()).toBe(true); // 인덱스 1: 표시됨
+            expect(items[2].isVisible()).toBe(false); // 인덱스 2: 숨겨짐
+
+            expect(items[1].text()).toBe('2'); // 두 번째 아이템 (인덱스 1 = "2")
+        });
+
+        it('template 태그로 그룹화된 요소들이 각각의 인덱스로 인식되어야 한다', () => {
+            // given
+            const TestComponent = {
+                template: `
+                    <vs-index-view v-model="currentIndex" :keep-alive="false">
+                        <template v-for="i in 3" :key="i">
+                            <div class="item">{{ i }}</div>
+                        </template>
+                    </vs-index-view>
+                `,
+                components: { VsIndexView },
+                data() {
+                    return { currentIndex: 2 };
+                },
+            };
+
+            // when
+            const wrapper = mount(TestComponent);
+
+            // then
+            const items = wrapper.findAll('.item');
+            expect(items).toHaveLength(1); // 현재 인덱스(2)의 아이템만 표시
+            expect(items[0].text()).toBe('3'); // 세 번째 아이템 (인덱스 2 = "3")
+        });
+
+        it('조건부 렌더링과 v-for가 혼합된 경우에도 정확히 처리되어야 한다', () => {
+            // given
+            const TestComponent = {
+                template: `
+                    <vs-index-view v-model="currentIndex" :keep-alive="false">
+                        <div v-if="showFirst" class="conditional">조건부 첫 번째</div>
+                        <div v-for="i in 2" :key="i" class="item">{{ i }}</div>
+                    </vs-index-view>
+                `,
+                components: { VsIndexView },
+                data() {
+                    return {
+                        currentIndex: 1, // 두 번째 요소 (첫 번째 v-for 아이템)
+                        showFirst: true,
+                    };
+                },
+            };
+
+            // when
+            const wrapper = mount(TestComponent);
+
+            // then
+            const conditionalItems = wrapper.findAll('.conditional');
+            const forItems = wrapper.findAll('.item');
+
+            // 조건부 요소는 인덱스 0이므로 숨겨짐
+            expect(conditionalItems).toHaveLength(0);
+
+            // v-for의 첫 번째 아이템이 인덱스 1이므로 표시됨
+            expect(forItems).toHaveLength(1);
+            expect(forItems[0].text()).toBe('1');
+        });
+
+        it('중첩된 Fragment (template + v-for)가 올바르게 평면화되어야 한다', () => {
+            // given
+            const TestComponent = {
+                template: `
+                    <vs-index-view v-model="currentIndex" :keep-alive="false">
+                        <template v-for="group in groups" :key="group.id">
+                            <div v-for="item in group.items" :key="item.id" class="nested-item">
+                                {{ group.name }}-{{ item.name }}
+                            </div>
+                        </template>
+                    </vs-index-view>
+                `,
+                components: { VsIndexView },
+                data() {
+                    return {
+                        currentIndex: 2, // 세 번째 항목
+                        groups: [
+                            {
+                                id: 1,
+                                name: 'A',
+                                items: [
+                                    { id: 1, name: '1' },
+                                    { id: 2, name: '2' },
+                                ],
+                            },
+                            {
+                                id: 2,
+                                name: 'B',
+                                items: [{ id: 3, name: '1' }],
+                            },
+                        ],
+                    };
+                },
+            };
+
+            // when
+            const wrapper = mount(TestComponent);
+
+            // then - 중첩된 Fragment가 평면화되어 개별 인덱스로 처리됨
+            const items = wrapper.findAll('.nested-item');
+            expect(items).toHaveLength(1); // 현재 인덱스(2)의 아이템만 표시
+            expect(items[0].text()).toBe('B-1'); // 세 번째 아이템 (A-1, A-2, B-1 중 B-1)
+        });
+    });
+
+    describe('빈 슬롯 처리', () => {
+        it('슬롯이 비어있으면 아무것도 렌더링되지 않아야 한다', () => {
+            // given, when
+            const wrapper = mount(VsIndexView);
+
+            // then
+            expect(wrapper.html()).toBe('');
+        });
+
+        it('빈 슬롯 배열이 주어지면 아무것도 렌더링되지 않아야 한다', () => {
+            // given, when
+            const wrapper = mount(VsIndexView, {
+                slots: {
+                    default: [],
+                },
+            });
+
+            // then
+            expect(wrapper.html()).toBe('');
+        });
+    });
+
+    describe('조건부 렌더링 (v-if)', () => {
+        it('v-if가 false인 요소는 index 대상에서 제외되어야 한다', () => {
+            // given
+            const TestComponent = {
+                template: `
+                    <vs-index-view v-model="currentIndex" :keep-alive="false">
+                        <div v-if="showFirst" class="first-item">첫 번째</div>
+                        <div v-if="false" class="second-item">두 번째 (숨겨짐)</div>
+                        <div v-if="showThird" class="third-item">세 번째</div>
+                    </vs-index-view>
+                `,
+                components: { VsIndexView },
+                data() {
+                    return {
+                        currentIndex: 1, // 두 번째 인덱스
+                        showFirst: true,
+                        showThird: true,
+                    };
+                },
+            };
+
+            // when
+            const wrapper = mount(TestComponent);
+
+            // then - v-if="false"인 두 번째 요소는 제외되고, 실제로는 "세 번째" 요소가 인덱스 1에 해당
+            const items = wrapper.findAll('div[class*="item"]');
+            expect(items).toHaveLength(1); // 현재 인덱스(1)의 아이템만 표시
+
+            // v-if="false"인 요소는 DOM에 존재하지 않음
+            expect(wrapper.find('.second-item').exists()).toBe(false);
+
+            // 인덱스 1은 실제로는 "세 번째" 요소를 가리킴 (두 번째는 v-if="false"로 제외됨)
+            expect(items[0].classes()).toContain('third-item');
+            expect(items[0].text()).toBe('세 번째');
+        });
+
+        it('v-if가 false인 요소가 있을 때 keepAlive: true에서도 올바르게 동작해야 한다', () => {
+            // given
+            const TestComponent = {
+                template: `
+                    <vs-index-view v-model="currentIndex" :keep-alive="true">
+                        <div v-if="true" class="item-0">A</div>
+                        <div v-if="false" class="item-hidden">숨겨진 요소</div>
+                        <div v-if="true" class="item-1">B</div>
+                        <div v-if="true" class="item-2">C</div>
+                    </vs-index-view>
+                `,
+                components: { VsIndexView },
+                data() {
+                    return { currentIndex: 2 }; // 세 번째 인덱스 (실제로는 "C")
+                },
+            };
+
+            // when
+            const wrapper = mount(TestComponent);
+
+            // then - keepAlive가 true이므로 모든 실제 요소(v-if="true")가 DOM에 존재
+            const allItems = wrapper.findAll('div[class*="item"]');
+            expect(allItems).toHaveLength(3); // A, B, C만 존재 (숨겨진 요소 제외)
+
+            // v-if="false"인 요소는 DOM에 존재하지 않음
+            expect(wrapper.find('.item-hidden').exists()).toBe(false);
+
+            // 인덱스 2에 해당하는 요소만 표시됨
+            expect(allItems[0].isVisible()).toBe(false); // A (인덱스 0)
+            expect(allItems[1].isVisible()).toBe(false); // B (인덱스 1)
+            expect(allItems[2].isVisible()).toBe(true); // C (인덱스 2)
+
+            expect(allItems[2].classes()).toContain('item-2');
+            expect(allItems[2].text()).toBe('C');
+        });
+
+        it('모든 v-if가 false인 경우 아무것도 렌더링되지 않아야 한다', () => {
+            // given
+            const TestComponent = {
+                template: `
+                    <vs-index-view v-model="currentIndex" :keep-alive="false">
+                        <div v-if="false" class="item-1">첫 번째</div>
+                        <div v-if="false" class="item-2">두 번째</div>
+                    </vs-index-view>
+                `,
+                components: { VsIndexView },
+                data() {
+                    return { currentIndex: 0 };
+                },
+            };
+
+            // when
+            const wrapper = mount(TestComponent);
+
+            // then - 모든 요소가 v-if="false"이므로 아무것도 렌더링되지 않음
+            const vsIndexView = wrapper.findComponent({ name: 'VsIndexView' });
+            expect(vsIndexView.exists()).toBe(true);
+
+            const items = wrapper.findAll('div[class*="item"]');
+            expect(items).toHaveLength(0); // 아무 아이템도 없음
+        });
+    });
+});

--- a/packages/vlossom/src/components/vs-index-view/__tests__/vs-index-view.test.ts
+++ b/packages/vlossom/src/components/vs-index-view/__tests__/vs-index-view.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
 import VsIndexView from './../VsIndexView.vue';
 
 describe('VsIndexView', () => {
@@ -154,6 +155,7 @@ describe('VsIndexView', () => {
             });
 
             (wrapper.vm as any).updateIndex(1);
+            await nextTick(); // Vue의 반응성 시스템이 업데이트를 완료할 때까지 대기
 
             // then
             expect(wrapper.emitted('update:modelValue')).toBeTruthy();

--- a/packages/vlossom/src/components/vs-index-view/types.ts
+++ b/packages/vlossom/src/components/vs-index-view/types.ts
@@ -1,0 +1,9 @@
+import type VsIndexView from './VsIndexView.vue';
+
+declare module 'vue' {
+    interface GlobalComponents {
+        VsIndexView: typeof VsIndexView;
+    }
+}
+
+export type { VsIndexView };

--- a/packages/vlossom/src/declaration/enums.ts
+++ b/packages/vlossom/src/declaration/enums.ts
@@ -10,6 +10,7 @@ export enum VsComponent {
     VsGrid = 'VsGrid',
     VsHeader = 'VsHeader',
     VsImage = 'VsImage',
+    VsIndexView = 'VsIndexView',
     VsInnerScroll = 'VsInnerScroll',
     VsLayout = 'VsLayout',
     VsLoading = 'VsLoading',


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary
vs-index-view component를 작성합니다

## Description
- vs-index-view를 render function을 이용해서 구현했습니다
    - 기존 template을 이용한 구현은 `component :is`를 만들어 넣어야 했지만 이제는 필요 없음.
- v2부터는 vs-index-item 없이 쓰도록 변경합니다
```html
<vs-index-view v-model="index">
    <MyPage1 />
    <MyPage2 />
    <MyPage3 />
</vs-index-view>
```

- v-if, template, v-for Fragment node에도 정상동작 하도록 flatten으로 대응
<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
