### PR TITLE
style(VsTabs): vertical 모드에서의 기본 높이 보장 및 스타일 개선

### DIFF
--- a/packages/vlossom/src/components/vs-tabs/VsTabs.css
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.css
@@ -95,11 +95,13 @@
     &.vs-vertical {
         @apply flex-col;
 
+        height: var(--vs-tabs-height, auto);
+
         .vs-tabs-wrap {
             @apply h-full flex-col pr-1 pb-0;
 
             .vs-tab-list {
-                @apply flex-col;
+                @apply flex-col items-stretch;
 
                 border-right: 1px solid var(--tab-border-color);
                 border-bottom: 0;


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary

vs-tabs의 vertical 모드에서 레이아웃이 망가지지 않는 기본적인 높이가 보장되도록 합니다.

## Description

#### Before

<img width="220" height="127" alt="image" src="https://github.com/user-attachments/assets/551abae4-6caa-4de0-9983-3910ad6fe009" />

#### After

<img width="225" height="231" alt="image" src="https://github.com/user-attachments/assets/48330bf6-a29a-4b4d-b448-8b7e38f0a032" />

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
