### PR TITLE
feat(VsDrawer): create vs-drawer component

### DIFF
--- a/packages/vlossom/package.json
+++ b/packages/vlossom/package.json
@@ -62,6 +62,7 @@
     "dependencies": {
         "@vueuse/core": "^13.6.0",
         "change-case": "^5.4.4",
+        "nanoid": "^5.1.5",
         "radash": "^12.1.1",
         "vue": "^3.5.18"
     },

--- a/packages/vlossom/pnpm-lock.yaml
+++ b/packages/vlossom/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       change-case:
         specifier: ^5.4.4
         version: 5.4.4
+      nanoid:
+        specifier: ^5.1.5
+        version: 5.1.5
       radash:
         specifier: ^12.1.1
         version: 12.1.1
@@ -3234,8 +3237,8 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-component-type-helpers@3.0.5:
-    resolution: {integrity: sha512-uoNZaJ+a1/zppa/Vgmi8zIOP2PHXDN2rT8NyF+zQRK6ZG94lNB9prcV0GdLJbY9i9lrD47JOVIH92SaiA7oJ1A==}
+  vue-component-type-helpers@3.0.6:
+    resolution: {integrity: sha512-6CRM8X7EJqWCJOiKPvSLQG+hJPb/Oy2gyJx3pLjUEhY7PuaCthQu3e0zAGI1lqUBobrrk9IT0K8sG2GsCluxoQ==}
 
   vue-docgen-api@4.79.2:
     resolution: {integrity: sha512-n9ENAcs+40awPZMsas7STqjkZiVlIjxIKgiJr5rSohDP0/JCrD9VtlzNojafsA1MChm/hz2h3PDtUedx3lbgfA==}
@@ -4109,7 +4112,7 @@ snapshots:
       storybook: 9.1.1(@testing-library/dom@10.4.1)(prettier@3.5.3)(vite@7.0.6(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.90.0))
       type-fest: 2.19.0
       vue: 3.5.18(typescript@5.8.3)
-      vue-component-type-helpers: 3.0.5
+      vue-component-type-helpers: 3.0.6
 
   '@tailwindcss/node@4.1.11':
     dependencies:
@@ -6413,7 +6416,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-component-type-helpers@3.0.5: {}
+  vue-component-type-helpers@3.0.6: {}
 
   vue-docgen-api@4.79.2(vue@3.5.18(typescript@5.8.3)):
     dependencies:

--- a/packages/vlossom/sandbox/sandbox.ts
+++ b/packages/vlossom/sandbox/sandbox.ts
@@ -4,7 +4,7 @@ import { createVlossom } from '@/framework';
 import { VlossomComponents } from '@/components/component-map';
 
 // component type 추론을 위해서 import
-import '@/components/component-types';
+import '@/components';
 
 // 실제 vlossom 사용할 때는 import 'vlossom/styles';
 import '@/styles/index.css';

--- a/packages/vlossom/src/components/component-map.ts
+++ b/packages/vlossom/src/components/component-map.ts
@@ -11,6 +11,7 @@ import VsBar from './vs-bar/VsBar.vue';
 import VsButton from './vs-button/VsButton.vue';
 import VsContainer from './vs-container/VsContainer.vue';
 import VsDivider from './vs-divider/VsDivider.vue';
+import VsDrawer from './vs-drawer/VsDrawer.vue';
 import VsExpandable from './vs-expandable/VsExpandable.vue';
 import VsFocusTrap from './vs-focus-trap/VsFocusTrap.vue';
 import VsFooter from './vs-footer/VsFooter.vue';
@@ -35,6 +36,7 @@ export const VlossomComponents = {
     VsButton,
     VsContainer,
     VsDivider,
+    VsDrawer,
     VsExpandable,
     VsFocusTrap,
     VsFooter,

--- a/packages/vlossom/src/components/index.ts
+++ b/packages/vlossom/src/components/index.ts
@@ -27,6 +27,7 @@ export { default as VsBar } from './vs-bar/VsBar.vue';
 export { default as VsButton } from './vs-button/VsButton.vue';
 export { default as VsContainer } from './vs-container/VsContainer.vue';
 export { default as VsDivider } from './vs-divider/VsDivider.vue';
+export { default as VsDrawer } from './vs-drawer/VsDrawer.vue';
 export { default as VsExpandable } from './vs-expandable/VsExpandable.vue';
 export { default as VsFocusTrap } from './vs-focus-trap/VsFocusTrap.vue';
 export { default as VsFooter } from './vs-footer/VsFooter.vue';

--- a/packages/vlossom/src/components/index.ts
+++ b/packages/vlossom/src/components/index.ts
@@ -4,6 +4,7 @@ export type * from './vs-bar/types';
 export type * from './vs-button/types';
 export type * from './vs-container/types';
 export type * from './vs-divider/types';
+export type * from './vs-drawer/types';
 export type * from './vs-expandable/types';
 export type * from './vs-focus-trap/types';
 export type * from './vs-footer/types';

--- a/packages/vlossom/src/components/vs-bar/types.ts
+++ b/packages/vlossom/src/components/vs-bar/types.ts
@@ -1,5 +1,5 @@
 import type VsBar from './VsBar.vue';
-import type { SizeStyleSet, BoxStyleSet, TextStyleSet } from '@/declaration';
+import type { SizeStyleSet, BoxStyleSet, TextStyleSet, CssPosition } from '@/declaration';
 
 declare module 'vue' {
     interface GlobalComponents {
@@ -10,7 +10,7 @@ declare module 'vue' {
 export type { VsBar };
 
 export interface VsBarStyleSet extends SizeStyleSet, Omit<BoxStyleSet, 'display' | 'opacity'>, TextStyleSet {
-    position?: 'fixed' | 'absolute' | 'relative' | 'sticky' | 'static';
+    position?: CssPosition;
     boxShadow?: string;
     top?: string | number;
     bottom?: string | number;

--- a/packages/vlossom/src/components/vs-button/VsButton.vue
+++ b/packages/vlossom/src/components/vs-button/VsButton.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, toRefs, useTemplateRef, watch } from 'vue';
+import { computed, defineComponent, toRefs, useTemplateRef, watch, type TemplateRef } from 'vue';
 import { VsComponent } from '@/declaration';
 import { getButtonProps, getColorSchemeProps, getStyleSetProps } from '@/props';
 import { useColorScheme, useStyleSet } from '@/composables';
@@ -40,7 +40,7 @@ export default defineComponent({
         const { colorScheme, styleSet, circle, disabled, ghost, large, loading, outline, primary, responsive, small } =
             toRefs(props);
 
-        const buttonRef = useTemplateRef<HTMLButtonElement>('buttonRef');
+        const buttonRef: TemplateRef<HTMLButtonElement> = useTemplateRef('buttonRef');
 
         const { colorSchemeClass } = useColorScheme(name, colorScheme);
 

--- a/packages/vlossom/src/components/vs-container/VsContainer.css
+++ b/packages/vlossom/src/components/vs-container/VsContainer.css
@@ -1,5 +1,6 @@
 .vs-container {
     @apply relative w-full;
 
+    transition: padding 0.3s ease-in-out;
     container-type: inline-size;
 }

--- a/packages/vlossom/src/components/vs-container/VsContainer.vue
+++ b/packages/vlossom/src/components/vs-container/VsContainer.vue
@@ -8,6 +8,7 @@
 import { computed, defineComponent, getCurrentInstance, inject } from 'vue';
 import { LAYOUT_STORE_KEY, VsComponent } from '@/declaration';
 import { LayoutStore } from '@/stores';
+import { objectUtil } from '@/utils';
 
 const name = VsComponent.VsContainer;
 export default defineComponent({
@@ -19,26 +20,36 @@ export default defineComponent({
         // only for vs-layout children
         const isLayoutChild = computed(() => getCurrentInstance()?.parent?.type.name === VsComponent.VsLayout);
 
-        const { header, footer } = inject(LAYOUT_STORE_KEY, LayoutStore.getDefaultLayoutStore());
+        const { header, footer, drawers } = inject(LAYOUT_STORE_KEY, LayoutStore.getDefaultLayoutStore());
         const layoutStyles = computed(() => {
             if (!isLayoutChild.value) {
                 return {};
             }
 
-            const styles: { [key: string]: string } = {};
             const needPadding = ['absolute', 'fixed', 'sticky'];
-
             const { position: headerPosition, height: headerHeight } = header.value;
-            if (needPadding.includes(headerPosition) && headerHeight) {
-                styles.paddingTop = headerHeight;
-            }
+            const headerStyles = objectUtil.shake({
+                paddingTop: needPadding.includes(headerPosition) && headerHeight ? headerHeight : undefined,
+            });
 
             const { position: footerPosition, height: footerHeight } = footer.value;
-            if (needPadding.includes(footerPosition) && footerHeight) {
-                styles.paddingBottom = footerHeight;
-            }
+            const footerStyles = objectUtil.shake({
+                paddingBottom: needPadding.includes(footerPosition) && footerHeight ? footerHeight : undefined,
+            });
 
-            return styles;
+            const { left, top, bottom, right } = drawers.value;
+            const drawerStyles = objectUtil.shake({
+                paddingLeft: left.isOpen && left.responsive && left.size ? left.size : undefined,
+                paddingTop: top.isOpen && top.responsive && top.size ? top.size : undefined,
+                paddingBottom: bottom.isOpen && bottom.responsive && bottom.size ? bottom.size : undefined,
+                paddingRight: right.isOpen && right.responsive && right.size ? right.size : undefined,
+            });
+
+            return {
+                ...headerStyles,
+                ...footerStyles,
+                ...drawerStyles,
+            };
         });
 
         return { layoutStyles };

--- a/packages/vlossom/src/components/vs-container/__tests__/vs-container.test.ts
+++ b/packages/vlossom/src/components/vs-container/__tests__/vs-container.test.ts
@@ -43,9 +43,7 @@ describe('VsContainer', () => {
             const wrapper = mount(VsContainer);
 
             // then
-            const container = wrapper.find('.vs-container');
-            const style = container.attributes('style');
-            expect(style).toBeUndefined();
+            expect(wrapper.vm.layoutStyles).toEqual({});
         });
     });
 
@@ -74,9 +72,10 @@ describe('VsContainer', () => {
 
             // then
             const container = wrapper.findComponent(VsContainer);
-            const style = container.attributes('style');
-            expect(style).toContain('padding-top: 70px');
-            expect(style).toContain('padding-bottom: 90px');
+            expect(container.vm.layoutStyles).toEqual({
+                paddingTop: '70px',
+                paddingBottom: '90px',
+            });
         });
 
         it('header와 footer position이 relative일 때 패딩이 적용되지 않아야 한다', () => {
@@ -93,8 +92,7 @@ describe('VsContainer', () => {
 
             // then
             const container = wrapper.findComponent(VsContainer);
-            const style = container.attributes('style');
-            expect(style).toBeUndefined();
+            expect(container.vm.layoutStyles).toEqual({});
         });
 
         it('header와 footer position이 static일 때 패딩이 적용되지 않아야 한다', () => {
@@ -111,11 +109,10 @@ describe('VsContainer', () => {
 
             // then
             const container = wrapper.findComponent(VsContainer);
-            const style = container.attributes('style');
-            expect(style).toBeUndefined();
+            expect(container.vm.layoutStyles).toEqual({});
         });
 
-        it('header와 footer position이 sticky일 때 패딩이 적용되지 않아야 한다', () => {
+        it('header와 footer position이 sticky일 때 패딩이 적용되어야 한다', () => {
             // given
             layoutStore.setHeader({ position: 'sticky', height: '60px' });
             layoutStore.setFooter({ position: 'sticky', height: '80px' });
@@ -129,9 +126,287 @@ describe('VsContainer', () => {
 
             // then
             const container = wrapper.findComponent(VsContainer);
-            const style = container.attributes('style');
-            expect(style).toContain('padding-top: 60px');
-            expect(style).toContain('padding-bottom: 80px');
+            expect(container.vm.layoutStyles).toEqual({
+                paddingTop: '60px',
+                paddingBottom: '80px',
+            });
+        });
+    });
+
+    describe('drawers 관련 테스트', () => {
+        // vs-layout 컴포넌트 모킹
+        const MockVsLayout = defineComponent({
+            name: VsComponent.VsLayout,
+            setup() {
+                provide(LAYOUT_STORE_KEY, layoutStore);
+                return {};
+            },
+            template: '<div><slot /></div>',
+        });
+
+        describe('각 방향별 drawer 테스트', () => {
+            it('left drawer가 열려있고 responsive이며 size가 설정되어 있을 때 왼쪽 패딩이 적용되어야 한다', () => {
+                // given
+                layoutStore.setDrawer({
+                    placement: 'left',
+                    isOpen: true,
+                    responsive: true,
+                    size: '200px',
+                });
+
+                // when
+                const wrapper = mount(MockVsLayout, {
+                    slots: {
+                        default: VsContainer,
+                    },
+                });
+
+                // then
+                const container = wrapper.findComponent(VsContainer);
+                expect(container.vm.layoutStyles).toEqual({
+                    paddingLeft: '200px',
+                });
+            });
+
+            it('top drawer가 열려있고 responsive이며 size가 설정되어 있을 때 위쪽 패딩이 적용되어야 한다', () => {
+                // given
+                layoutStore.setDrawer({
+                    placement: 'top',
+                    isOpen: true,
+                    responsive: true,
+                    size: '150px',
+                });
+
+                // when
+                const wrapper = mount(MockVsLayout, {
+                    slots: {
+                        default: VsContainer,
+                    },
+                });
+
+                // then
+                const container = wrapper.findComponent(VsContainer);
+                expect(container.vm.layoutStyles).toEqual({
+                    paddingTop: '150px',
+                });
+            });
+
+            it('right drawer가 열려있고 responsive이며 size가 설정되어 있을 때 오른쪽 패딩이 적용되어야 한다', () => {
+                // given
+                layoutStore.setDrawer({
+                    placement: 'right',
+                    isOpen: true,
+                    responsive: true,
+                    size: '250px',
+                });
+
+                // when
+                const wrapper = mount(MockVsLayout, {
+                    slots: {
+                        default: VsContainer,
+                    },
+                });
+
+                // then
+                const container = wrapper.findComponent(VsContainer);
+                expect(container.vm.layoutStyles).toEqual({
+                    paddingRight: '250px',
+                });
+            });
+
+            it('bottom drawer가 열려있고 responsive이며 size가 설정되어 있을 때 아래쪽 패딩이 적용되어야 한다', () => {
+                // given
+                layoutStore.setDrawer({
+                    placement: 'bottom',
+                    isOpen: true,
+                    responsive: true,
+                    size: '100px',
+                });
+
+                // when
+                const wrapper = mount(MockVsLayout, {
+                    slots: {
+                        default: VsContainer,
+                    },
+                });
+
+                // then
+                const container = wrapper.findComponent(VsContainer);
+                expect(container.vm.layoutStyles).toEqual({
+                    paddingBottom: '100px',
+                });
+            });
+        });
+
+        describe('drawer 조건 테스트', () => {
+            it('drawer가 닫혀있으면 패딩이 적용되지 않아야 한다', () => {
+                // given
+                layoutStore.setDrawer({
+                    placement: 'left',
+                    isOpen: false,
+                    responsive: true,
+                    size: '200px',
+                });
+
+                // when
+                const wrapper = mount(MockVsLayout, {
+                    slots: {
+                        default: VsContainer,
+                    },
+                });
+
+                // then
+                const container = wrapper.findComponent(VsContainer);
+                expect(container.vm.layoutStyles).toEqual({});
+            });
+
+            it('drawer가 responsive하지 않으면 패딩이 적용되지 않아야 한다', () => {
+                // given
+                layoutStore.setDrawer({
+                    placement: 'left',
+                    isOpen: true,
+                    responsive: false,
+                    size: '200px',
+                });
+
+                // when
+                const wrapper = mount(MockVsLayout, {
+                    slots: {
+                        default: VsContainer,
+                    },
+                });
+
+                // then
+                const container = wrapper.findComponent(VsContainer);
+                expect(container.vm.layoutStyles).toEqual({});
+            });
+
+            it('drawer의 size가 빈 문자열이면 패딩이 적용되지 않아야 한다', () => {
+                // given
+                layoutStore.setDrawer({
+                    placement: 'left',
+                    isOpen: true,
+                    responsive: true,
+                    size: '',
+                });
+
+                // when
+                const wrapper = mount(MockVsLayout, {
+                    slots: {
+                        default: VsContainer,
+                    },
+                });
+
+                // then
+                const container = wrapper.findComponent(VsContainer);
+                expect(container.vm.layoutStyles).toEqual({});
+            });
+        });
+
+        describe('모든 drawer가 활성화된 경우', () => {
+            it('모든 방향의 drawer가 활성화되어 있을 때 모든 패딩이 적용되어야 한다', () => {
+                // given
+                layoutStore.setDrawer({ placement: 'left', isOpen: true, responsive: true, size: '200px' });
+                layoutStore.setDrawer({ placement: 'top', isOpen: true, responsive: true, size: '150px' });
+                layoutStore.setDrawer({ placement: 'right', isOpen: true, responsive: true, size: '250px' });
+                layoutStore.setDrawer({ placement: 'bottom', isOpen: true, responsive: true, size: '100px' });
+
+                // when
+                const wrapper = mount(MockVsLayout, {
+                    slots: {
+                        default: VsContainer,
+                    },
+                });
+
+                // then
+                const container = wrapper.findComponent(VsContainer);
+                expect(container.vm.layoutStyles).toEqual({
+                    paddingLeft: '200px',
+                    paddingTop: '150px',
+                    paddingBottom: '100px',
+                    paddingRight: '250px',
+                });
+            });
+        });
+    });
+
+    describe('복합 조합 테스트', () => {
+        // vs-layout 컴포넌트 모킹
+        const MockVsLayout = defineComponent({
+            name: VsComponent.VsLayout,
+            setup() {
+                provide(LAYOUT_STORE_KEY, layoutStore);
+                return {};
+            },
+            template: '<div><slot /></div>',
+        });
+
+        it('header, footer, drawer가 모두 활성화되어 있을 때 모든 패딩이 올바르게 적용되어야 한다', () => {
+            // given
+            layoutStore.setHeader({ position: 'fixed', height: '70px' });
+            layoutStore.setFooter({ position: 'absolute', height: '90px' });
+            layoutStore.setDrawer({ placement: 'left', isOpen: true, responsive: true, size: '200px' });
+            layoutStore.setDrawer({ placement: 'right', isOpen: true, responsive: true, size: '250px' });
+
+            // when
+            const wrapper = mount(MockVsLayout, {
+                slots: {
+                    default: VsContainer,
+                },
+            });
+
+            // then
+            const container = wrapper.findComponent(VsContainer);
+            expect(container.vm.layoutStyles).toEqual({
+                paddingTop: '70px',
+                paddingBottom: '90px',
+                paddingLeft: '200px',
+                paddingRight: '250px',
+            });
+        });
+
+        it('header는 sticky이고 drawer는 top/bottom일 때 padding-top이 중복되지 않고 올바르게 계산되어야 한다', () => {
+            // given
+            layoutStore.setHeader({ position: 'sticky', height: '60px' });
+            layoutStore.setDrawer({ placement: 'top', isOpen: true, responsive: true, size: '40px' });
+            layoutStore.setDrawer({ placement: 'bottom', isOpen: true, responsive: true, size: '50px' });
+
+            // when
+            const wrapper = mount(MockVsLayout, {
+                slots: {
+                    default: VsContainer,
+                },
+            });
+
+            // then
+            const container = wrapper.findComponent(VsContainer);
+            // drawerStyles가 나중에 spread되므로 drawer의 paddingTop이 우선됨
+            expect(container.vm.layoutStyles).toEqual({
+                paddingTop: '40px',
+                paddingBottom: '50px',
+            });
+        });
+
+        it('일부 조건만 활성화되어 있을 때 해당하는 패딩만 적용되어야 한다', () => {
+            // given
+            layoutStore.setHeader({ position: 'relative', height: '60px' }); // padding 적용되지 않음
+            layoutStore.setFooter({ position: 'fixed', height: '80px' }); // padding 적용됨
+            layoutStore.setDrawer({ placement: 'left', isOpen: false, responsive: true, size: '200px' }); // padding 적용되지 않음
+            layoutStore.setDrawer({ placement: 'right', isOpen: true, responsive: true, size: '250px' }); // padding 적용됨
+
+            // when
+            const wrapper = mount(MockVsLayout, {
+                slots: {
+                    default: VsContainer,
+                },
+            });
+
+            // then
+            const container = wrapper.findComponent(VsContainer);
+            expect(container.vm.layoutStyles).toEqual({
+                paddingBottom: '80px',
+                paddingRight: '250px',
+            });
         });
     });
 });

--- a/packages/vlossom/src/components/vs-drawer/README.md
+++ b/packages/vlossom/src/components/vs-drawer/README.md
@@ -1,0 +1,180 @@
+# VsDrawer
+
+화면 가장자리에서 슬라이딩하여 나타나는 사이드바 형태의 드로어(서랍) 컴포넌트입니다. 네비게이션 메뉴, 사이드바, 필터 패널 등 다양한 용도로 활용할 수 있으며, `vs-layout`과 함께 사용하면 반응형 레이아웃을 구성할 수 있습니다.
+
+**Available Version**: 2.0.0+
+
+## 기본 사용법
+
+### 기본 드로어
+
+```html
+<template>
+    <div>
+        <vs-button @click="drawerOpen = true">드로어 열기</vs-button>
+        <vs-drawer v-model="drawerOpen">
+            <h3>드로어 내용</h3>
+            <p>여기에 사이드바 내용을 넣어주세요.</p>
+        </vs-drawer>
+    </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+const drawerOpen = ref(false);
+</script>
+```
+
+### 다양한 위치의 드로어
+
+```html
+<template>
+    <div>
+        <vs-drawer v-model="leftDrawer" placement="left">
+            <h3>왼쪽 드로어</h3>
+        </vs-drawer>
+
+        <vs-drawer v-model="rightDrawer" placement="right">
+            <h3>오른쪽 드로어</h3>
+        </vs-drawer>
+
+        <vs-drawer v-model="topDrawer" placement="top">
+            <h3>상단 드로어</h3>
+        </vs-drawer>
+
+        <vs-drawer v-model="bottomDrawer" placement="bottom">
+            <h3>하단 드로어</h3>
+        </vs-drawer>
+    </div>
+</template>
+```
+
+### 크기 조절
+
+```html
+<template>
+    <div>
+        <!-- 사전 정의된 크기 (xs, sm, md, lg, xl) -->
+        <vs-drawer v-model="smallDrawer" size="sm">Small Drawer</vs-drawer>
+        <vs-drawer v-model="mediumDrawer" size="md">Medium Drawer</vs-drawer>
+        <vs-drawer v-model="largeDrawer" size="lg">Large Drawer</vs-drawer>
+
+        <!-- 커스텀 크기 -->
+        <vs-drawer v-model="customDrawer" size="350px">Custom Size Drawer</vs-drawer>
+        <vs-drawer v-model="percentDrawer" size="30%">Percent Size Drawer</vs-drawer>
+    </div>
+</template>
+```
+
+### vs-layout과 함께 사용하는 반응형 드로어
+
+```html
+<template>
+    <vs-layout>
+        <vs-drawer
+            placement="left"
+            size="280px"
+            layout-responsive
+            open
+        >
+            <template #header>
+                <h2>네비게이션</h2>
+            </template>
+
+            <nav>
+                <a href="#">홈</a>
+                ...
+            </nav>
+
+            <template #footer>
+                <small>© 2024 My App</small>
+            </template>
+        </vs-drawer>
+
+        <vs-header>Header Content</vs-header>
+        <vs-container>
+            <!-- 드로어가 열린 상태에서 자동으로 왼쪽 패딩이 적용됩니다 -->
+            <main>Main Content</main>
+        </vs-container>
+        <vs-footer>Footer Content</vs-footer>
+    </vs-layout>
+</template>
+```
+
+### 고정 포지션 드로어
+
+```html
+<template>
+    <vs-drawer v-model="fixedDrawer" fixed>
+        <!-- 페이지 스크롤과 관계없이 화면에 고정됩니다 -->
+        <h3>고정 드로어</h3>
+    </vs-drawer>
+</template>
+```
+
+## Props
+
+| Prop               | Type                                     | Default  | Required | Description                                                 |
+| ------------------ | ---------------------------------------- | -------- | -------- | ----------------------------------------------------------- |
+| `colorScheme`      | `ColorScheme`                            | -        | -        | 컴포넌트 색상 테마                                          |
+| `styleSet`         | `string \| VsDrawerStyleSet`             | -        | -        | 커스텀 스타일 설정 객체                                     |
+| `callbacks`        | `OverlayCallbacks`                       | -        | -        | 오버레이 상태 변화 시 호출될 콜백 함수들                    |
+| `dimClose`         | `boolean`                                | `false`  | -        | 배경(dimmed) 클릭 시 드로어를 닫을지 여부                   |
+| `dimmed`           | `boolean`                                | `false`  | -        | 배경 어둡게 처리(dimmed overlay) 사용 여부                  |
+| `escClose`         | `boolean`                                | `false`  | -        | ESC 키 누를 시 드로어를 닫을지 여부                         |
+| `focusLock`        | `boolean`                                | `false`  | -        | 포커스가 드로어 내부에만 머무르도록 제한할지 여부           |
+| `id`               | `string`                                 | -        | -        | 고유 식별자                                                 |
+| `fixed`            | `boolean`                                | `false`  | -        | 고정 포지션(position: fixed) 사용 여부                      |
+| `layoutResponsive` | `boolean`                                | `false`  | -        | vs-layout과 연동하여 반응형 레이아웃 적용 여부              |
+| `open`             | `boolean`                                | `false`  | -        | 초기 열림 상태 (제어되지 않는 모드)                         |
+| `placement`        | `'left' \| 'right' \| 'top' \| 'bottom'` | `'left'` | -        | 드로어가 나타나는 위치                                      |
+| `size`             | `SizeProp`                               | `'sm'`   | -        | 드로어 크기 ('xs'\|'sm'\|'md'\|'lg'\|'xl' 또는 사용자 정의) |
+| `modelValue`       | `boolean`                                | `false`  | -        | v-model 바인딩을 위한 값                                    |
+
+## Events
+
+| Event               | Payload   | Description                       |
+| ------------------- | --------- | --------------------------------- |
+| `update:modelValue` | `boolean` | v-model 값 업데이트 시 발생       |
+| `open`              | -         | 드로어가 열릴 때 발생             |
+| `close`             | -         | 드로어가 닫힐 때 발생             |
+| `click-dimmed`      | -         | 배경(dimmed overlay) 클릭 시 발생 |
+
+## Types
+
+```typescript
+interface VsDrawerStyleSet {
+    backgroundColor?: string;
+    border?: string;
+    borderRadius?: string;
+    padding?: string;
+    opacity?: string | number;
+    position?: 'absolute' | 'fixed';
+    size?: string;
+    dimmed?: {
+        backgroundColor?: string;
+        opacity?: number;
+    };
+}
+
+type DrawerPlacement = 'left' | 'right' | 'top' | 'bottom';
+type SizeProp = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | string | number;
+```
+
+## Slots
+
+| Slot      | Description               |
+| --------- | ------------------------- |
+| `default` | 드로어의 메인 콘텐츠 영역 |
+| `header`  | 드로어 상단 헤더 영역     |
+| `footer`  | 드로어 하단 푸터 영역     |
+
+## 특징
+
+- **다양한 위치 지원**: `left`, `right`, `top`, `bottom` 4방향에서 슬라이딩
+- **유연한 크기 조절**: 사전 정의된 크기(`xs`~`xl`) 또는 픽셀/퍼센트 등 커스텀 크기 지원
+- **오버레이 기능**: 배경 어둡게 처리, 배경 클릭으로 닫기, ESC 키로 닫기 등
+- **접근성**: 포커스 트랩 기능으로 키보드 네비게이션 지원
+- **애니메이션**: 부드러운 슬라이딩 애니메이션 효과
+- **v-model 지원**: 양방향 데이터 바인딩을 통한 상태 관리
+- **vs-layout 연동**: 반응형 레이아웃 구성을 위한 레이아웃 시스템과의 완벽한 통합

--- a/packages/vlossom/src/components/vs-drawer/VsDrawer.css
+++ b/packages/vlossom/src/components/vs-drawer/VsDrawer.css
@@ -1,3 +1,5 @@
+@reference 'tailwindcss';
+
 .vs-drawer {
     --vs-drawer-size: initial;
 
@@ -11,27 +13,23 @@
     --vs-drawer-dimmed-backgroundColor: initial;
     --vs-drawer-dimmed-opacity: initial;
 
-    @apply pointer-events-none h-full w-full overflow-hidden;
+    @apply pointer-events-none top-0 left-0 h-full w-full overflow-hidden;
 
     position: var(--vs-drawer-position, absolute);
-    top: 0;
-    left: 0;
 
     &.vs-drawer-dimmed {
         @apply pointer-events-auto;
     }
 
     .vs-drawer-dimmed {
-        @apply absolute h-full w-full;
+        @apply absolute top-0 left-0 h-full w-full;
 
-        top: 0;
-        left: 0;
         opacity: var(--vs-drawer-dimmed-opacity, 0.4);
         background-color: var(--vs-drawer-dimmed-backgroundColor, var(--vs-black));
     }
 
     .vs-drawer-content {
-        @apply absolute;
+        @apply pointer-events-auto absolute;
 
         opacity: var(--vs-drawer-opacity, 1);
         border: var(--vs-drawer-border, none);
@@ -40,8 +38,8 @@
         padding: var(--vs-drawer-padding, 0);
 
         &.vs-drawer-left {
-            top: 0;
-            left: 0;
+            @apply top-0 left-0;
+
             transform: translateX(0);
             border-top-right-radius: var(--vs-drawer-borderRadius, 0);
             border-bottom-right-radius: var(--vs-drawer-borderRadius, 0);
@@ -50,8 +48,8 @@
         }
 
         &.vs-drawer-right {
-            top: 0;
-            right: 0;
+            @apply top-0 right-0;
+
             transform: translateX(0);
             border-top-left-radius: var(--vs-drawer-borderRadius, 0);
             border-bottom-left-radius: var(--vs-drawer-borderRadius, 0);
@@ -60,8 +58,8 @@
         }
 
         &.vs-drawer-top {
-            top: 0;
-            left: 0;
+            @apply top-0 left-0;
+
             transform: translateY(0);
             border-bottom-right-radius: var(--vs-drawer-borderRadius, 0);
             border-bottom-left-radius: var(--vs-drawer-borderRadius, 0);
@@ -70,8 +68,8 @@
         }
 
         &.vs-drawer-bottom {
-            bottom: 0;
-            left: 0;
+            @apply bottom-0 left-0;
+
             transform: translateY(0);
             border-top-right-radius: var(--vs-drawer-borderRadius, 0);
             border-top-left-radius: var(--vs-drawer-borderRadius, 0);

--- a/packages/vlossom/src/components/vs-drawer/VsDrawer.css
+++ b/packages/vlossom/src/components/vs-drawer/VsDrawer.css
@@ -1,0 +1,108 @@
+.vs-drawer {
+    --vs-drawer-size: initial;
+
+    --vs-drawer-backgroundColor: initial;
+    --vs-drawer-border: initial;
+    --vs-drawer-borderRadius: initial;
+    --vs-drawer-padding: initial;
+    --vs-drawer-opacity: initial;
+
+    --vs-drawer-dimmed-backgroundColor: initial;
+    --vs-drawer-dimmed-opacity: initial;
+
+    @apply pointer-events-none absolute h-full w-full overflow-hidden;
+    top: 0;
+    left: 0;
+
+    &.vs-drawer-dimmed {
+        @apply pointer-events-auto;
+    }
+
+    .vs-drawer-dimmed {
+        @apply absolute h-full w-full;
+
+        top: 0;
+        left: 0;
+        opacity: var(--vs-drawer-dimmed-opacity, 0.4);
+        background-color: var(--vs-drawer-dimmed-backgroundColor, var(--vs-black));
+    }
+
+    .vs-drawer-content {
+        @apply absolute;
+
+        transform: translateX(0) translateY(0);
+        opacity: var(--vs-drawer-opacity, 1);
+        border: var(--vs-drawer-border, none);
+        border-radius: var(--vs-drawer-borderRadius, 0);
+        background-color: var(--vs-drawer-backgroundColor, var(--vs-comp-bg));
+        padding: var(--vs-drawer-padding, 0);
+
+        &.vs-drawer-left {
+            top: 0;
+            left: 0;
+            border-top-right-radius: var(--vs-drawer-borderRadius, 0);
+            border-bottom-right-radius: var(--vs-drawer-borderRadius, 0);
+            width: var(--vs-drawer-size);
+            height: 100%;
+        }
+
+        &.vs-drawer-right {
+            top: 0;
+            right: 0;
+            border-top-left-radius: var(--vs-drawer-borderRadius, 0);
+            border-bottom-left-radius: var(--vs-drawer-borderRadius, 0);
+            width: var(--vs-drawer-size);
+            height: 100%;
+        }
+
+        &.vs-drawer-top {
+            top: 0;
+            left: 0;
+            border-bottom-right-radius: var(--vs-drawer-borderRadius, 0);
+            border-bottom-left-radius: var(--vs-drawer-borderRadius, 0);
+            width: 100%;
+            height: var(--vs-drawer-size);
+        }
+
+        &.vs-drawer-bottom {
+            bottom: 0;
+            left: 0;
+            border-top-right-radius: var(--vs-drawer-borderRadius, 0);
+            border-top-left-radius: var(--vs-drawer-borderRadius, 0);
+            width: 100%;
+            height: var(--vs-drawer-size);
+        }
+    }
+}
+
+.drawer-enter-active .vs-drawer-dimmed,
+.drawer-leave-active .vs-drawer-dimmed,
+.drawer-enter-active .vs-drawer-content,
+.drawer-leave-active .vs-drawer-content {
+    transition: all 0.8s;
+}
+
+.drawer-enter-from .vs-drawer-dimmed,
+.drawer-leave-to .vs-drawer-dimmed {
+    opacity: 0;
+}
+
+.drawer-enter-from .vs-drawer-content.vs-drawer-left,
+.drawer-leave-to .vs-drawer-content.vs-drawer-left {
+    transform: translateX(-100%);
+}
+
+.drawer-enter-from .vs-drawer-content.vs-drawer-right,
+.drawer-leave-to .vs-drawer-content.vs-drawer-right {
+    transform: translateX(100%);
+}
+
+.drawer-enter-from .vs-drawer-content.vs-drawer-bottom,
+.drawer-leave-to .vs-drawer-content.vs-drawer-bottom {
+    transform: translateY(100%);
+}
+
+.drawer-enter-from .vs-drawer-content.vs-drawer-top,
+.drawer-leave-to .vs-drawer-content.vs-drawer-top {
+    transform: translateY(-100%);
+}

--- a/packages/vlossom/src/components/vs-drawer/VsDrawer.css
+++ b/packages/vlossom/src/components/vs-drawer/VsDrawer.css
@@ -2,6 +2,7 @@
 
 .vs-drawer {
     --vs-drawer-size: initial;
+    --vs-drawer-boxShadow: initial;
 
     --vs-drawer-position: initial;
     --vs-drawer-backgroundColor: initial;
@@ -32,7 +33,7 @@
         @apply pointer-events-auto absolute;
 
         opacity: var(--vs-drawer-opacity, 1);
-        border: var(--vs-drawer-border, none);
+        box-shadow: var(--vs-drawer-boxShadow, none);
         border-radius: var(--vs-drawer-borderRadius, 0);
         background-color: var(--vs-drawer-backgroundColor, var(--vs-comp-bg));
         padding: var(--vs-drawer-padding, 0);
@@ -41,6 +42,7 @@
             @apply top-0 left-0;
 
             transform: translateX(0);
+            border-right: var(--vs-drawer-border, 1px solid var(--vs-line-color));
             border-top-right-radius: var(--vs-drawer-borderRadius, 0);
             border-bottom-right-radius: var(--vs-drawer-borderRadius, 0);
             width: var(--vs-drawer-size);
@@ -51,6 +53,7 @@
             @apply top-0 right-0;
 
             transform: translateX(0);
+            border-left: var(--vs-drawer-border, 1px solid var(--vs-line-color));
             border-top-left-radius: var(--vs-drawer-borderRadius, 0);
             border-bottom-left-radius: var(--vs-drawer-borderRadius, 0);
             width: var(--vs-drawer-size);
@@ -61,6 +64,7 @@
             @apply top-0 left-0;
 
             transform: translateY(0);
+            border-top: var(--vs-drawer-border, 1px solid var(--vs-line-color));
             border-bottom-right-radius: var(--vs-drawer-borderRadius, 0);
             border-bottom-left-radius: var(--vs-drawer-borderRadius, 0);
             width: 100%;
@@ -71,6 +75,7 @@
             @apply bottom-0 left-0;
 
             transform: translateY(0);
+            border-bottom: var(--vs-drawer-border, 1px solid var(--vs-line-color));
             border-top-right-radius: var(--vs-drawer-borderRadius, 0);
             border-top-left-radius: var(--vs-drawer-borderRadius, 0);
             width: 100%;

--- a/packages/vlossom/src/components/vs-drawer/VsDrawer.css
+++ b/packages/vlossom/src/components/vs-drawer/VsDrawer.css
@@ -1,6 +1,7 @@
 .vs-drawer {
     --vs-drawer-size: initial;
 
+    --vs-drawer-position: initial;
     --vs-drawer-backgroundColor: initial;
     --vs-drawer-border: initial;
     --vs-drawer-borderRadius: initial;
@@ -10,7 +11,9 @@
     --vs-drawer-dimmed-backgroundColor: initial;
     --vs-drawer-dimmed-opacity: initial;
 
-    @apply pointer-events-none absolute h-full w-full overflow-hidden;
+    @apply pointer-events-none h-full w-full overflow-hidden;
+
+    position: var(--vs-drawer-position, absolute);
     top: 0;
     left: 0;
 
@@ -30,7 +33,6 @@
     .vs-drawer-content {
         @apply absolute;
 
-        transform: translateX(0) translateY(0);
         opacity: var(--vs-drawer-opacity, 1);
         border: var(--vs-drawer-border, none);
         border-radius: var(--vs-drawer-borderRadius, 0);
@@ -40,6 +42,7 @@
         &.vs-drawer-left {
             top: 0;
             left: 0;
+            transform: translateX(0);
             border-top-right-radius: var(--vs-drawer-borderRadius, 0);
             border-bottom-right-radius: var(--vs-drawer-borderRadius, 0);
             width: var(--vs-drawer-size);
@@ -49,6 +52,7 @@
         &.vs-drawer-right {
             top: 0;
             right: 0;
+            transform: translateX(0);
             border-top-left-radius: var(--vs-drawer-borderRadius, 0);
             border-bottom-left-radius: var(--vs-drawer-borderRadius, 0);
             width: var(--vs-drawer-size);
@@ -58,6 +62,7 @@
         &.vs-drawer-top {
             top: 0;
             left: 0;
+            transform: translateY(0);
             border-bottom-right-radius: var(--vs-drawer-borderRadius, 0);
             border-bottom-left-radius: var(--vs-drawer-borderRadius, 0);
             width: 100%;
@@ -67,6 +72,7 @@
         &.vs-drawer-bottom {
             bottom: 0;
             left: 0;
+            transform: translateY(0);
             border-top-right-radius: var(--vs-drawer-borderRadius, 0);
             border-top-left-radius: var(--vs-drawer-borderRadius, 0);
             width: 100%;
@@ -76,10 +82,12 @@
 }
 
 .drawer-enter-active .vs-drawer-dimmed,
-.drawer-leave-active .vs-drawer-dimmed,
+.drawer-leave-active .vs-drawer-dimmed {
+    transition: opacity 0.25s;
+}
 .drawer-enter-active .vs-drawer-content,
 .drawer-leave-active .vs-drawer-content {
-    transition: all 0.8s;
+    transition: transform 0.25s ease-in-out;
 }
 
 .drawer-enter-from .vs-drawer-dimmed,

--- a/packages/vlossom/src/components/vs-drawer/VsDrawer.vue
+++ b/packages/vlossom/src/components/vs-drawer/VsDrawer.vue
@@ -1,0 +1,200 @@
+<template>
+    <Transition name="drawer" :duration="ANIMATION_DURATION">
+        <div
+            v-show="isOpen"
+            ref="drawerRef"
+            :class="['vs-drawer', colorSchemeClass, { 'vs-drawer-dimmed': dimmed }]"
+            :style="styleSetVariables"
+        >
+            <div v-if="dimmed" class="vs-drawer-dimmed" aria-hidden="true" @click.prevent.stop="onClickDimmed" />
+            <vs-focus-trap
+                ref="focusTrapRef"
+                :class="['vs-drawer-content', `vs-drawer-${placement}`]"
+                :focus-lock="focusLock"
+            >
+                <vs-inner-scroll :hide-scroll>
+                    <template #header>
+                        <slot name="header" />
+                    </template>
+                    <slot />
+                    <template #footer>
+                        <slot name="footer" />
+                    </template>
+                </vs-inner-scroll>
+            </vs-focus-trap>
+        </div>
+    </Transition>
+</template>
+
+<script lang="ts">
+import {
+    computed,
+    defineComponent,
+    getCurrentInstance,
+    inject,
+    onBeforeMount,
+    toRefs,
+    useTemplateRef,
+    watch,
+    watchEffect,
+    type ComputedRef,
+    type PropType,
+} from 'vue';
+import {
+    LAYOUT_STORE_KEY,
+    ANIMATION_DURATION,
+    OVERLAY_CLOSE,
+    OVERLAY_OPEN,
+    VsComponent,
+    type DrawerPlacement,
+    type Focusable,
+    type SizeProp,
+    SIZES,
+    type Size,
+} from '@/declaration';
+import { useColorScheme, useOverlay, useStyleSet } from '@/composables';
+import { getColorSchemeProps, getStyleSetProps, getOverlayProps, getPositionProps } from '@/props';
+import { LayoutStore } from '@/stores';
+import { objectUtil, stringUtil } from '@/utils';
+import type { VsDrawerStyleSet } from './types';
+import VsFocusTrap from '@/components/vs-focus-trap/VsFocusTrap.vue';
+import VsInnerScroll from '@/components/vs-inner-scroll/VsInnerScroll.vue';
+
+const name = VsComponent.VsDrawer;
+export default defineComponent({
+    name,
+    components: { VsFocusTrap, VsInnerScroll },
+    props: {
+        ...getColorSchemeProps(),
+        ...getStyleSetProps<VsDrawerStyleSet>(),
+        ...getOverlayProps(),
+        ...getPositionProps(),
+        layoutResponsive: { type: Boolean, default: false },
+        open: { type: Boolean, default: false },
+        placement: {
+            type: String as PropType<DrawerPlacement>,
+            default: 'left',
+        },
+        size: { type: [String, Number] as PropType<SizeProp> },
+        // v-model
+        modelValue: { type: Boolean, default: false },
+    },
+    emits: ['update:modelValue', 'open', 'close', 'click-dimmed'],
+    setup(props, { emit }) {
+        const {
+            colorScheme,
+            styleSet,
+            id,
+            callbacks,
+            dimClose,
+            escClose,
+            open: initialOpen,
+            modelValue,
+            position,
+            layoutResponsive,
+            placement,
+            size,
+        } = toRefs(props);
+
+        const drawerRef = useTemplateRef<HTMLElement>('drawerRef');
+        const focusTrapRef = useTemplateRef<Focusable>('focusTrapRef');
+        const DRAWER_SIZE: Record<Size, string> = {
+            xs: '12%',
+            sm: '20%',
+            md: '40%',
+            lg: '60%',
+            xl: '80%',
+        };
+
+        const { colorSchemeClass } = useColorScheme(name, colorScheme);
+        const drawerSize = computed(() => {
+            if (!size.value) {
+                return DRAWER_SIZE.sm;
+            }
+            if (SIZES.includes(size.value as Size)) {
+                return DRAWER_SIZE[size.value as Size];
+            }
+            return stringUtil.toStringSize(size.value);
+        });
+
+        const additionalStyleSet: ComputedRef<Partial<VsDrawerStyleSet>> = computed(() => {
+            return objectUtil.shake({
+                position: position.value ? position.value : undefined,
+                size: drawerSize.value,
+            });
+        });
+
+        const { styleSetVariables } = useStyleSet<VsDrawerStyleSet>(name, styleSet, additionalStyleSet);
+
+        const computedCallbacks = computed(() => {
+            return {
+                ...callbacks.value,
+                [OVERLAY_OPEN]: () => {
+                    focusTrapRef.value?.focus();
+                },
+                [OVERLAY_CLOSE]: () => {
+                    focusTrapRef.value?.blur();
+                },
+            };
+        });
+
+        const { isOpen, open, close } = useOverlay(id, computedCallbacks, escClose);
+
+        function onClickDimmed() {
+            emit('click-dimmed');
+            if (dimClose.value) {
+                close();
+            }
+        }
+
+        // only for vs-layout children
+        const isLayoutChild = computed(() => getCurrentInstance()?.parent?.type.name === VsComponent.VsLayout);
+
+        const layoutStore = inject(LAYOUT_STORE_KEY, LayoutStore.getDefaultLayoutStore());
+        watchEffect(() => {
+            if (!isLayoutChild.value) {
+                return;
+            }
+            layoutStore.setDrawer({
+                isOpen: isOpen.value,
+                placement: placement.value,
+                size: drawerSize.value || DRAWER_SIZE.sm,
+                responsive: layoutResponsive.value,
+            });
+        });
+
+        onBeforeMount(() => {
+            if (initialOpen.value || modelValue.value) {
+                open();
+            }
+        });
+
+        watch(isOpen, (o) => {
+            if (o) {
+                open();
+            } else {
+                close();
+            }
+
+            emit('update:modelValue', o);
+            emit(o ? 'open' : 'close');
+        });
+
+        watch(modelValue, (o) => {
+            isOpen.value = o;
+        });
+
+        return {
+            drawerRef,
+            focusTrapRef,
+            colorSchemeClass,
+            styleSetVariables,
+            isOpen,
+            ANIMATION_DURATION,
+            onClickDimmed,
+        };
+    },
+});
+</script>
+
+<style src="./VsDrawer.css" />

--- a/packages/vlossom/src/components/vs-drawer/VsDrawer.vue
+++ b/packages/vlossom/src/components/vs-drawer/VsDrawer.vue
@@ -39,6 +39,7 @@ import {
     watchEffect,
     type ComputedRef,
     type PropType,
+    type TemplateRef,
 } from 'vue';
 import {
     LAYOUT_STORE_KEY,
@@ -96,8 +97,8 @@ export default defineComponent({
             size,
         } = toRefs(props);
 
-        const drawerRef = useTemplateRef<HTMLElement>('drawerRef');
-        const focusTrapRef = useTemplateRef<Focusable>('focusTrapRef');
+        const drawerRef: TemplateRef<HTMLElement> = useTemplateRef('drawerRef');
+        const focusTrapRef: TemplateRef<Focusable> = useTemplateRef('focusTrapRef');
         const DRAWER_SIZE: Record<Size, string> = {
             xs: '12%',
             sm: '20%',

--- a/packages/vlossom/src/components/vs-drawer/VsDrawer.vue
+++ b/packages/vlossom/src/components/vs-drawer/VsDrawer.vue
@@ -53,7 +53,7 @@ import {
     type Size,
 } from '@/declaration';
 import { useColorScheme, useOverlay, useStyleSet } from '@/composables';
-import { getColorSchemeProps, getStyleSetProps, getOverlayProps, getPositionProps } from '@/props';
+import { getColorSchemeProps, getStyleSetProps, getOverlayProps } from '@/props';
 import { LayoutStore } from '@/stores';
 import { objectUtil, stringUtil } from '@/utils';
 import type { VsDrawerStyleSet } from './types';
@@ -68,7 +68,7 @@ export default defineComponent({
         ...getColorSchemeProps(),
         ...getStyleSetProps<VsDrawerStyleSet>(),
         ...getOverlayProps(),
-        ...getPositionProps(),
+        fixed: { type: Boolean, default: false },
         layoutResponsive: { type: Boolean, default: false },
         open: { type: Boolean, default: false },
         placement: {
@@ -88,9 +88,9 @@ export default defineComponent({
             callbacks,
             dimClose,
             escClose,
+            fixed,
             open: initialOpen,
             modelValue,
-            position,
             layoutResponsive,
             placement,
             size,
@@ -119,7 +119,7 @@ export default defineComponent({
 
         const additionalStyleSet: ComputedRef<Partial<VsDrawerStyleSet>> = computed(() => {
             return objectUtil.shake({
-                position: position.value ? position.value : undefined,
+                position: fixed.value ? 'fixed' : undefined,
                 size: drawerSize.value,
             });
         });

--- a/packages/vlossom/src/components/vs-drawer/__tests__/vs-drawer.test.ts
+++ b/packages/vlossom/src/components/vs-drawer/__tests__/vs-drawer.test.ts
@@ -1,0 +1,423 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { provide, defineComponent, h } from 'vue';
+import { LayoutStore } from '@/stores';
+import { LAYOUT_STORE_KEY, VsComponent } from '@/declaration';
+import VsDrawer from './../VsDrawer.vue';
+
+describe('VsDrawer', () => {
+    let layoutStore: LayoutStore;
+    let defaultOptions: any;
+
+    beforeEach(() => {
+        // 각 테스트마다 새로운 LayoutStore 인스턴스 생성
+        layoutStore = LayoutStore.getDefaultLayoutStore();
+
+        defaultOptions = {
+            props: {
+                modelValue: false,
+                placement: 'left',
+            },
+            global: {
+                stubs: {
+                    'vs-focus-trap': {
+                        template: '<div class="vs-focus-trap-stub"><slot /></div>',
+                        methods: {
+                            focus: vi.fn(),
+                            blur: vi.fn(),
+                        },
+                    },
+                    'vs-inner-scroll': {
+                        template:
+                            '<div class="vs-inner-scroll-stub"><slot name="header" /><slot /><slot name="footer" /></div>',
+                    },
+                    Transition: {
+                        template: '<div><slot /></div>',
+                    },
+                },
+            },
+        };
+    });
+
+    describe('기본 렌더링', () => {
+        it('기본 상태에서 drawer가 렌더링되어야 한다', () => {
+            // given, when
+            const wrapper = mount(VsDrawer, defaultOptions);
+
+            // then
+            expect(wrapper.find('.vs-drawer').exists()).toBe(true);
+        });
+
+        it('modelValue가 false일 때 drawer가 보이지 않아야 한다', () => {
+            // given, when
+            const wrapper = mount(VsDrawer, {
+                ...defaultOptions,
+                props: {
+                    ...defaultOptions.props,
+                    modelValue: false,
+                },
+            });
+
+            // then
+            expect(wrapper.vm.isOpen).toBe(false);
+        });
+
+        it('modelValue가 true일 때 drawer가 보여야 한다', async () => {
+            // given, when
+            const wrapper = mount(VsDrawer, {
+                ...defaultOptions,
+                props: {
+                    ...defaultOptions.props,
+                    modelValue: true,
+                },
+            });
+
+            await wrapper.vm.$nextTick();
+
+            // then
+            expect(wrapper.vm.isOpen).toBe(true);
+        });
+    });
+
+    describe('placement props', () => {
+        it('placement가 left일 때 올바른 클래스가 적용되어야 한다', () => {
+            // given, when
+            const wrapper = mount(VsDrawer, {
+                ...defaultOptions,
+                props: {
+                    ...defaultOptions.props,
+                    placement: 'left',
+                    modelValue: true,
+                },
+            });
+
+            // then
+            expect(wrapper.find('.vs-drawer-left').exists()).toBe(true);
+        });
+
+        it('placement가 right일 때 올바른 클래스가 적용되어야 한다', () => {
+            // given, when
+            const wrapper = mount(VsDrawer, {
+                ...defaultOptions,
+                props: {
+                    ...defaultOptions.props,
+                    placement: 'right',
+                    modelValue: true,
+                },
+            });
+
+            // then
+            expect(wrapper.find('.vs-drawer-right').exists()).toBe(true);
+        });
+
+        it('placement가 top일 때 올바른 클래스가 적용되어야 한다', () => {
+            // given, when
+            const wrapper = mount(VsDrawer, {
+                ...defaultOptions,
+                props: {
+                    ...defaultOptions.props,
+                    placement: 'top',
+                    modelValue: true,
+                },
+            });
+
+            // then
+            expect(wrapper.find('.vs-drawer-top').exists()).toBe(true);
+        });
+
+        it('placement가 bottom일 때 올바른 클래스가 적용되어야 한다', () => {
+            // given, when
+            const wrapper = mount(VsDrawer, {
+                ...defaultOptions,
+                props: {
+                    ...defaultOptions.props,
+                    placement: 'bottom',
+                    modelValue: true,
+                },
+            });
+
+            // then
+            expect(wrapper.find('.vs-drawer-bottom').exists()).toBe(true);
+        });
+    });
+
+    describe('size props', () => {
+        it('size가 없을 때 기본 크기(sm)가 적용되어야 한다', () => {
+            // given, when
+            const wrapper = mount(VsDrawer, {
+                ...defaultOptions,
+                props: {
+                    ...defaultOptions.props,
+                    modelValue: true,
+                },
+            });
+
+            // then
+            const style = wrapper.find('.vs-drawer').attributes('style');
+            expect(style).toContain('--vs-drawer-size: 20%');
+        });
+
+        it('size가 lg일 때 60%가 적용되어야 한다', () => {
+            // given, when
+            const wrapper = mount(VsDrawer, {
+                ...defaultOptions,
+                props: {
+                    ...defaultOptions.props,
+                    modelValue: true,
+                    size: 'lg',
+                },
+            });
+
+            // then
+            const style = wrapper.find('.vs-drawer').attributes('style');
+            expect(style).toContain('--vs-drawer-size: 60%');
+        });
+
+        it('size가 문자열로 주어지면 해당 값이 적용되어야 한다', () => {
+            // given, when
+            const wrapper = mount(VsDrawer, {
+                ...defaultOptions,
+                props: {
+                    ...defaultOptions.props,
+                    modelValue: true,
+                    size: '300px',
+                },
+            });
+
+            // then
+            const style = wrapper.find('.vs-drawer').attributes('style');
+            expect(style).toContain('--vs-drawer-size: 300px');
+        });
+    });
+
+    describe('fixed props', () => {
+        it('fixed가 true일 때 position: fixed가 적용되어야 한다', () => {
+            // given, when
+            const wrapper = mount(VsDrawer, {
+                ...defaultOptions,
+                props: {
+                    ...defaultOptions.props,
+                    modelValue: true,
+                    fixed: true,
+                },
+            });
+
+            // then
+            const style = wrapper.find('.vs-drawer').attributes('style');
+            expect(style).toContain('--vs-drawer-position: fixed');
+        });
+    });
+
+    describe('dimmed 기능', () => {
+        it('dimmed가 true일 때 dimmed 요소가 렌더링되어야 한다', () => {
+            // given, when
+            const wrapper = mount(VsDrawer, {
+                ...defaultOptions,
+                props: {
+                    ...defaultOptions.props,
+                    modelValue: true,
+                    dimmed: true,
+                },
+            });
+
+            // then
+            expect(wrapper.find('.vs-drawer-dimmed').exists()).toBe(true);
+        });
+
+        it('dimmed 요소를 클릭하면 click-dimmed 이벤트가 발생해야 한다', async () => {
+            // given
+            const wrapper = mount(VsDrawer, {
+                ...defaultOptions,
+                props: {
+                    ...defaultOptions.props,
+                    modelValue: true,
+                    dimmed: true,
+                },
+            });
+
+            await wrapper.vm.$nextTick();
+
+            // when
+            const dimmedElement = wrapper.find('.vs-drawer-dimmed');
+            expect(dimmedElement.exists()).toBe(true); // dimmed 요소 존재 확인
+
+            // onClickDimmed 함수를 직접 호출
+            await wrapper.vm.onClickDimmed();
+
+            // then
+            expect(wrapper.emitted('click-dimmed')).toBeTruthy();
+        });
+
+        it('dimClose가 true일 때 dimmed 클릭 시 close 이벤트가 발생해야 한다', async () => {
+            // given
+            const wrapper = mount(VsDrawer, {
+                ...defaultOptions,
+                props: {
+                    ...defaultOptions.props,
+                    modelValue: true,
+                    dimmed: true,
+                    dimClose: true,
+                },
+            });
+
+            await wrapper.vm.$nextTick();
+
+            // when
+            const dimmedElement = wrapper.find('.vs-drawer-dimmed');
+            expect(dimmedElement.exists()).toBe(true); // dimmed 요소 존재 확인
+
+            // onClickDimmed 함수를 직접 호출
+            await wrapper.vm.onClickDimmed();
+            await wrapper.vm.$nextTick();
+
+            // then
+            expect(wrapper.emitted('close')).toBeTruthy();
+        });
+    });
+
+    describe('modelValue 이벤트', () => {
+        it('modelValue 변경 시 update:modelValue 이벤트가 발생해야 한다', async () => {
+            // given
+            const wrapper = mount(VsDrawer, {
+                ...defaultOptions,
+                props: {
+                    ...defaultOptions.props,
+                    modelValue: false,
+                },
+            });
+
+            // when
+            await wrapper.setProps({ modelValue: true });
+
+            // then
+            expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+        });
+
+        it('drawer가 열릴 때 open 이벤트가 발생해야 한다', async () => {
+            // given
+            const wrapper = mount(VsDrawer, {
+                ...defaultOptions,
+                props: {
+                    ...defaultOptions.props,
+                    modelValue: false,
+                },
+            });
+
+            // when
+            await wrapper.setProps({ modelValue: true });
+
+            // then
+            expect(wrapper.emitted('open')).toBeTruthy();
+        });
+
+        it('drawer가 닫힐 때 close 이벤트가 발생해야 한다', async () => {
+            // given
+            const wrapper = mount(VsDrawer, {
+                ...defaultOptions,
+                props: {
+                    ...defaultOptions.props,
+                    modelValue: true,
+                },
+            });
+
+            // when
+            await wrapper.setProps({ modelValue: false });
+
+            // then
+            expect(wrapper.emitted('close')).toBeTruthy();
+        });
+    });
+
+    describe('vs-layout 연동', () => {
+        // vs-layout 컴포넌트 모킹
+        const MockVsLayout = defineComponent({
+            name: VsComponent.VsLayout,
+            setup() {
+                provide(LAYOUT_STORE_KEY, layoutStore);
+                return {};
+            },
+            template: '<div><slot /></div>',
+        });
+
+        it('vs-layout의 자식일 때 layoutStore.setDrawer가 호출되어야 한다', () => {
+            // given
+            const setDrawerSpy = vi.spyOn(layoutStore, 'setDrawer');
+
+            // when
+            mount(MockVsLayout, {
+                slots: {
+                    default: () =>
+                        h(VsDrawer, {
+                            modelValue: true,
+                            placement: 'left',
+                            size: 'md',
+                        }),
+                },
+                global: {
+                    stubs: {
+                        'vs-focus-trap': {
+                            template: '<div class="vs-focus-trap-stub"><slot /></div>',
+                            methods: { focus: vi.fn(), blur: vi.fn() },
+                        },
+                        'vs-inner-scroll': {
+                            template:
+                                '<div class="vs-inner-scroll-stub"><slot name="header" /><slot /><slot name="footer" /></div>',
+                        },
+                        Transition: {
+                            template: '<div><slot /></div>',
+                        },
+                    },
+                },
+            });
+
+            // then
+            expect(setDrawerSpy).toHaveBeenCalledWith({
+                isOpen: true,
+                placement: 'left',
+                size: '40%',
+                responsive: false,
+            });
+        });
+
+        it('layoutResponsive가 true일 때 responsive 옵션이 전달되어야 한다', () => {
+            // given
+            const setDrawerSpy = vi.spyOn(layoutStore, 'setDrawer');
+
+            // when
+            mount(MockVsLayout, {
+                slots: {
+                    default: () =>
+                        h(VsDrawer, {
+                            modelValue: true,
+                            placement: 'right',
+                            size: 'lg',
+                            layoutResponsive: true,
+                        }),
+                },
+                global: {
+                    stubs: {
+                        'vs-focus-trap': {
+                            template: '<div class="vs-focus-trap-stub"><slot /></div>',
+                            methods: { focus: vi.fn(), blur: vi.fn() },
+                        },
+                        'vs-inner-scroll': {
+                            template:
+                                '<div class="vs-inner-scroll-stub"><slot name="header" /><slot /><slot name="footer" /></div>',
+                        },
+                        Transition: {
+                            template: '<div><slot /></div>',
+                        },
+                    },
+                },
+            });
+
+            // then
+            expect(setDrawerSpy).toHaveBeenCalledWith({
+                isOpen: true,
+                placement: 'right',
+                size: '60%',
+                responsive: true,
+            });
+        });
+    });
+});

--- a/packages/vlossom/src/components/vs-drawer/types.ts
+++ b/packages/vlossom/src/components/vs-drawer/types.ts
@@ -1,0 +1,19 @@
+import type VsDrawer from './VsDrawer.vue';
+import type { BoxStyleSet, CssPosition } from '@/declaration';
+
+declare module 'vue' {
+    interface GlobalComponents {
+        VsDrawer: typeof VsDrawer;
+    }
+}
+
+export type { VsDrawer };
+
+export interface VsDrawerStyleSet extends Omit<BoxStyleSet, 'display'> {
+    position?: CssPosition;
+    size?: string;
+    dimmed?: {
+        backgroundColor?: string;
+        opacity?: number;
+    };
+}

--- a/packages/vlossom/src/components/vs-drawer/types.ts
+++ b/packages/vlossom/src/components/vs-drawer/types.ts
@@ -12,6 +12,7 @@ export type { VsDrawer };
 export interface VsDrawerStyleSet extends Omit<BoxStyleSet, 'display'> {
     position?: 'absolute' | 'fixed';
     size?: string;
+    boxShadow?: string;
     dimmed?: {
         backgroundColor?: string;
         opacity?: number;

--- a/packages/vlossom/src/components/vs-drawer/types.ts
+++ b/packages/vlossom/src/components/vs-drawer/types.ts
@@ -1,5 +1,5 @@
 import type VsDrawer from './VsDrawer.vue';
-import type { BoxStyleSet, CssPosition } from '@/declaration';
+import type { BoxStyleSet } from '@/declaration';
 
 declare module 'vue' {
     interface GlobalComponents {
@@ -10,7 +10,7 @@ declare module 'vue' {
 export type { VsDrawer };
 
 export interface VsDrawerStyleSet extends Omit<BoxStyleSet, 'display'> {
-    position?: CssPosition;
+    position?: 'absolute' | 'fixed';
     size?: string;
     dimmed?: {
         backgroundColor?: string;

--- a/packages/vlossom/src/components/vs-layout/README.md
+++ b/packages/vlossom/src/components/vs-layout/README.md
@@ -49,4 +49,4 @@
 
 - **유기적인 layout 제공**: `vs-header`, `vs-container`, `vs-drawer`, `vs-footer`와 함께 사용하면 쉽게 layout 구성 가능
 - **레이아웃 스토어 제공**: `LAYOUT_STORE_KEY`를 통해 하위 컴포넌트에 레이아웃 상태를 provide를 이용해 제공
-- **동적 패딩 조정**: 각 드로어의 `responsive` 속성이 활성화되면 열린 드로어에 따라 자동으로 패딩 조정 가능
+- **동적 패딩 조정**: 각 드로어의 `responsive` 속성이 활성화되면 열린 드로어에 따라 자동으로 vs-container의 패딩 조정 가능

--- a/packages/vlossom/src/components/vs-layout/VsLayout.css
+++ b/packages/vlossom/src/components/vs-layout/VsLayout.css
@@ -1,4 +1,3 @@
 .vs-layout {
     @apply relative h-full w-full;
-    transition: padding 0.3s;
 }

--- a/packages/vlossom/src/components/vs-layout/VsLayout.vue
+++ b/packages/vlossom/src/components/vs-layout/VsLayout.vue
@@ -1,34 +1,23 @@
 <template>
-    <div class="vs-layout" :style="layoutStyle">
+    <div class="vs-layout">
         <slot />
     </div>
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, provide } from 'vue';
+import { defineComponent, provide } from 'vue';
 import { LayoutStore } from '@/stores';
 import { LAYOUT_STORE_KEY, VsComponent } from '@/declaration';
-import { objectUtil } from '@/utils';
 
 const name = VsComponent.VsLayout;
 export default defineComponent({
     name,
     setup() {
         const layoutStore = LayoutStore.getDefaultLayoutStore();
+
         provide(LAYOUT_STORE_KEY, layoutStore);
 
-        const layoutStyle = computed(() => {
-            const { left, top, bottom, right } = layoutStore.drawers.value;
-
-            return objectUtil.shake({
-                paddingLeft: left.isOpen && left.responsive && left.size ? left.size : undefined,
-                paddingTop: top.isOpen && top.responsive && top.size ? top.size : undefined,
-                paddingBottom: bottom.isOpen && bottom.responsive && bottom.size ? bottom.size : undefined,
-                paddingRight: right.isOpen && right.responsive && right.size ? right.size : undefined,
-            });
-        });
-
-        return { layoutStyle };
+        return {};
     },
 });
 </script>

--- a/packages/vlossom/src/components/vs-layout/__tests__/vs-layout.test.ts
+++ b/packages/vlossom/src/components/vs-layout/__tests__/vs-layout.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
+import { defineComponent, inject } from 'vue';
 import VsLayout from './../VsLayout.vue';
 import { LayoutStore } from '@/stores';
+import { LAYOUT_STORE_KEY } from '@/declaration';
 
 describe('VsLayout', () => {
     let layoutStore: LayoutStore;
@@ -14,130 +16,29 @@ describe('VsLayout', () => {
 
     describe('LayoutStore 제공', () => {
         it('LAYOUT_STORE_KEY로 LayoutStore 인스턴스를 제공해야 한다', () => {
-            // given, when
-            const wrapper = mount(VsLayout);
-
-            // then
-            expect(wrapper.vm).toBeDefined();
-        });
-    });
-
-    describe('drawer responsive 속성', () => {
-        it('모든 drawer가 responsive가 false일 때 기본 스타일이 적용되어야 한다', () => {
-            // given, when
-            const wrapper = mount(VsLayout);
-
-            // then
-            const layout = wrapper.find('.vs-layout');
-            expect(layout.attributes('style')).toBeUndefined();
-            expect(wrapper.vm.layoutStyle).toEqual({});
-        });
-
-        it('responsive가 true인 drawer가 열려있을 때 해당하는 padding이 적용되어야 한다', () => {
             // given
-            layoutStore.setDrawers({
-                left: { isOpen: true, placement: 'left', size: '250px', responsive: true },
-                top: { isOpen: false, placement: 'top', size: '60px', responsive: false },
-                right: { isOpen: true, placement: 'right', size: '250px', responsive: true },
-                bottom: { isOpen: false, placement: 'bottom', size: '60px', responsive: false },
+            const ChildComponent = defineComponent({
+                name: 'TestChild',
+                setup() {
+                    const injectedLayoutStore = inject(LAYOUT_STORE_KEY);
+                    return { injectedLayoutStore };
+                },
+                template: '<div>test</div>',
             });
 
             // when
-            const wrapper = mount(VsLayout);
+            const wrapper = mount(VsLayout, {
+                slots: {
+                    default: ChildComponent,
+                },
+            });
+
+            const childWrapper = wrapper.findComponent(ChildComponent);
 
             // then
-            expect(wrapper.vm.layoutStyle).toEqual({
-                paddingLeft: '250px',
-                paddingRight: '250px',
-            });
-        });
-
-        it('모든 drawer가 responsive가 true이고 열려있을 때 모든 padding이 적용되어야 한다', () => {
-            // given
-            layoutStore.setDrawers({
-                left: { isOpen: true, placement: 'left', size: '250px', responsive: true },
-                top: { isOpen: true, placement: 'top', size: '60px', responsive: true },
-                right: { isOpen: true, placement: 'right', size: '250px', responsive: true },
-                bottom: { isOpen: true, placement: 'bottom', size: '60px', responsive: true },
-            });
-
-            // when
-            const wrapper = mount(VsLayout);
-
-            // then
-            expect(wrapper.vm.layoutStyle).toEqual({
-                paddingLeft: '250px',
-                paddingRight: '250px',
-                paddingTop: '60px',
-                paddingBottom: '60px',
-            });
-        });
-
-        it('모든 drawer가 닫혀있거나 responsive가 false일 때 padding이 적용되지 않아야 한다', () => {
-            // given
-            layoutStore.setDrawers({
-                left: { isOpen: false, placement: 'left', size: '250px', responsive: false },
-                top: { isOpen: false, placement: 'top', size: '60px', responsive: false },
-                right: { isOpen: false, placement: 'right', size: '250px', responsive: false },
-                bottom: { isOpen: false, placement: 'bottom', size: '60px', responsive: false },
-            });
-
-            // when
-            const wrapper = mount(VsLayout);
-
-            // then
-            expect(wrapper.vm.layoutStyle).toEqual({});
-        });
-
-        it('일부 drawer만 responsive가 true이고 열려있을 때 해당하는 padding만 적용되어야 한다', () => {
-            // given
-            layoutStore.setDrawers({
-                left: { isOpen: true, placement: 'left', size: '300px', responsive: true },
-                top: { isOpen: false, placement: 'top', size: '80px', responsive: false },
-                right: { isOpen: false, placement: 'right', size: '300px', responsive: false },
-                bottom: { isOpen: true, placement: 'bottom', size: '80px', responsive: true },
-            });
-
-            // when
-            const wrapper = mount(VsLayout);
-
-            // then
-            expect(wrapper.vm.layoutStyle).toEqual({
-                paddingLeft: '300px',
-                paddingBottom: '80px',
-            });
-        });
-
-        it('drawer size가 빈 문자열일 때 padding이 적용되지 않아야 한다', () => {
-            // given
-            layoutStore.setDrawers({
-                left: { isOpen: true, placement: 'left', size: '', responsive: true },
-                top: { isOpen: true, placement: 'top', size: '', responsive: true },
-                right: { isOpen: true, placement: 'right', size: '', responsive: true },
-                bottom: { isOpen: true, placement: 'bottom', size: '', responsive: true },
-            });
-
-            // when
-            const wrapper = mount(VsLayout);
-
-            // then
-            expect(wrapper.vm.layoutStyle).toEqual({});
-        });
-
-        it('drawer가 열려있어도 responsive가 false이면 padding이 적용되지 않아야 한다', () => {
-            // given
-            layoutStore.setDrawers({
-                left: { isOpen: true, placement: 'left', size: '250px', responsive: false },
-                top: { isOpen: true, placement: 'top', size: '60px', responsive: false },
-                right: { isOpen: true, placement: 'right', size: '250px', responsive: false },
-                bottom: { isOpen: true, placement: 'bottom', size: '60px', responsive: false },
-            });
-
-            // when
-            const wrapper = mount(VsLayout);
-
-            // then
-            expect(wrapper.vm.layoutStyle).toEqual({});
+            expect(childWrapper.vm.injectedLayoutStore).toBeDefined();
+            expect(childWrapper.vm.injectedLayoutStore).toBe(layoutStore);
+            expect(childWrapper.vm.injectedLayoutStore).toBeInstanceOf(LayoutStore);
         });
     });
 });

--- a/packages/vlossom/src/composables/__tests__/color-scheme-composable.test.ts
+++ b/packages/vlossom/src/composables/__tests__/color-scheme-composable.test.ts
@@ -1,17 +1,28 @@
 import { ref, type Ref } from 'vue';
-import { describe, it, expect } from 'vitest';
-import { useColorScheme } from '../color-scheme-composable';
-import { VsComponent } from '@/declaration';
-import type { ColorScheme } from '@/declaration';
-import { useOptionsStore } from '@/stores';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import * as stores from '@/stores';
+import { VsComponent, type ColorScheme } from '@/declaration';
+import { OptionsStore } from '@/stores';
+import { useColorScheme } from './../color-scheme-composable';
 
 describe('useColorScheme', () => {
+    let optionsStore: OptionsStore;
+
+    beforeEach(() => {
+        optionsStore = new OptionsStore();
+        vi.spyOn(stores, 'useOptionsStore').mockReturnValue(optionsStore);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
     describe('computedColorScheme', () => {
         it('colorScheme.value가 있을 때 우선적으로 사용해야 함', () => {
             // given
             const colorScheme: Ref<ColorScheme> = ref('red');
             const component = VsComponent.VsButton;
-            useOptionsStore().setColorScheme({
+            optionsStore.setColorScheme({
                 [component]: 'blue',
             });
 
@@ -26,7 +37,7 @@ describe('useColorScheme', () => {
             // given
             const colorScheme: Ref<ColorScheme | undefined> = ref(undefined);
             const component = VsComponent.VsButton;
-            useOptionsStore().setColorScheme({
+            optionsStore.setColorScheme({
                 [component]: 'blue',
             });
 
@@ -41,7 +52,7 @@ describe('useColorScheme', () => {
             // given
             const colorScheme: Ref<ColorScheme | undefined> = ref(undefined);
             const component = 'CustomComponent';
-            useOptionsStore().setColorScheme({
+            optionsStore.setColorScheme({
                 [component]: 'green',
             });
 
@@ -94,14 +105,14 @@ describe('useColorScheme', () => {
             expect(computedColorScheme.value).toBe(undefined);
 
             // when
-            useOptionsStore().setColorScheme({
+            optionsStore.setColorScheme({
                 [component]: 'cyan',
             });
             // then
             expect(computedColorScheme.value).toBe('cyan');
 
             // when
-            useOptionsStore().setColorScheme({});
+            optionsStore.setColorScheme({});
             // then
             expect(computedColorScheme.value).toBe(undefined);
         });
@@ -136,7 +147,7 @@ describe('useColorScheme', () => {
             // given
             const colorScheme: Ref<ColorScheme | undefined> = ref(undefined);
             const component = VsComponent.VsSection;
-            useOptionsStore().setColorScheme({
+            optionsStore.setColorScheme({
                 [component]: 'emerald',
             });
 
@@ -178,7 +189,7 @@ describe('useColorScheme', () => {
             // given
             const colorScheme: Ref<ColorScheme | undefined> = ref(undefined);
             const component = VsComponent.VsButton;
-            useOptionsStore().setColorScheme({
+            optionsStore.setColorScheme({
                 [component]: 'blue',
             });
 

--- a/packages/vlossom/src/composables/__tests__/overlay-composable.test.ts
+++ b/packages/vlossom/src/composables/__tests__/overlay-composable.test.ts
@@ -1,23 +1,20 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ref, nextTick } from 'vue';
-import { OverlayCallbackStore } from '@/stores/overlay-callback-store';
-import { VS_ANIMATION_DURATION } from '@/declaration';
-import type { OverlayCallbacks } from '@/declaration';
+import * as stores from '@/stores';
+import { OverlayCallbackStore } from '@/stores';
+import { VS_ANIMATION_DURATION, type OverlayCallbacks } from '@/declaration';
 import { useOverlay } from './../overlay-composable';
 
-// useOverlayCallbackStore를 새로운 인스턴스를 반환하도록 mock
-vi.mock('@/stores', () => ({
-    useOverlayCallbackStore: vi.fn(),
-}));
-
-const { useOverlayCallbackStore } = await import('@/stores');
-
 describe('useOverlay', () => {
-    let mockStore: OverlayCallbackStore;
+    let overlayCallbackStore: OverlayCallbackStore;
 
     beforeEach(() => {
-        mockStore = new OverlayCallbackStore();
-        vi.mocked(useOverlayCallbackStore).mockReturnValue(mockStore);
+        overlayCallbackStore = new OverlayCallbackStore();
+        vi.spyOn(stores, 'useOverlayCallbackStore').mockReturnValue(overlayCallbackStore);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
     });
 
     describe('초기 상태', () => {
@@ -71,7 +68,7 @@ describe('useOverlay', () => {
             const callbacks = ref<OverlayCallbacks>({});
             const escClose = ref(true);
             const { open } = useOverlay(id, callbacks, escClose);
-            const pushSpy = vi.spyOn(mockStore, 'push');
+            const pushSpy = vi.spyOn(overlayCallbackStore, 'push');
 
             // when
             open();
@@ -128,7 +125,7 @@ describe('useOverlay', () => {
             const callbacks = ref<OverlayCallbacks>({});
             const escClose = ref(true);
             const { open, close } = useOverlay(id, callbacks, escClose);
-            const removeSpy = vi.spyOn(mockStore, 'remove');
+            const removeSpy = vi.spyOn(overlayCallbackStore, 'remove');
 
             open();
             await nextTick();
@@ -149,7 +146,7 @@ describe('useOverlay', () => {
             const callbacks = ref<OverlayCallbacks>({});
             const escClose = ref(true);
             const { isOpen } = useOverlay(id, callbacks, escClose);
-            const pushSpy = vi.spyOn(mockStore, 'push');
+            const pushSpy = vi.spyOn(overlayCallbackStore, 'push');
 
             // when
             isOpen.value = true;
@@ -165,7 +162,7 @@ describe('useOverlay', () => {
             const callbacks = ref<OverlayCallbacks>({});
             const escClose = ref(true);
             const { isOpen } = useOverlay(id, callbacks, escClose);
-            const removeSpy = vi.spyOn(mockStore, 'remove');
+            const removeSpy = vi.spyOn(overlayCallbackStore, 'remove');
 
             // 먼저 열어두고
             isOpen.value = true;
@@ -192,8 +189,8 @@ describe('useOverlay', () => {
             const escClose = ref(true);
 
             const { isOpen, closing, open, overlayId } = useOverlay(id, callbacks, escClose);
-            const pushSpy = vi.spyOn(mockStore, 'push');
-            const removeSpy = vi.spyOn(mockStore, 'remove');
+            const pushSpy = vi.spyOn(overlayCallbackStore, 'push');
+            const removeSpy = vi.spyOn(overlayCallbackStore, 'remove');
 
             // 초기 상태 확인
             expect(isOpen.value).toBe(false);

--- a/packages/vlossom/src/composables/__tests__/overlay-composable.test.ts
+++ b/packages/vlossom/src/composables/__tests__/overlay-composable.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref, nextTick } from 'vue';
+import { OverlayCallbackStore } from '@/stores/overlay-callback-store';
+import { VS_ANIMATION_DURATION } from '@/declaration';
+import type { OverlayCallbacks } from '@/declaration';
+import { useOverlay } from './../overlay-composable';
+
+// useOverlayCallbackStore를 새로운 인스턴스를 반환하도록 mock
+vi.mock('@/stores', () => ({
+    useOverlayCallbackStore: vi.fn(),
+}));
+
+const { useOverlayCallbackStore } = await import('@/stores');
+
+describe('useOverlay', () => {
+    let mockStore: OverlayCallbackStore;
+
+    beforeEach(() => {
+        mockStore = new OverlayCallbackStore();
+        vi.mocked(useOverlayCallbackStore).mockReturnValue(mockStore);
+    });
+
+    describe('초기 상태', () => {
+        it('isOpen, closing이 false로 초기화되어야 한다', () => {
+            // given
+            const id = ref('test-id');
+            const callbacks = ref<OverlayCallbacks>({});
+            const escClose = ref(true);
+
+            // when
+            const { isOpen, closing } = useOverlay(id, callbacks, escClose);
+
+            // then
+            expect(isOpen.value).toBe(false);
+            expect(closing.value).toBe(false);
+        });
+
+        it('id가 주어지면 overlayId가 해당 값이어야 한다', () => {
+            // given
+            const testId = 'custom-overlay-id';
+            const id = ref(testId);
+            const callbacks = ref<OverlayCallbacks>({});
+            const escClose = ref(true);
+
+            // when
+            const { overlayId } = useOverlay(id, callbacks, escClose);
+
+            // then
+            expect(overlayId.value).toBe(testId);
+        });
+    });
+
+    describe('open 함수', () => {
+        it('open을 호출하면 isOpen이 true가 되어야 한다', () => {
+            // given
+            const id = ref('test-id');
+            const callbacks = ref<OverlayCallbacks>({});
+            const escClose = ref(true);
+            const { isOpen, open } = useOverlay(id, callbacks, escClose);
+
+            // when
+            open();
+
+            // then
+            expect(isOpen.value).toBe(true);
+        });
+
+        it('open을 호출하면 store에 콜백이 push되어야 한다', async () => {
+            // given
+            const id = ref('test-id');
+            const callbacks = ref<OverlayCallbacks>({});
+            const escClose = ref(true);
+            const { open } = useOverlay(id, callbacks, escClose);
+            const pushSpy = vi.spyOn(mockStore, 'push');
+
+            // when
+            open();
+            await nextTick();
+
+            // then
+            expect(pushSpy).toHaveBeenCalledWith(id.value, expect.any(Object));
+        });
+    });
+
+    describe('close 함수', () => {
+        it('close를 호출하면 isOpen이 false가 되어야 한다', () => {
+            // given
+            const id = ref('test-id');
+            const callbacks = ref<OverlayCallbacks>({});
+            const escClose = ref(true);
+            const { isOpen, open, close } = useOverlay(id, callbacks, escClose);
+            open();
+
+            // when
+            close();
+
+            // then
+            expect(isOpen.value).toBe(false);
+        });
+
+        it('close를 호출하면 closing이 true가 되었다가 애니메이션 duration 후 false가 되어야 한다', async () => {
+            // given
+            vi.useFakeTimers();
+            const id = ref('test-id');
+            const callbacks = ref<OverlayCallbacks>({});
+            const escClose = ref(true);
+            const { closing, open, close } = useOverlay(id, callbacks, escClose);
+            open();
+            await nextTick();
+
+            // when
+            close();
+            await nextTick();
+
+            // then
+            expect(closing.value).toBe(true);
+
+            // 애니메이션 시간이 지나면
+            vi.advanceTimersByTime(VS_ANIMATION_DURATION);
+            expect(closing.value).toBe(false);
+
+            vi.useRealTimers();
+        });
+
+        it('close를 호출하면 store에서 콜백이 remove되어야 한다', async () => {
+            // given
+            const id = ref('test-id');
+            const callbacks = ref<OverlayCallbacks>({});
+            const escClose = ref(true);
+            const { open, close } = useOverlay(id, callbacks, escClose);
+            const removeSpy = vi.spyOn(mockStore, 'remove');
+
+            open();
+            await nextTick();
+
+            // when
+            close();
+            await nextTick();
+
+            // then
+            expect(removeSpy).toHaveBeenCalledWith(id.value);
+        });
+    });
+
+    describe('watch isOpen', () => {
+        it('isOpen이 true로 변경되면 store에 push되어야 한다', async () => {
+            // given
+            const id = ref('test-id');
+            const callbacks = ref<OverlayCallbacks>({});
+            const escClose = ref(true);
+            const { isOpen } = useOverlay(id, callbacks, escClose);
+            const pushSpy = vi.spyOn(mockStore, 'push');
+
+            // when
+            isOpen.value = true;
+            await nextTick();
+
+            // then
+            expect(pushSpy).toHaveBeenCalledWith(id.value, expect.any(Object));
+        });
+
+        it('isOpen이 false로 변경되면 store에서 remove되어야 한다', async () => {
+            // given
+            const id = ref('test-id');
+            const callbacks = ref<OverlayCallbacks>({});
+            const escClose = ref(true);
+            const { isOpen } = useOverlay(id, callbacks, escClose);
+            const removeSpy = vi.spyOn(mockStore, 'remove');
+
+            // 먼저 열어두고
+            isOpen.value = true;
+            await nextTick();
+
+            // when
+            isOpen.value = false;
+            await nextTick();
+
+            // then
+            expect(removeSpy).toHaveBeenCalledWith(id.value);
+        });
+    });
+
+    describe('통합 테스트', () => {
+        it('전체적인 라이프사이클이 올바르게 동작해야 한다', async () => {
+            // given
+            vi.useFakeTimers();
+            const id = ref('lifecycle-test');
+            const escapeCallback = vi.fn();
+            const callbacks = ref<OverlayCallbacks>({
+                'key-Escape': escapeCallback,
+            });
+            const escClose = ref(true);
+
+            const { isOpen, closing, open, overlayId } = useOverlay(id, callbacks, escClose);
+            const pushSpy = vi.spyOn(mockStore, 'push');
+            const removeSpy = vi.spyOn(mockStore, 'remove');
+
+            // 초기 상태 확인
+            expect(isOpen.value).toBe(false);
+            expect(closing.value).toBe(false);
+            expect(overlayId.value).toBe('lifecycle-test');
+
+            // when - open
+            open();
+            await nextTick();
+
+            // then - 열린 상태
+            expect(isOpen.value).toBe(true);
+            expect(closing.value).toBe(false);
+            expect(pushSpy).toHaveBeenCalledWith('lifecycle-test', expect.any(Object));
+
+            // when - escape key 처리
+            const pushedCallbacks = pushSpy.mock.calls[0][1];
+            pushedCallbacks.value['key-Escape']();
+            await nextTick();
+
+            // then - 닫힌 상태
+            expect(isOpen.value).toBe(false);
+            expect(closing.value).toBe(true);
+            expect(escapeCallback).toHaveBeenCalledTimes(1);
+            expect(removeSpy).toHaveBeenCalledWith('lifecycle-test');
+
+            // when - 애니메이션 완료
+            vi.advanceTimersByTime(VS_ANIMATION_DURATION);
+
+            // then - closing false
+            expect(closing.value).toBe(false);
+
+            vi.useRealTimers();
+        });
+    });
+});

--- a/packages/vlossom/src/composables/__tests__/overlay-composable.test.ts
+++ b/packages/vlossom/src/composables/__tests__/overlay-composable.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ref, nextTick } from 'vue';
 import * as stores from '@/stores';
 import { OverlayCallbackStore } from '@/stores';
-import { VS_ANIMATION_DURATION, type OverlayCallbacks } from '@/declaration';
+import { ANIMATION_DURATION, type OverlayCallbacks } from '@/declaration';
 import { useOverlay } from './../overlay-composable';
 
 describe('useOverlay', () => {
@@ -113,7 +113,7 @@ describe('useOverlay', () => {
             expect(closing.value).toBe(true);
 
             // 애니메이션 시간이 지나면
-            vi.advanceTimersByTime(VS_ANIMATION_DURATION);
+            vi.advanceTimersByTime(ANIMATION_DURATION);
             expect(closing.value).toBe(false);
 
             vi.useRealTimers();
@@ -218,7 +218,7 @@ describe('useOverlay', () => {
             expect(removeSpy).toHaveBeenCalledWith('lifecycle-test');
 
             // when - 애니메이션 완료
-            vi.advanceTimersByTime(VS_ANIMATION_DURATION);
+            vi.advanceTimersByTime(ANIMATION_DURATION);
 
             // then - closing false
             expect(closing.value).toBe(false);

--- a/packages/vlossom/src/composables/__tests__/style-set-composable.test.ts
+++ b/packages/vlossom/src/composables/__tests__/style-set-composable.test.ts
@@ -1,10 +1,22 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ref } from 'vue';
-import { useStyleSet } from '../style-set-composable';
-import { useOptionsStore } from '@/stores';
+import * as stores from '@/stores';
+import { OptionsStore } from '@/stores';
 import { VsComponent } from '@/declaration';
+import { useStyleSet } from './../style-set-composable';
 
 describe('useStyleSet', () => {
+    let optionsStore: OptionsStore;
+
+    beforeEach(() => {
+        optionsStore = new OptionsStore();
+        vi.spyOn(stores, 'useOptionsStore').mockReturnValue(optionsStore);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
     describe('componentStyleSet', () => {
         it('styleSet이 undefined이면 빈 객체를 반환해야 한다', () => {
             // given
@@ -24,8 +36,7 @@ describe('useStyleSet', () => {
             const styles = { color: 'red', fontSize: '14px' };
             const styleSet = ref('primary');
 
-            const optionStore = useOptionsStore();
-            optionStore.setStyleSet({ [styleSet.value]: { [component]: styles } });
+            optionsStore.setStyleSet({ [styleSet.value]: { [component]: styles } });
 
             // when
             const { componentStyleSet } = useStyleSet(component, styleSet);
@@ -54,8 +65,7 @@ describe('useStyleSet', () => {
             const styleSet = ref('primary');
             const additionalStyleSet = ref({ backgroundColor: 'blue', fontSize: '16px' });
 
-            const optionStore = useOptionsStore();
-            optionStore.setStyleSet({ [styleSet.value]: { [component]: styles } });
+            optionsStore.setStyleSet({ [styleSet.value]: { [component]: styles } });
 
             // when
             const { componentStyleSet } = useStyleSet(component, styleSet, additionalStyleSet);

--- a/packages/vlossom/src/composables/index.ts
+++ b/packages/vlossom/src/composables/index.ts
@@ -1,2 +1,3 @@
 export * from './color-scheme-composable';
+export * from './overlay-composable';
 export * from './style-set-composable';

--- a/packages/vlossom/src/composables/overlay-composable.ts
+++ b/packages/vlossom/src/composables/overlay-composable.ts
@@ -1,0 +1,48 @@
+import { computed, type Ref, ref, watch } from 'vue';
+import { useOverlayCallbackStore } from '@/stores';
+import { stringUtil } from '@/utils';
+import { VS_ANIMATION_DURATION, type OverlayCallbacks } from '@/declaration';
+
+export function useOverlay(id: Ref<string>, callbacks: Ref<OverlayCallbacks> = ref({}), escClose: Ref<boolean>) {
+    const innerId = stringUtil.createID();
+    const overlayId = computed(() => id.value || innerId);
+    const overlayCallbackStore = useOverlayCallbackStore();
+
+    const isOpen = ref(false);
+    const closing = ref(false);
+
+    function open() {
+        isOpen.value = true;
+    }
+
+    function close() {
+        isOpen.value = false;
+    }
+
+    const computedCallbacks = computed(() => {
+        return {
+            ...callbacks.value,
+            'key-Escape': () => {
+                callbacks.value['key-Escape']?.();
+                if (escClose.value) {
+                    close();
+                }
+            },
+        };
+    });
+
+    watch(isOpen, (o) => {
+        if (o) {
+            overlayCallbackStore.push(overlayId.value, computedCallbacks);
+        } else {
+            closing.value = true;
+            overlayCallbackStore.remove(overlayId.value);
+
+            setTimeout(() => {
+                closing.value = false;
+            }, VS_ANIMATION_DURATION);
+        }
+    });
+
+    return { overlayId, isOpen, closing, open, close };
+}

--- a/packages/vlossom/src/composables/overlay-composable.ts
+++ b/packages/vlossom/src/composables/overlay-composable.ts
@@ -1,7 +1,7 @@
 import { computed, type Ref, ref, watch } from 'vue';
 import { useOverlayCallbackStore } from '@/stores';
 import { stringUtil } from '@/utils';
-import { VS_ANIMATION_DURATION, type OverlayCallbacks } from '@/declaration';
+import { ANIMATION_DURATION, type OverlayCallbacks } from '@/declaration';
 
 export function useOverlay(id: Ref<string>, callbacks: Ref<OverlayCallbacks> = ref({}), escClose: Ref<boolean>) {
     const innerId = stringUtil.createID();
@@ -40,7 +40,7 @@ export function useOverlay(id: Ref<string>, callbacks: Ref<OverlayCallbacks> = r
 
             setTimeout(() => {
                 closing.value = false;
-            }, VS_ANIMATION_DURATION);
+            }, ANIMATION_DURATION);
         }
     });
 

--- a/packages/vlossom/src/declaration/constants.ts
+++ b/packages/vlossom/src/declaration/constants.ts
@@ -2,10 +2,10 @@ export const THEME_KEY = 'vlossom:theme';
 export const LAYOUT_STORE_KEY = 'vlossom:layout-store';
 export const FORM_STORE_KEY = 'vlossom:form-store';
 
-export const VS_OVERLAY_CLOSE = 'vlossom:overlay-close';
-export const VS_OVERLAY_OPEN = 'vlossom:overlay-open';
+export const OVERLAY_OPEN = 'vlossom:overlay-open';
+export const OVERLAY_CLOSE = 'vlossom:overlay-close';
 
-export const VS_ANIMATION_DURATION = 300;
+export const ANIMATION_DURATION = 300;
 
 export const COLORS = [
     'red',
@@ -31,3 +31,5 @@ export const COLORS = [
     'neutral',
     'stone',
 ] as const;
+
+export const SIZES = ['xs', 'sm', 'md', 'lg', 'xl'] as const;

--- a/packages/vlossom/src/declaration/constants.ts
+++ b/packages/vlossom/src/declaration/constants.ts
@@ -2,6 +2,11 @@ export const THEME_KEY = 'vlossom:theme';
 export const LAYOUT_STORE_KEY = 'vlossom:layout-store';
 export const FORM_STORE_KEY = 'vlossom:form-store';
 
+export const VS_OVERLAY_CLOSE = 'vlossom:overlay-close';
+export const VS_OVERLAY_OPEN = 'vlossom:overlay-open';
+
+export const VS_ANIMATION_DURATION = 300;
+
 export const COLORS = [
     'red',
     'orange',

--- a/packages/vlossom/src/declaration/enums.ts
+++ b/packages/vlossom/src/declaration/enums.ts
@@ -5,6 +5,7 @@ export enum VsComponent {
     VsButton = 'VsButton',
     VsContainer = 'VsContainer',
     VsDivider = 'VsDivider',
+    VsDrawer = 'VsDrawer',
     VsExpandable = 'VsExpandable',
     VsFocusTrap = 'VsFocusTrap',
     VsFooter = 'VsFooter',

--- a/packages/vlossom/src/declaration/types.ts
+++ b/packages/vlossom/src/declaration/types.ts
@@ -31,6 +31,8 @@ export interface BarLayout {
 
 export type DrawerPlacement = 'top' | 'bottom' | 'left' | 'right';
 
+export type OverlayCallbacks<T = void> = { [eventName: string]: (...args: any[]) => T | Promise<T> };
+
 export interface DrawerLayout {
     isOpen: boolean;
     responsive: boolean;

--- a/packages/vlossom/src/declaration/types.ts
+++ b/packages/vlossom/src/declaration/types.ts
@@ -1,5 +1,5 @@
 import type { Component, Ref } from 'vue';
-import type { COLORS } from './constants';
+import type { COLORS, SIZES } from './constants';
 import type { VsComponent } from './enums';
 
 export type ColorScheme = (typeof COLORS)[number];
@@ -44,6 +44,10 @@ export interface DrawerLayout {
 
 export type DrawerLayouts = { [key in DrawerPlacement]: DrawerLayout };
 
+export type Size = (typeof SIZES)[number];
+
+export type SizeProp = Size | string | number;
+
 export interface Breakpoints {
     xs?: string | number;
     sm?: string | number;
@@ -81,4 +85,9 @@ export interface FlexStyleSet {
     alignItems?: string;
     justifyContent?: string;
     gap?: string;
+}
+
+export interface Focusable {
+    focus(): void;
+    blur(): void;
 }

--- a/packages/vlossom/src/declaration/types.ts
+++ b/packages/vlossom/src/declaration/types.ts
@@ -1,4 +1,4 @@
-import type { Component } from 'vue';
+import type { Component, Ref } from 'vue';
 import type { COLORS } from './constants';
 import type { VsComponent } from './enums';
 
@@ -30,6 +30,8 @@ export interface BarLayout {
 }
 
 export type DrawerPlacement = 'top' | 'bottom' | 'left' | 'right';
+
+export type OverlayTuple = [string, Ref<OverlayCallbacks>];
 
 export type OverlayCallbacks<T = void> = { [eventName: string]: (...args: any[]) => T | Promise<T> };
 

--- a/packages/vlossom/src/props/index.ts
+++ b/packages/vlossom/src/props/index.ts
@@ -1,4 +1,5 @@
 export * from './button-props';
+export * from './overlay-props';
 export * from './position-props';
 export * from './responsive-props';
 export * from './style-props';

--- a/packages/vlossom/src/props/overlay-props.ts
+++ b/packages/vlossom/src/props/overlay-props.ts
@@ -1,0 +1,18 @@
+import type { PropType } from 'vue';
+import type { OverlayCallbacks } from '@/declaration';
+
+export function getOverlayProps() {
+    return {
+        callbacks: {
+            type: Object as PropType<OverlayCallbacks>,
+            default: () => ({}),
+        },
+        dimClose: { type: Boolean, default: false },
+        dimmed: { type: Boolean, default: false },
+        escClose: { type: Boolean, default: false },
+        focusLock: { type: Boolean, default: false },
+        hideScroll: { type: Boolean, default: false },
+        id: { type: String, default: '' },
+        scrollLock: { type: Boolean, default: false },
+    };
+}

--- a/packages/vlossom/src/props/position-props.ts
+++ b/packages/vlossom/src/props/position-props.ts
@@ -1,9 +1,10 @@
 import type { PropType } from 'vue';
+import type { CssPosition } from '@/declaration';
 
 export function getPositionProps() {
     return {
         position: {
-            type: String as PropType<'relative' | 'absolute' | 'fixed' | 'sticky' | 'static'>,
+            type: String as PropType<CssPosition>,
         },
     };
 }

--- a/packages/vlossom/src/stores/__tests__/overlay-callback-store.test.ts
+++ b/packages/vlossom/src/stores/__tests__/overlay-callback-store.test.ts
@@ -326,27 +326,5 @@ describe('OverlayCallbackStore', () => {
             expect(store.overlays.value).toHaveLength(0);
             expect(store.getLastOverlayId()).toBe('');
         });
-
-        it('같은 ID로 중복 추가 후 제거가 올바르게 동작해야 한다', async () => {
-            // given
-            const overlayId = 'duplicate-overlay';
-            const callbacks1: Ref<OverlayCallbacks> = ref({ close: vi.fn() });
-            const callbacks2: Ref<OverlayCallbacks> = ref({ close: vi.fn() });
-
-            // when
-            await store.push(overlayId, callbacks1);
-            await store.push(overlayId, callbacks2);
-
-            // then
-            expect(store.overlays.value).toHaveLength(2);
-
-            // when - 첫 번째 발견된 것 제거
-            await store.remove(overlayId);
-
-            // then
-            expect(store.overlays.value).toHaveLength(1);
-            expect(callbacks1.value.close).toHaveBeenCalledTimes(1);
-            expect(callbacks2.value.close).not.toHaveBeenCalled();
-        });
     });
 });

--- a/packages/vlossom/src/stores/__tests__/overlay-callback-store.test.ts
+++ b/packages/vlossom/src/stores/__tests__/overlay-callback-store.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ref, type Ref } from 'vue';
 import { OverlayCallbackStore } from '../overlay-callback-store';
-import { VS_OVERLAY_OPEN, VS_OVERLAY_CLOSE } from '@/declaration';
+import { OVERLAY_OPEN, OVERLAY_CLOSE } from '@/declaration';
 import type { OverlayCallbacks } from '@/declaration';
 
 describe('OverlayCallbackStore', () => {
@@ -34,7 +34,7 @@ describe('OverlayCallbackStore', () => {
             const vlossomOpenCallback = vi.fn();
             const callbacks: Ref<OverlayCallbacks> = ref({
                 open: openCallback,
-                [VS_OVERLAY_OPEN]: vlossomOpenCallback,
+                [OVERLAY_OPEN]: vlossomOpenCallback,
             });
 
             // when
@@ -110,7 +110,7 @@ describe('OverlayCallbackStore', () => {
             const vlossomCloseCallback = vi.fn();
             const callbacks: Ref<OverlayCallbacks> = ref({
                 close: closeCallback,
-                [VS_OVERLAY_CLOSE]: vlossomCloseCallback,
+                [OVERLAY_CLOSE]: vlossomCloseCallback,
             });
             await store.push(overlayId, callbacks);
 

--- a/packages/vlossom/src/stores/__tests__/overlay-callback-store.test.ts
+++ b/packages/vlossom/src/stores/__tests__/overlay-callback-store.test.ts
@@ -1,0 +1,352 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { OverlayCallbackStore } from '../overlay-callback-store';
+import { VS_OVERLAY_OPEN, VS_OVERLAY_CLOSE } from '@/declaration';
+import type { OverlayCallbacks } from '@/declaration';
+
+describe('OverlayCallbackStore', () => {
+    let store: OverlayCallbackStore;
+
+    beforeEach(() => {
+        store = new OverlayCallbackStore();
+    });
+
+    describe('초기 상태', () => {
+        it('overlays가 빈 배열로 초기화되어야 한다', () => {
+            // then
+            expect(store.overlays.value).toEqual([]);
+        });
+
+        it('getLastOverlayId가 빈 문자열을 반환해야 한다', () => {
+            // when
+            const result = store.getLastOverlayId();
+
+            // then
+            expect(result).toBe('');
+        });
+    });
+
+    describe('push', () => {
+        it('overlay를 추가하고 open 콜백을 실행해야 한다', async () => {
+            // given
+            const overlayId = 'test-overlay-1';
+            const openCallback = vi.fn();
+            const vlossomOpenCallback = vi.fn();
+            const callbacks = ref<OverlayCallbacks>({
+                open: openCallback,
+                [VS_OVERLAY_OPEN]: vlossomOpenCallback,
+            });
+
+            // when
+            await store.push(overlayId, callbacks);
+
+            // then
+            expect(store.overlays.value).toHaveLength(1);
+            expect(store.overlays.value[0][0]).toBe(overlayId);
+            expect(store.overlays.value[0][1]).toBe(callbacks);
+            expect(vlossomOpenCallback).toHaveBeenCalledTimes(1);
+            expect(openCallback).toHaveBeenCalledTimes(1);
+        });
+
+        it('여러 overlay를 순서대로 추가할 수 있어야 한다', async () => {
+            // given
+            const overlay1 = 'overlay-1';
+            const overlay2 = 'overlay-2';
+            const callbacks1 = ref<OverlayCallbacks>({ open: vi.fn() });
+            const callbacks2 = ref<OverlayCallbacks>({ open: vi.fn() });
+
+            // when
+            await store.push(overlay1, callbacks1);
+            await store.push(overlay2, callbacks2);
+
+            // then
+            expect(store.overlays.value).toHaveLength(2);
+            expect(store.overlays.value[0][0]).toBe(overlay1);
+            expect(store.overlays.value[1][0]).toBe(overlay2);
+        });
+
+        it('open 콜백이 없어도 정상 작동해야 한다', async () => {
+            // given
+            const overlayId = 'test-overlay';
+            const callbacks = ref<OverlayCallbacks>({});
+
+            // when & then
+            expect(async () => {
+                await store.push(overlayId, callbacks);
+            }).not.toThrow();
+            expect(store.overlays.value).toHaveLength(1);
+        });
+    });
+
+    describe('getLastOverlayId', () => {
+        it('마지막에 추가된 overlay의 ID를 반환해야 한다', async () => {
+            // given
+            const overlay1 = 'overlay-1';
+            const overlay2 = 'overlay-2';
+            const callbacks = ref<OverlayCallbacks>({});
+
+            // when
+            await store.push(overlay1, callbacks);
+            await store.push(overlay2, callbacks);
+
+            // then
+            expect(store.getLastOverlayId()).toBe(overlay2);
+        });
+
+        it('overlay가 없을 때 빈 문자열을 반환해야 한다', () => {
+            // when
+            const result = store.getLastOverlayId();
+
+            // then
+            expect(result).toBe('');
+        });
+    });
+
+    describe('pop', () => {
+        it('마지막 overlay를 제거하고 close 콜백을 실행해야 한다', async () => {
+            // given
+            const overlayId = 'test-overlay';
+            const closeCallback = vi.fn();
+            const vlossomCloseCallback = vi.fn();
+            const callbacks = ref<OverlayCallbacks>({
+                close: closeCallback,
+                [VS_OVERLAY_CLOSE]: vlossomCloseCallback,
+            });
+            await store.push(overlayId, callbacks);
+
+            // when
+            await store.pop();
+
+            // then
+            expect(store.overlays.value).toHaveLength(0);
+            expect(vlossomCloseCallback).toHaveBeenCalledTimes(1);
+            expect(closeCallback).toHaveBeenCalledTimes(1);
+        });
+
+        it('인자를 콜백에 전달해야 한다', async () => {
+            // given
+            const overlayId = 'test-overlay';
+            const closeCallback = vi.fn();
+            const callbacks = ref<OverlayCallbacks>({ close: closeCallback });
+            await store.push(overlayId, callbacks);
+            const args = ['arg1', 'arg2'];
+
+            // when
+            await store.pop(...args);
+
+            // then
+            expect(closeCallback).toHaveBeenCalledWith(...args);
+        });
+
+        it('overlay가 없을 때는 에러가 발생한다', () => {
+            // when & then
+            expect(() => {
+                store.pop();
+            }).toThrow(TypeError);
+        });
+
+        it('close 콜백이 없어도 정상 작동해야 한다', async () => {
+            // given
+            const overlayId = 'test-overlay';
+            const callbacks = ref<OverlayCallbacks>({});
+            await store.push(overlayId, callbacks);
+
+            // when & then
+            expect(async () => {
+                await store.pop();
+            }).not.toThrow();
+            expect(store.overlays.value).toHaveLength(0);
+        });
+    });
+
+    describe('remove', () => {
+        it('지정된 ID의 overlay를 제거하고 close 콜백을 실행해야 한다', async () => {
+            // given
+            const overlay1 = 'overlay-1';
+            const overlay2 = 'overlay-2';
+            const closeCallback1 = vi.fn();
+            const closeCallback2 = vi.fn();
+            const callbacks1 = ref<OverlayCallbacks>({ close: closeCallback1 });
+            const callbacks2 = ref<OverlayCallbacks>({ close: closeCallback2 });
+
+            await store.push(overlay1, callbacks1);
+            await store.push(overlay2, callbacks2);
+
+            // when
+            await store.remove(overlay1);
+
+            // then
+            expect(store.overlays.value).toHaveLength(1);
+            expect(store.overlays.value[0][0]).toBe(overlay2);
+            expect(closeCallback1).toHaveBeenCalledTimes(1);
+            expect(closeCallback2).not.toHaveBeenCalled();
+        });
+
+        it('존재하지 않는 ID로 제거를 시도해도 정상 작동해야 한다', async () => {
+            // given
+            const overlayId = 'existing-overlay';
+            const callbacks = ref<OverlayCallbacks>({});
+            await store.push(overlayId, callbacks);
+
+            // when & then
+            expect(async () => {
+                await store.remove('non-existing-overlay');
+            }).not.toThrow();
+            expect(store.overlays.value).toHaveLength(1);
+        });
+
+        it('인자를 콜백에 전달해야 한다', async () => {
+            // given
+            const overlayId = 'test-overlay';
+            const closeCallback = vi.fn();
+            const callbacks = ref<OverlayCallbacks>({ close: closeCallback });
+            await store.push(overlayId, callbacks);
+            const args = ['arg1', 'arg2'];
+
+            // when
+            await store.remove(overlayId, ...args);
+
+            // then
+            expect(closeCallback).toHaveBeenCalledWith(...args);
+        });
+    });
+
+    describe('clear', () => {
+        it('모든 overlay를 제거해야 한다', async () => {
+            // given
+            const overlay1 = 'overlay-1';
+            const overlay2 = 'overlay-2';
+            const overlay3 = 'overlay-3';
+            const closeCallback1 = vi.fn();
+            const closeCallback2 = vi.fn();
+            const closeCallback3 = vi.fn();
+
+            await store.push(overlay1, ref({ close: closeCallback1 }));
+            await store.push(overlay2, ref({ close: closeCallback2 }));
+            await store.push(overlay3, ref({ close: closeCallback3 }));
+
+            // when
+            await store.clear();
+
+            // then
+            expect(store.overlays.value).toHaveLength(0);
+            expect(closeCallback1).toHaveBeenCalledTimes(1);
+            expect(closeCallback2).toHaveBeenCalledTimes(1);
+            expect(closeCallback3).toHaveBeenCalledTimes(1);
+        });
+
+        it('LIFO 순서로 overlay를 제거해야 한다', async () => {
+            // given
+            const callOrder: string[] = [];
+            const overlay1 = 'overlay-1';
+            const overlay2 = 'overlay-2';
+            const closeCallback1 = vi.fn(() => {
+                callOrder.push('close-1');
+            });
+            const closeCallback2 = vi.fn(() => {
+                callOrder.push('close-2');
+            });
+
+            await store.push(overlay1, ref({ close: closeCallback1 }));
+            await store.push(overlay2, ref({ close: closeCallback2 }));
+
+            // when
+            await store.clear();
+
+            // then
+            expect(callOrder).toEqual(['close-2', 'close-1']);
+        });
+
+        it('overlay가 없을 때도 정상 작동해야 한다', async () => {
+            // when & then
+            expect(async () => {
+                await store.clear();
+            }).not.toThrow();
+        });
+
+        it('인자를 모든 콜백에 전달해야 한다', async () => {
+            // given
+            const overlay1 = 'overlay-1';
+            const overlay2 = 'overlay-2';
+            const closeCallback1 = vi.fn();
+            const closeCallback2 = vi.fn();
+
+            await store.push(overlay1, ref({ close: closeCallback1 }));
+            await store.push(overlay2, ref({ close: closeCallback2 }));
+            const args = ['arg1', 'arg2'];
+
+            // when
+            await store.clear(...args);
+
+            // then
+            expect(closeCallback1).toHaveBeenCalledWith(...args);
+            expect(closeCallback2).toHaveBeenCalledWith(...args);
+        });
+    });
+
+    describe('통합 테스트', () => {
+        it('복합 시나리오에서 올바르게 동작해야 한다', async () => {
+            // given
+            const overlay1 = 'overlay-1';
+            const overlay2 = 'overlay-2';
+            const overlay3 = 'overlay-3';
+            const callbacks1 = ref<OverlayCallbacks>({
+                open: vi.fn(),
+                close: vi.fn(),
+            });
+            const callbacks2 = ref<OverlayCallbacks>({
+                open: vi.fn(),
+                close: vi.fn(),
+            });
+            const callbacks3 = ref<OverlayCallbacks>({
+                open: vi.fn(),
+                close: vi.fn(),
+            });
+
+            // when & then
+            // 3개 추가
+            await store.push(overlay1, callbacks1);
+            await store.push(overlay2, callbacks2);
+            await store.push(overlay3, callbacks3);
+            expect(store.overlays.value).toHaveLength(3);
+            expect(store.getLastOverlayId()).toBe(overlay3);
+
+            // 중간 제거
+            await store.remove(overlay2);
+            expect(store.overlays.value).toHaveLength(2);
+            expect(store.overlays.value.map(([id]) => id)).toEqual([overlay1, overlay3]);
+
+            // 마지막 pop
+            await store.pop();
+            expect(store.overlays.value).toHaveLength(1);
+            expect(store.getLastOverlayId()).toBe(overlay1);
+
+            // 모두 clear
+            await store.clear();
+            expect(store.overlays.value).toHaveLength(0);
+            expect(store.getLastOverlayId()).toBe('');
+        });
+
+        it('같은 ID로 중복 추가 후 제거가 올바르게 동작해야 한다', async () => {
+            // given
+            const overlayId = 'duplicate-overlay';
+            const callbacks1 = ref<OverlayCallbacks>({ close: vi.fn() });
+            const callbacks2 = ref<OverlayCallbacks>({ close: vi.fn() });
+
+            // when
+            await store.push(overlayId, callbacks1);
+            await store.push(overlayId, callbacks2);
+
+            // then
+            expect(store.overlays.value).toHaveLength(2);
+
+            // when - 첫 번째 발견된 것 제거
+            await store.remove(overlayId);
+
+            // then
+            expect(store.overlays.value).toHaveLength(1);
+            expect(callbacks1.value.close).toHaveBeenCalledTimes(1);
+            expect(callbacks2.value.close).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/vlossom/src/stores/__tests__/overlay-callback-store.test.ts
+++ b/packages/vlossom/src/stores/__tests__/overlay-callback-store.test.ts
@@ -138,13 +138,6 @@ describe('OverlayCallbackStore', () => {
             expect(closeCallback).toHaveBeenCalledWith(...args);
         });
 
-        it('overlay가 없을 때는 에러가 발생한다', () => {
-            // when & then
-            expect(() => {
-                store.pop();
-            }).toThrow(TypeError);
-        });
-
         it('close 콜백이 없어도 정상 작동해야 한다', async () => {
             // given
             const overlayId = 'test-overlay';

--- a/packages/vlossom/src/stores/__tests__/overlay-callback-store.test.ts
+++ b/packages/vlossom/src/stores/__tests__/overlay-callback-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { ref } from 'vue';
+import { ref, type Ref } from 'vue';
 import { OverlayCallbackStore } from '../overlay-callback-store';
 import { VS_OVERLAY_OPEN, VS_OVERLAY_CLOSE } from '@/declaration';
 import type { OverlayCallbacks } from '@/declaration';
@@ -32,7 +32,7 @@ describe('OverlayCallbackStore', () => {
             const overlayId = 'test-overlay-1';
             const openCallback = vi.fn();
             const vlossomOpenCallback = vi.fn();
-            const callbacks = ref<OverlayCallbacks>({
+            const callbacks: Ref<OverlayCallbacks> = ref({
                 open: openCallback,
                 [VS_OVERLAY_OPEN]: vlossomOpenCallback,
             });
@@ -52,8 +52,8 @@ describe('OverlayCallbackStore', () => {
             // given
             const overlay1 = 'overlay-1';
             const overlay2 = 'overlay-2';
-            const callbacks1 = ref<OverlayCallbacks>({ open: vi.fn() });
-            const callbacks2 = ref<OverlayCallbacks>({ open: vi.fn() });
+            const callbacks1: Ref<OverlayCallbacks> = ref({ open: vi.fn() });
+            const callbacks2: Ref<OverlayCallbacks> = ref({ open: vi.fn() });
 
             // when
             await store.push(overlay1, callbacks1);
@@ -68,7 +68,7 @@ describe('OverlayCallbackStore', () => {
         it('open 콜백이 없어도 정상 작동해야 한다', async () => {
             // given
             const overlayId = 'test-overlay';
-            const callbacks = ref<OverlayCallbacks>({});
+            const callbacks: Ref<OverlayCallbacks> = ref({});
 
             // when & then
             expect(async () => {
@@ -83,7 +83,7 @@ describe('OverlayCallbackStore', () => {
             // given
             const overlay1 = 'overlay-1';
             const overlay2 = 'overlay-2';
-            const callbacks = ref<OverlayCallbacks>({});
+            const callbacks: Ref<OverlayCallbacks> = ref({});
 
             // when
             await store.push(overlay1, callbacks);
@@ -108,7 +108,7 @@ describe('OverlayCallbackStore', () => {
             const overlayId = 'test-overlay';
             const closeCallback = vi.fn();
             const vlossomCloseCallback = vi.fn();
-            const callbacks = ref<OverlayCallbacks>({
+            const callbacks: Ref<OverlayCallbacks> = ref({
                 close: closeCallback,
                 [VS_OVERLAY_CLOSE]: vlossomCloseCallback,
             });
@@ -127,7 +127,7 @@ describe('OverlayCallbackStore', () => {
             // given
             const overlayId = 'test-overlay';
             const closeCallback = vi.fn();
-            const callbacks = ref<OverlayCallbacks>({ close: closeCallback });
+            const callbacks: Ref<OverlayCallbacks> = ref({ close: closeCallback });
             await store.push(overlayId, callbacks);
             const args = ['arg1', 'arg2'];
 
@@ -148,7 +148,7 @@ describe('OverlayCallbackStore', () => {
         it('close 콜백이 없어도 정상 작동해야 한다', async () => {
             // given
             const overlayId = 'test-overlay';
-            const callbacks = ref<OverlayCallbacks>({});
+            const callbacks: Ref<OverlayCallbacks> = ref({});
             await store.push(overlayId, callbacks);
 
             // when & then
@@ -166,8 +166,8 @@ describe('OverlayCallbackStore', () => {
             const overlay2 = 'overlay-2';
             const closeCallback1 = vi.fn();
             const closeCallback2 = vi.fn();
-            const callbacks1 = ref<OverlayCallbacks>({ close: closeCallback1 });
-            const callbacks2 = ref<OverlayCallbacks>({ close: closeCallback2 });
+            const callbacks1: Ref<OverlayCallbacks> = ref({ close: closeCallback1 });
+            const callbacks2: Ref<OverlayCallbacks> = ref({ close: closeCallback2 });
 
             await store.push(overlay1, callbacks1);
             await store.push(overlay2, callbacks2);
@@ -185,7 +185,7 @@ describe('OverlayCallbackStore', () => {
         it('존재하지 않는 ID로 제거를 시도해도 정상 작동해야 한다', async () => {
             // given
             const overlayId = 'existing-overlay';
-            const callbacks = ref<OverlayCallbacks>({});
+            const callbacks: Ref<OverlayCallbacks> = ref({});
             await store.push(overlayId, callbacks);
 
             // when & then
@@ -199,7 +199,7 @@ describe('OverlayCallbackStore', () => {
             // given
             const overlayId = 'test-overlay';
             const closeCallback = vi.fn();
-            const callbacks = ref<OverlayCallbacks>({ close: closeCallback });
+            const callbacks: Ref<OverlayCallbacks> = ref({ close: closeCallback });
             await store.push(overlayId, callbacks);
             const args = ['arg1', 'arg2'];
 
@@ -220,10 +220,13 @@ describe('OverlayCallbackStore', () => {
             const closeCallback1 = vi.fn();
             const closeCallback2 = vi.fn();
             const closeCallback3 = vi.fn();
+            const callbacks1: Ref<OverlayCallbacks> = ref({ close: closeCallback1 });
+            const callbacks2: Ref<OverlayCallbacks> = ref({ close: closeCallback2 });
+            const callbacks3: Ref<OverlayCallbacks> = ref({ close: closeCallback3 });
 
-            await store.push(overlay1, ref({ close: closeCallback1 }));
-            await store.push(overlay2, ref({ close: closeCallback2 }));
-            await store.push(overlay3, ref({ close: closeCallback3 }));
+            await store.push(overlay1, callbacks1);
+            await store.push(overlay2, callbacks2);
+            await store.push(overlay3, callbacks3);
 
             // when
             await store.clear();
@@ -246,9 +249,11 @@ describe('OverlayCallbackStore', () => {
             const closeCallback2 = vi.fn(() => {
                 callOrder.push('close-2');
             });
+            const callbacks1: Ref<OverlayCallbacks> = ref({ close: closeCallback1 });
+            const callbacks2: Ref<OverlayCallbacks> = ref({ close: closeCallback2 });
 
-            await store.push(overlay1, ref({ close: closeCallback1 }));
-            await store.push(overlay2, ref({ close: closeCallback2 }));
+            await store.push(overlay1, callbacks1);
+            await store.push(overlay2, callbacks2);
 
             // when
             await store.clear();
@@ -270,9 +275,11 @@ describe('OverlayCallbackStore', () => {
             const overlay2 = 'overlay-2';
             const closeCallback1 = vi.fn();
             const closeCallback2 = vi.fn();
+            const callbacks1: Ref<OverlayCallbacks> = ref({ close: closeCallback1 });
+            const callbacks2: Ref<OverlayCallbacks> = ref({ close: closeCallback2 });
 
-            await store.push(overlay1, ref({ close: closeCallback1 }));
-            await store.push(overlay2, ref({ close: closeCallback2 }));
+            await store.push(overlay1, callbacks1);
+            await store.push(overlay2, callbacks2);
             const args = ['arg1', 'arg2'];
 
             // when
@@ -290,15 +297,15 @@ describe('OverlayCallbackStore', () => {
             const overlay1 = 'overlay-1';
             const overlay2 = 'overlay-2';
             const overlay3 = 'overlay-3';
-            const callbacks1 = ref<OverlayCallbacks>({
+            const callbacks1: Ref<OverlayCallbacks> = ref({
                 open: vi.fn(),
                 close: vi.fn(),
             });
-            const callbacks2 = ref<OverlayCallbacks>({
+            const callbacks2: Ref<OverlayCallbacks> = ref({
                 open: vi.fn(),
                 close: vi.fn(),
             });
-            const callbacks3 = ref<OverlayCallbacks>({
+            const callbacks3: Ref<OverlayCallbacks> = ref({
                 open: vi.fn(),
                 close: vi.fn(),
             });
@@ -330,8 +337,8 @@ describe('OverlayCallbackStore', () => {
         it('같은 ID로 중복 추가 후 제거가 올바르게 동작해야 한다', async () => {
             // given
             const overlayId = 'duplicate-overlay';
-            const callbacks1 = ref<OverlayCallbacks>({ close: vi.fn() });
-            const callbacks2 = ref<OverlayCallbacks>({ close: vi.fn() });
+            const callbacks1: Ref<OverlayCallbacks> = ref({ close: vi.fn() });
+            const callbacks2: Ref<OverlayCallbacks> = ref({ close: vi.fn() });
 
             // when
             await store.push(overlayId, callbacks1);

--- a/packages/vlossom/src/stores/index.ts
+++ b/packages/vlossom/src/stores/index.ts
@@ -1,2 +1,3 @@
 export * from './layout-store';
 export * from './options-store';
+export * from './overlay-callback-store';

--- a/packages/vlossom/src/stores/overlay-callback-store.ts
+++ b/packages/vlossom/src/stores/overlay-callback-store.ts
@@ -1,0 +1,73 @@
+import { ref, type Ref, readonly } from 'vue';
+import { type OverlayCallbacks, VS_OVERLAY_CLOSE, VS_OVERLAY_OPEN } from '@/declaration';
+
+export class OverlayCallbackStore {
+    // overlay tuple: [id, { [eventName: callback }]
+    private _overlays: Ref<[string, Ref<OverlayCallbacks>][]> = ref([]);
+
+    public overlays = readonly(this._overlays);
+
+    constructor() {
+        document.addEventListener('keydown', (event: KeyboardEvent) => {
+            if (this._overlays.value.length === 0) {
+                return;
+            }
+
+            const keyEventName = `key-${event.key}`;
+            const [lastOverlayId, callbacks] = this._overlays.value[this._overlays.value.length - 1];
+            if (!callbacks.value[keyEventName]) {
+                return;
+            }
+
+            // Prevent default action for registered key event (ex. enter, esc)
+            event.preventDefault();
+
+            this.run(lastOverlayId, keyEventName, event);
+        });
+    }
+
+    private async run<T = void>(id: string, eventName: string, ...args: any[]): Promise<T | void> {
+        const index = this._overlays.value.findIndex(([overlayId]) => overlayId === id);
+        if (index === -1) {
+            return;
+        }
+        const [, callbacks] = this._overlays.value[index];
+        return await callbacks.value[eventName]?.(...args);
+    }
+
+    public getLastOverlayId() {
+        return this._overlays.value.length > 0 ? this._overlays.value[this._overlays.value.length - 1][0] : '';
+    }
+
+    public push(id: string, callbacks: Ref<OverlayCallbacks>) {
+        this._overlays.value.push([id, callbacks]);
+        this.run(id, VS_OVERLAY_OPEN);
+        return this.run(id, 'open');
+    }
+
+    public pop(...args: any[]) {
+        const [targetId] = this._overlays.value[this._overlays.value.length - 1];
+        this.run(targetId, VS_OVERLAY_CLOSE, ...args);
+        const result = this.run(targetId, 'close', ...args);
+        this._overlays.value.pop();
+        return result;
+    }
+
+    public remove(id: string, ...args: any[]) {
+        const index = this._overlays.value.findIndex(([stackId]) => stackId === id);
+        if (index === -1) {
+            return;
+        }
+        const [targetId] = this._overlays.value[index];
+        this.run(targetId, VS_OVERLAY_CLOSE, ...args);
+        const result = this.run(targetId, 'close', ...args);
+        this._overlays.value.splice(index, 1);
+        return result;
+    }
+
+    public clear(...args: any[]) {
+        while (this._overlays.value.length > 0) {
+            this.pop(...args);
+        }
+    }
+}

--- a/packages/vlossom/src/stores/overlay-callback-store.ts
+++ b/packages/vlossom/src/stores/overlay-callback-store.ts
@@ -4,10 +4,13 @@ import { type OverlayCallbacks, VS_OVERLAY_CLOSE, VS_OVERLAY_OPEN } from '@/decl
 export class OverlayCallbackStore {
     // overlay tuple: [id, { [eventName: callback }]
     private _overlays: Ref<[string, Ref<OverlayCallbacks>][]> = ref([]);
+    private _historyStateKey = 'vlossom-overlay';
+    private _isHandlingPopstate = false;
 
     public overlays = readonly(this._overlays);
 
     constructor() {
+        // Handle keyboard events
         document.addEventListener('keydown', (event: KeyboardEvent) => {
             if (this._overlays.value.length === 0) {
                 return;
@@ -23,6 +26,34 @@ export class OverlayCallbackStore {
             event.preventDefault();
 
             this.run(lastOverlayId, keyEventName, event);
+        });
+
+        // Handle Android back button via popstate event
+        window.addEventListener('popstate', (event: PopStateEvent) => {
+            if (this._isHandlingPopstate || this._overlays.value.length === 0) {
+                return;
+            }
+
+            // Check if this popstate event is related to our overlay
+            const currentState = event.state;
+            const shouldHandleBackButton =
+                !currentState ||
+                !currentState[this._historyStateKey] ||
+                currentState[this._historyStateKey] < this._overlays.value.length;
+
+            if (shouldHandleBackButton) {
+                const [lastOverlayId, callbacks] = this._overlays.value[this._overlays.value.length - 1];
+
+                // Try to run android-back callback first, fallback to key-Escape
+                const backEventName = 'android-back';
+                const escEventName = 'key-Escape';
+
+                if (callbacks.value[backEventName]) {
+                    this.run(lastOverlayId, backEventName, event);
+                } else if (callbacks.value[escEventName]) {
+                    this.run(lastOverlayId, escEventName, event);
+                }
+            }
         });
     }
 
@@ -41,6 +72,14 @@ export class OverlayCallbackStore {
 
     public push(id: string, callbacks: Ref<OverlayCallbacks>) {
         this._overlays.value.push([id, callbacks]);
+
+        // Add history state for Android back button support
+        const newState = {
+            ...window.history.state,
+            [this._historyStateKey]: this._overlays.value.length,
+        };
+        window.history.pushState(newState, '', window.location.href);
+
         this.run(id, VS_OVERLAY_OPEN);
         return this.run(id, 'open');
     }
@@ -50,6 +89,22 @@ export class OverlayCallbackStore {
         this.run(targetId, VS_OVERLAY_CLOSE, ...args);
         const result = this.run(targetId, 'close', ...args);
         this._overlays.value.pop();
+
+        // Handle history state when popping overlay
+        this._isHandlingPopstate = true;
+        try {
+            // Only go back in history if current state has our overlay key
+            const currentState = window.history.state;
+            if (currentState && currentState[this._historyStateKey]) {
+                window.history.back();
+            }
+        } finally {
+            // Reset flag after a short delay to avoid interference
+            setTimeout(() => {
+                this._isHandlingPopstate = false;
+            }, 10);
+        }
+
         return result;
     }
 
@@ -62,12 +117,56 @@ export class OverlayCallbackStore {
         this.run(targetId, VS_OVERLAY_CLOSE, ...args);
         const result = this.run(targetId, 'close', ...args);
         this._overlays.value.splice(index, 1);
+
+        // Handle history state when removing specific overlay
+        this._isHandlingPopstate = true;
+        try {
+            const currentState = window.history.state;
+            if (currentState && currentState[this._historyStateKey]) {
+                // If removing the last overlay or there are no overlays left
+                if (this._overlays.value.length === 0) {
+                    window.history.back();
+                } else {
+                    // Update the state to reflect current overlay count
+                    const updatedState = {
+                        ...currentState,
+                        [this._historyStateKey]: this._overlays.value.length,
+                    };
+                    window.history.replaceState(updatedState, '', window.location.href);
+                }
+            }
+        } finally {
+            setTimeout(() => {
+                this._isHandlingPopstate = false;
+            }, 10);
+        }
+
         return result;
     }
 
     public clear(...args: any[]) {
+        const overlayCount = this._overlays.value.length;
+
         while (this._overlays.value.length > 0) {
             this.pop(...args);
+        }
+
+        // Handle history state when clearing all overlays
+        if (overlayCount > 0) {
+            this._isHandlingPopstate = true;
+            try {
+                const currentState = window.history.state;
+                if (currentState && currentState[this._historyStateKey]) {
+                    // Go back in history for each overlay that was cleared
+                    for (let i = 0; i < overlayCount - 1; i++) {
+                        window.history.back();
+                    }
+                }
+            } finally {
+                setTimeout(() => {
+                    this._isHandlingPopstate = false;
+                }, 10);
+            }
         }
     }
 }

--- a/packages/vlossom/src/stores/overlay-callback-store.ts
+++ b/packages/vlossom/src/stores/overlay-callback-store.ts
@@ -1,20 +1,29 @@
 import { ref, type Ref, readonly } from 'vue';
-import { type OverlayCallbacks, VS_OVERLAY_CLOSE, VS_OVERLAY_OPEN } from '@/declaration';
+import { type OverlayTuple, type OverlayCallbacks, VS_OVERLAY_CLOSE, VS_OVERLAY_OPEN } from '@/declaration';
 
 export class OverlayCallbackStore {
     // overlay tuple: [id, { [eventName: callback }]
-    private _overlays: Ref<[string, Ref<OverlayCallbacks>][]> = ref([]);
+    private _overlays: Ref<OverlayTuple[]> = ref([]);
 
     public overlays = readonly(this._overlays);
 
     constructor() {
+        this.addOverlayCallbackKeyEventListener();
+    }
+
+    private addOverlayCallbackKeyEventListener() {
         document.addEventListener('keydown', (event: KeyboardEvent) => {
-            if (this._overlays.value.length === 0) {
+            if (this.overlays.value.length === 0) {
+                return;
+            }
+
+            const overlay = this.getLastOverlay();
+            if (!overlay) {
                 return;
             }
 
             const keyEventName = `key-${event.key}`;
-            const [lastOverlayId, callbacks] = this._overlays.value[this._overlays.value.length - 1];
+            const [lastOverlayId, callbacks] = overlay;
             if (!callbacks.value[keyEventName]) {
                 return;
             }
@@ -26,17 +35,25 @@ export class OverlayCallbackStore {
         });
     }
 
-    private async run<T = void>(id: string, eventName: string, ...args: any[]): Promise<T | void> {
+    public getLastOverlay(): [string, Ref<OverlayCallbacks>] | null {
+        return this._overlays.value.length > 0 ? this._overlays.value[this._overlays.value.length - 1] : null;
+    }
+
+    public getLastOverlayId(): string {
+        const overlay = this.getLastOverlay();
+        if (!overlay) {
+            return '';
+        }
+        return overlay[0];
+    }
+
+    public async run<T = void>(id: string, eventName: string, ...args: any[]): Promise<T | void> {
         const index = this._overlays.value.findIndex(([overlayId]) => overlayId === id);
         if (index === -1) {
             return;
         }
         const [, callbacks] = this._overlays.value[index];
         return await callbacks.value[eventName]?.(...args);
-    }
-
-    public getLastOverlayId() {
-        return this._overlays.value.length > 0 ? this._overlays.value[this._overlays.value.length - 1][0] : '';
     }
 
     public push(id: string, callbacks: Ref<OverlayCallbacks>) {
@@ -46,10 +63,15 @@ export class OverlayCallbackStore {
     }
 
     public pop(...args: any[]) {
-        const [targetId] = this._overlays.value[this._overlays.value.length - 1];
+        const overlay = this.getLastOverlay();
+        if (!overlay) {
+            return;
+        }
+        const [targetId] = overlay;
         this.run(targetId, VS_OVERLAY_CLOSE, ...args);
         const result = this.run(targetId, 'close', ...args);
         this._overlays.value.pop();
+
         return result;
     }
 
@@ -71,4 +93,10 @@ export class OverlayCallbackStore {
             this.pop(...args);
         }
     }
+}
+
+const overlayCallbackStore = new OverlayCallbackStore();
+
+export function useOverlayCallbackStore() {
+    return overlayCallbackStore;
 }

--- a/packages/vlossom/src/stores/overlay-callback-store.ts
+++ b/packages/vlossom/src/stores/overlay-callback-store.ts
@@ -1,5 +1,5 @@
 import { ref, type Ref, readonly } from 'vue';
-import { type OverlayTuple, type OverlayCallbacks, VS_OVERLAY_CLOSE, VS_OVERLAY_OPEN } from '@/declaration';
+import { type OverlayTuple, type OverlayCallbacks, OVERLAY_CLOSE, OVERLAY_OPEN } from '@/declaration';
 
 export class OverlayCallbackStore {
     // overlay tuple: [id, { [eventName: callback }]
@@ -30,6 +30,7 @@ export class OverlayCallbackStore {
 
             // Prevent default action for registered key event (ex. enter, esc)
             event.preventDefault();
+            event.stopPropagation();
 
             this.run(lastOverlayId, keyEventName, event);
         });
@@ -58,7 +59,7 @@ export class OverlayCallbackStore {
 
     public push(id: string, callbacks: Ref<OverlayCallbacks>) {
         this._overlays.value.push([id, callbacks]);
-        this.run(id, VS_OVERLAY_OPEN);
+        this.run(id, OVERLAY_OPEN);
         return this.run(id, 'open');
     }
 
@@ -68,7 +69,7 @@ export class OverlayCallbackStore {
             return;
         }
         const [targetId] = overlay;
-        this.run(targetId, VS_OVERLAY_CLOSE, ...args);
+        this.run(targetId, OVERLAY_CLOSE, ...args);
         const result = this.run(targetId, 'close', ...args);
         this._overlays.value.pop();
 
@@ -81,7 +82,7 @@ export class OverlayCallbackStore {
             return;
         }
         const [targetId] = this._overlays.value[index];
-        this.run(targetId, VS_OVERLAY_CLOSE, ...args);
+        this.run(targetId, OVERLAY_CLOSE, ...args);
         const result = this.run(targetId, 'close', ...args);
         this._overlays.value.splice(index, 1);
 

--- a/packages/vlossom/src/stores/overlay-callback-store.ts
+++ b/packages/vlossom/src/stores/overlay-callback-store.ts
@@ -4,13 +4,10 @@ import { type OverlayCallbacks, VS_OVERLAY_CLOSE, VS_OVERLAY_OPEN } from '@/decl
 export class OverlayCallbackStore {
     // overlay tuple: [id, { [eventName: callback }]
     private _overlays: Ref<[string, Ref<OverlayCallbacks>][]> = ref([]);
-    private _historyStateKey = 'vlossom-overlay';
-    private _isHandlingPopstate = false;
 
     public overlays = readonly(this._overlays);
 
     constructor() {
-        // Handle keyboard events
         document.addEventListener('keydown', (event: KeyboardEvent) => {
             if (this._overlays.value.length === 0) {
                 return;
@@ -26,34 +23,6 @@ export class OverlayCallbackStore {
             event.preventDefault();
 
             this.run(lastOverlayId, keyEventName, event);
-        });
-
-        // Handle Android back button via popstate event
-        window.addEventListener('popstate', (event: PopStateEvent) => {
-            if (this._isHandlingPopstate || this._overlays.value.length === 0) {
-                return;
-            }
-
-            // Check if this popstate event is related to our overlay
-            const currentState = event.state;
-            const shouldHandleBackButton =
-                !currentState ||
-                !currentState[this._historyStateKey] ||
-                currentState[this._historyStateKey] < this._overlays.value.length;
-
-            if (shouldHandleBackButton) {
-                const [lastOverlayId, callbacks] = this._overlays.value[this._overlays.value.length - 1];
-
-                // Try to run android-back callback first, fallback to key-Escape
-                const backEventName = 'android-back';
-                const escEventName = 'key-Escape';
-
-                if (callbacks.value[backEventName]) {
-                    this.run(lastOverlayId, backEventName, event);
-                } else if (callbacks.value[escEventName]) {
-                    this.run(lastOverlayId, escEventName, event);
-                }
-            }
         });
     }
 
@@ -72,14 +41,6 @@ export class OverlayCallbackStore {
 
     public push(id: string, callbacks: Ref<OverlayCallbacks>) {
         this._overlays.value.push([id, callbacks]);
-
-        // Add history state for Android back button support
-        const newState = {
-            ...window.history.state,
-            [this._historyStateKey]: this._overlays.value.length,
-        };
-        window.history.pushState(newState, '', window.location.href);
-
         this.run(id, VS_OVERLAY_OPEN);
         return this.run(id, 'open');
     }
@@ -89,22 +50,6 @@ export class OverlayCallbackStore {
         this.run(targetId, VS_OVERLAY_CLOSE, ...args);
         const result = this.run(targetId, 'close', ...args);
         this._overlays.value.pop();
-
-        // Handle history state when popping overlay
-        this._isHandlingPopstate = true;
-        try {
-            // Only go back in history if current state has our overlay key
-            const currentState = window.history.state;
-            if (currentState && currentState[this._historyStateKey]) {
-                window.history.back();
-            }
-        } finally {
-            // Reset flag after a short delay to avoid interference
-            setTimeout(() => {
-                this._isHandlingPopstate = false;
-            }, 10);
-        }
-
         return result;
     }
 
@@ -118,55 +63,12 @@ export class OverlayCallbackStore {
         const result = this.run(targetId, 'close', ...args);
         this._overlays.value.splice(index, 1);
 
-        // Handle history state when removing specific overlay
-        this._isHandlingPopstate = true;
-        try {
-            const currentState = window.history.state;
-            if (currentState && currentState[this._historyStateKey]) {
-                // If removing the last overlay or there are no overlays left
-                if (this._overlays.value.length === 0) {
-                    window.history.back();
-                } else {
-                    // Update the state to reflect current overlay count
-                    const updatedState = {
-                        ...currentState,
-                        [this._historyStateKey]: this._overlays.value.length,
-                    };
-                    window.history.replaceState(updatedState, '', window.location.href);
-                }
-            }
-        } finally {
-            setTimeout(() => {
-                this._isHandlingPopstate = false;
-            }, 10);
-        }
-
         return result;
     }
 
     public clear(...args: any[]) {
-        const overlayCount = this._overlays.value.length;
-
         while (this._overlays.value.length > 0) {
             this.pop(...args);
-        }
-
-        // Handle history state when clearing all overlays
-        if (overlayCount > 0) {
-            this._isHandlingPopstate = true;
-            try {
-                const currentState = window.history.state;
-                if (currentState && currentState[this._historyStateKey]) {
-                    // Go back in history for each overlay that was cleared
-                    for (let i = 0; i < overlayCount - 1; i++) {
-                        window.history.back();
-                    }
-                }
-            } finally {
-                setTimeout(() => {
-                    this._isHandlingPopstate = false;
-                }, 10);
-            }
         }
     }
 }

--- a/packages/vlossom/src/styles/variables.css
+++ b/packages/vlossom/src/styles/variables.css
@@ -4,14 +4,12 @@
         --vs-no-color-inverse: var(--vs-black);
 
         --vs-app-bg: #f8f8f8;
-        --vs-dimmed-bg: rgba(0, 0, 0, 0.45);
 
         @variant dark {
             --vs-no-color: var(--vs-black);
             --vs-no-color-inverse: var(--vs-white);
 
             --vs-app-bg: #14151f;
-            --vs-dimmed-bg: rgba(0, 0, 0, 0.6);
         }
 
         --vs-line-height: 1.6;

--- a/packages/vlossom/src/utils/string-util.ts
+++ b/packages/vlossom/src/utils/string-util.ts
@@ -1,6 +1,14 @@
 import { kebabCase } from 'change-case';
+import { customAlphabet } from 'nanoid';
 
 export const stringUtil = {
+    createID(size = 10): string {
+        // element ID should not start with a number
+        // https://www.w3schools.com/html/html_id.asp
+        const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+        const nanoid = customAlphabet(chars, size);
+        return nanoid();
+    },
     toStringSize(value: number | string): string {
         if (typeof value === 'number') {
             return `${value}px`;


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary
vs-drawer component를 생성합니다

## Description
- vs-drawer 구현
- vs-drawer가 overlay로 취급되기 때문에 overlay-callback-store와 overlay-composable, overlay-props를 작성함
- id 생성 로직이 필요해서 nanoid 설치 (vue에 있는 useId는 쓸 수 없었음)
- vs-layout에 있던 padding 로직을 vs-container로 옮김 (퍼센트로 전달된 size 표현을 위해서)
- vs-container test 로직 수정
- test에서 stores를 mocking하는 방법이 틀려서 수정함

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
