### PR TITLE
fix(VsLabelValue, VsSwitch): 누락된 글로벌 컴포넌트 타입 선언을 추가

### DIFF
--- a/packages/vlossom/src/components/vs-label-value/types.ts
+++ b/packages/vlossom/src/components/vs-label-value/types.ts
@@ -1,4 +1,11 @@
+import type VsLabelValue from './VsLabelValue.vue';
 import type { BoxStyleSet, TextStyleSet } from '@/declaration';
+
+declare module 'vue' {
+    interface GlobalComponents {
+        VsLabelValue: typeof VsLabelValue;
+    }
+}
 
 export interface VsLabelValueStyleSet extends Omit<BoxStyleSet, 'backgroundColor' | 'padding'> {
     label?: TextStyleSet & {

--- a/packages/vlossom/src/components/vs-switch/types.ts
+++ b/packages/vlossom/src/components/vs-switch/types.ts
@@ -1,4 +1,11 @@
+import type VsSwitch from './VsSwitch.vue';
 import type { SizeStyleSet, VsInputWrapperStyleSet } from '@/main';
+
+declare module 'vue' {
+    interface GlobalComponents {
+        VsSwitch: typeof VsSwitch;
+    }
+}
 
 export interface VsSwitchStyleSet extends SizeStyleSet {
     backgroundColor?: string;


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [ ] Fix Bug (fix)

## Summary

`vs-switch`와 `vs-label-value`의 type.ts 파일에서 누락된 글로벌 컴포넌트 타입 선언을 추가합니다.

- Closes #157
