### PR TITLE
fix(VsMessage): prevent icon from shrinking by adding 'flex-shrink' s…

### DIFF
--- a/packages/vlossom/src/components/vs-message/VsMessage.vue
+++ b/packages/vlossom/src/components/vs-message/VsMessage.vue
@@ -1,6 +1,6 @@
 <template>
     <div :class="['vs-message', colorClass]">
-        <i :style="{ width: sizeValue, height: sizeValue }">
+        <i :style="{ width: sizeValue, height: sizeValue, 'flex-shrink': 0 }">
             <vs-render :content="icon" />
         </i>
         <span class="vs-message-text" :style="{ fontSize: sizeValue }">{{ text }}</span>


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary

`vs-message`의 아이콘이 줄어들거나 사라지는 이슈를 해결합니다.

## Description

<img width="129" height="81" alt="image" src="https://github.com/user-attachments/assets/25eecd2d-51d5-4c91-a491-9e83c90de655" />

컴포넌트의 너비가 충분하지 않은 경우, 아이콘이 사라지거나 작아지는 이슈가 있었음

<img width="153" height="78" alt="image" src="https://github.com/user-attachments/assets/67ef40a3-9fa5-4df5-a820-6474fd7a9159" />

`flex-shrink: 0 `를 추가해 정상적으로 아이콘이 표시되도록 함

- Closes #178 