### PR TITLE
refactor: rename component name variable

### DIFF
--- a/packages/vlossom/src/components/vs-accordion/VsAccordion.vue
+++ b/packages/vlossom/src/components/vs-accordion/VsAccordion.vue
@@ -27,9 +27,9 @@ import type { VsAccordionStyleSet } from './types';
 import VsResponsive from '@/components/vs-responsive/VsResponsive.vue';
 import VsExpandable from '@/components/vs-expandable/VsExpandable.vue';
 
-const name = VsComponent.VsAccordion;
+const componentName = VsComponent.VsAccordion;
 export default defineComponent({
-    name,
+    name: componentName,
     components: { VsResponsive, VsExpandable },
     props: {
         ...getColorSchemeProps(),
@@ -46,9 +46,9 @@ export default defineComponent({
     setup(props, { emit }) {
         const { colorScheme, styleSet, open, modelValue, disabled, primary } = toRefs(props);
 
-        const { colorSchemeClass } = useColorScheme(name, colorScheme);
+        const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { componentStyleSet, styleSetVariables } = useStyleSet<VsAccordionStyleSet>(name, styleSet);
+        const { componentStyleSet, styleSetVariables } = useStyleSet<VsAccordionStyleSet>(componentName, styleSet);
 
         const isOpen = ref(open.value || modelValue.value);
 

--- a/packages/vlossom/src/components/vs-avatar/VsAvatar.vue
+++ b/packages/vlossom/src/components/vs-avatar/VsAvatar.vue
@@ -11,9 +11,9 @@ import { VsComponent } from '@/declaration';
 import { getColorSchemeProps, getStyleSetProps } from '@/props';
 import { type VsAvatarStyleSet } from './types';
 
-const name = VsComponent.VsAvatar;
+const componentName = VsComponent.VsAvatar;
 export default defineComponent({
-    name,
+    name: componentName,
     props: {
         ...getColorSchemeProps(),
         ...getStyleSetProps<VsAvatarStyleSet>(),
@@ -21,9 +21,9 @@ export default defineComponent({
     setup(props) {
         const { colorScheme, styleSet } = toRefs(props);
 
-        const { colorSchemeClass } = useColorScheme(name, colorScheme);
+        const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { styleSetVariables } = useStyleSet<VsAvatarStyleSet>(name, styleSet);
+        const { styleSetVariables } = useStyleSet<VsAvatarStyleSet>(componentName, styleSet);
 
         return {
             colorSchemeClass,

--- a/packages/vlossom/src/components/vs-bar/VsBar.vue
+++ b/packages/vlossom/src/components/vs-bar/VsBar.vue
@@ -12,9 +12,9 @@ import { objectUtil } from '@/utils';
 import { getColorSchemeProps, getPositionProps, getStyleSetProps } from '@/props';
 import type { VsBarStyleSet } from './types';
 
-const name = VsComponent.VsBar;
+const componentName = VsComponent.VsBar;
 export default defineComponent({
-    name,
+    name: componentName,
     props: {
         ...getColorSchemeProps(),
         ...getStyleSetProps<VsBarStyleSet>(),
@@ -25,13 +25,17 @@ export default defineComponent({
     setup(props) {
         const { colorScheme, styleSet, primary, position } = toRefs(props);
 
-        const { colorSchemeClass } = useColorScheme(name, colorScheme);
+        const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
         const additionalStyleSet: ComputedRef<Partial<VsBarStyleSet>> = computed(() => {
             return objectUtil.shake({
                 position: position.value ? position.value : undefined,
             });
         });
-        const { componentStyleSet, styleSetVariables } = useStyleSet<VsBarStyleSet>(name, styleSet, additionalStyleSet);
+        const { componentStyleSet, styleSetVariables } = useStyleSet<VsBarStyleSet>(
+            componentName,
+            styleSet,
+            additionalStyleSet,
+        );
 
         const classObj = computed(() => ({
             'vs-primary': primary.value,

--- a/packages/vlossom/src/components/vs-block/VsBlock.vue
+++ b/packages/vlossom/src/components/vs-block/VsBlock.vue
@@ -18,9 +18,9 @@ import type { VsBlockStyleSet } from './types';
 
 import VsResponsive from '@/components/vs-responsive/VsResponsive.vue';
 
-const name = VsComponent.VsBlock;
+const componentName = VsComponent.VsBlock;
 export default defineComponent({
-    name,
+    name: componentName,
     components: { VsResponsive },
     props: {
         ...getResponsiveProps(),
@@ -29,8 +29,8 @@ export default defineComponent({
     },
     setup(props) {
         const { colorScheme, styleSet } = toRefs(props);
-        const { colorSchemeClass } = useColorScheme(name, colorScheme);
-        const { styleSetVariables } = useStyleSet<VsBlockStyleSet>(name, styleSet);
+        const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
+        const { styleSetVariables } = useStyleSet<VsBlockStyleSet>(componentName, styleSet);
 
         return {
             colorSchemeClass,

--- a/packages/vlossom/src/components/vs-button/VsButton.vue
+++ b/packages/vlossom/src/components/vs-button/VsButton.vue
@@ -25,9 +25,9 @@ import type { VsButtonStyleSet } from './types';
 
 import VsLoading from '@/components/vs-loading/VsLoading.vue';
 
-const name = VsComponent.VsButton;
+const componentName = VsComponent.VsButton;
 export default defineComponent({
-    name,
+    name: componentName,
     components: { VsLoading },
     props: {
         ...getColorSchemeProps(),
@@ -40,9 +40,9 @@ export default defineComponent({
 
         const buttonRef: TemplateRef<HTMLButtonElement> = useTemplateRef('buttonRef');
 
-        const { colorSchemeClass } = useColorScheme(name, colorScheme);
+        const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { componentStyleSet, styleSetVariables } = useStyleSet<VsButtonStyleSet>(name, styleSet);
+        const { componentStyleSet, styleSetVariables } = useStyleSet<VsButtonStyleSet>(componentName, styleSet);
 
         const classObj = computed(() => ({
             'vs-focusable': !disabled.value && !loading.value,

--- a/packages/vlossom/src/components/vs-checkbox/VsCheckbox.vue
+++ b/packages/vlossom/src/components/vs-checkbox/VsCheckbox.vue
@@ -66,9 +66,9 @@ import type { VsCheckboxStyleSet } from './types';
 
 import VsInputWrapper from '@/components/vs-input-wrapper/VsInputWrapper.vue';
 
-const name = VsComponent.VsCheckbox;
+const componentName = VsComponent.VsCheckbox;
 export default defineComponent({
-    name,
+    name: componentName,
     components: { VsInputWrapper },
     props: {
         ...getColorSchemeProps(),
@@ -115,9 +115,9 @@ export default defineComponent({
 
         const checkboxRef: TemplateRef<HTMLInputElement> = useTemplateRef('checkboxRef');
 
-        const { colorSchemeClass } = useColorScheme(name, colorScheme);
+        const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { componentStyleSet, styleSetVariables } = useStyleSet<VsCheckboxStyleSet>(name, styleSet);
+        const { componentStyleSet, styleSetVariables } = useStyleSet<VsCheckboxStyleSet>(componentName, styleSet);
 
         const inputValue = ref(modelValue.value);
 

--- a/packages/vlossom/src/components/vs-checkbox/VsCheckboxSet.vue
+++ b/packages/vlossom/src/components/vs-checkbox/VsCheckboxSet.vue
@@ -69,10 +69,10 @@ import { useVsCheckboxSetRules } from './vs-checkbox-set-rules';
 import VsInputWrapper from '@/components/vs-input-wrapper/VsInputWrapper.vue';
 import VsCheckbox from '@/components/vs-checkbox/VsCheckbox.vue';
 
-const name = VsComponent.VsCheckboxSet;
+const componentName = VsComponent.VsCheckboxSet;
 
 export default defineComponent({
-    name,
+    name: componentName,
     components: { VsInputWrapper, VsCheckbox },
     props: {
         ...getColorSchemeProps(),
@@ -87,12 +87,12 @@ export default defineComponent({
         max: {
             type: [Number, String],
             default: Number.MAX_SAFE_INTEGER,
-            validator: (value: number | string) => propsUtil.checkValidNumber(name, 'max', value),
+            validator: (value: number | string) => propsUtil.checkValidNumber(componentName, 'max', value),
         },
         min: {
             type: [Number, String],
             default: 0,
-            validator: (value: number | string) => propsUtil.checkValidNumber(name, 'min', value),
+            validator: (value: number | string) => propsUtil.checkValidNumber(componentName, 'min', value),
         },
         vertical: { type: Boolean, default: false },
         // v-model
@@ -126,9 +126,9 @@ export default defineComponent({
 
         const checkboxRefs: TemplateRef<InstanceType<typeof VsCheckbox>[]> = ref([]);
 
-        const { colorSchemeClass } = useColorScheme(name, colorScheme);
+        const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { componentStyleSet, styleSetVariables } = useStyleSet<VsCheckboxSetStyleSet>(name, styleSet);
+        const { componentStyleSet, styleSetVariables } = useStyleSet<VsCheckboxSetStyleSet>(componentName, styleSet);
 
         const { stateClasses } = useStateClass(state);
 

--- a/packages/vlossom/src/components/vs-chip/VsChip.vue
+++ b/packages/vlossom/src/components/vs-chip/VsChip.vue
@@ -31,9 +31,9 @@ import { closeIcon } from '@/icons';
 
 import VsRender from '@/components/vs-render/VsRender.vue';
 
-const name = VsComponent.VsChip;
+const componentName = VsComponent.VsChip;
 export default defineComponent({
-    name,
+    name: componentName,
     components: { VsRender },
     props: {
         ...getColorSchemeProps(),
@@ -47,9 +47,9 @@ export default defineComponent({
     setup(props, { slots }) {
         const { colorScheme, small, primary, outline, styleSet } = toRefs(props);
 
-        const { colorSchemeClass } = useColorScheme(name, colorScheme);
+        const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { styleSetVariables } = useStyleSet<VsChipStyleSet>(name, styleSet);
+        const { styleSetVariables } = useStyleSet<VsChipStyleSet>(componentName, styleSet);
 
         const hasIcon = computed((): boolean => !!slots['icon']);
 

--- a/packages/vlossom/src/components/vs-container/VsContainer.vue
+++ b/packages/vlossom/src/components/vs-container/VsContainer.vue
@@ -10,9 +10,9 @@ import { LAYOUT_STORE_KEY, VsComponent } from '@/declaration';
 import { LayoutStore } from '@/stores';
 import { objectUtil } from '@/utils';
 
-const name = VsComponent.VsContainer;
+const componentName = VsComponent.VsContainer;
 export default defineComponent({
-    name,
+    name: componentName,
     props: {
         tag: { type: String, default: 'div' },
     },

--- a/packages/vlossom/src/components/vs-dimmed/VsDimmed.vue
+++ b/packages/vlossom/src/components/vs-dimmed/VsDimmed.vue
@@ -12,9 +12,9 @@ import { VsComponent } from '@/declaration';
 
 import type { VsDimmedStyleSet } from './types';
 
-const name = VsComponent.VsDimmed;
+const componentName = VsComponent.VsDimmed;
 export default defineComponent({
-    name,
+    name: componentName,
     props: {
         ...getStyleSetProps<VsDimmedStyleSet>(),
 
@@ -27,7 +27,7 @@ export default defineComponent({
 
         const show = ref(modelValue.value);
 
-        const { styleSetVariables } = useStyleSet<VsDimmedStyleSet>(name, styleSet);
+        const { styleSetVariables } = useStyleSet<VsDimmedStyleSet>(componentName, styleSet);
 
         watch(modelValue, (value) => {
             show.value = value;

--- a/packages/vlossom/src/components/vs-divider/VsDivider.vue
+++ b/packages/vlossom/src/components/vs-divider/VsDivider.vue
@@ -10,9 +10,9 @@ import { VsComponent } from '@/declaration';
 
 import type { VsDividerStyleSet } from './types';
 
-const name = VsComponent.VsDivider;
+const componentName = VsComponent.VsDivider;
 export default defineComponent({
-    name,
+    name: componentName,
     props: {
         ...getColorSchemeProps(),
         ...getStyleSetProps<VsDividerStyleSet>(),
@@ -22,9 +22,9 @@ export default defineComponent({
     setup(props) {
         const { colorScheme, styleSet, responsive, vertical } = toRefs(props);
 
-        const { colorSchemeClass } = useColorScheme(name, colorScheme);
+        const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { styleSetVariables } = useStyleSet<VsDividerStyleSet>(name, styleSet);
+        const { styleSetVariables } = useStyleSet<VsDividerStyleSet>(componentName, styleSet);
 
         const classObj = computed(() => ({
             'vs-vertical': vertical.value,

--- a/packages/vlossom/src/components/vs-drawer/VsDrawer.vue
+++ b/packages/vlossom/src/components/vs-drawer/VsDrawer.vue
@@ -69,9 +69,9 @@ import VsDimmed from '@/components/vs-dimmed/VsDimmed.vue';
 import VsFocusTrap from '@/components/vs-focus-trap/VsFocusTrap.vue';
 import VsInnerScroll from '@/components/vs-inner-scroll/VsInnerScroll.vue';
 
-const name = VsComponent.VsDrawer;
+const componentName = VsComponent.VsDrawer;
 export default defineComponent({
-    name,
+    name: componentName,
     components: { VsDimmed, VsFocusTrap, VsInnerScroll },
     props: {
         ...getColorSchemeProps(),
@@ -117,7 +117,7 @@ export default defineComponent({
             xl: '80%',
         };
 
-        const { colorSchemeClass } = useColorScheme(name, colorScheme);
+        const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
         const drawerSize = computed(() => {
             if (!size.value) {
                 return DRAWER_SIZE.sm;
@@ -136,7 +136,7 @@ export default defineComponent({
         });
 
         const { styleSetVariables, componentStyleSet } = useStyleSet<VsDrawerStyleSet>(
-            name,
+            componentName,
             styleSet,
             additionalStyleSet,
         );

--- a/packages/vlossom/src/components/vs-expandable/VsExpandable.vue
+++ b/packages/vlossom/src/components/vs-expandable/VsExpandable.vue
@@ -15,9 +15,9 @@ import { VsComponent } from '@/declaration';
 import { useStyleSet } from '@/composables';
 import type { VsExpandableStyleSet } from './types';
 
-const name = VsComponent.VsExpandable;
+const componentName = VsComponent.VsExpandable;
 export default defineComponent({
-    name,
+    name: componentName,
     props: {
         ...getStyleSetProps<VsExpandableStyleSet>(),
         open: { type: Boolean, required: true, default: false },
@@ -25,7 +25,7 @@ export default defineComponent({
     setup(props) {
         const { styleSet } = toRefs(props);
 
-        const { componentStyleSet } = useStyleSet<VsExpandableStyleSet>(name, styleSet);
+        const { componentStyleSet } = useStyleSet<VsExpandableStyleSet>(componentName, styleSet);
 
         function beforeEnter(el: Element) {
             const element = el as HTMLElement;

--- a/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
+++ b/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
@@ -113,10 +113,10 @@ import VsChip from '@/components/vs-chip/VsChip.vue';
 import VsRender from '@/components/vs-render/VsRender.vue';
 import { closeIcon } from '@/icons';
 
-const name = VsComponent.VsFileDrop;
+const componentName = VsComponent.VsFileDrop;
 
 export default defineComponent({
-    name,
+    name: componentName,
     components: { VsInputWrapper, VsChip, VsRender },
     props: {
         ...getInputProps<FileDropValueType>(),
@@ -128,12 +128,12 @@ export default defineComponent({
         max: {
             type: [Number, String],
             default: Number.MAX_SAFE_INTEGER,
-            validator: (value: number | string) => propsUtil.checkValidNumber(name, 'max', value),
+            validator: (value: number | string) => propsUtil.checkValidNumber(componentName, 'max', value),
         },
         min: {
             type: [Number, String],
             default: Number.MIN_SAFE_INTEGER,
-            validator: (value: number | string) => propsUtil.checkValidNumber(name, 'min', value),
+            validator: (value: number | string) => propsUtil.checkValidNumber(componentName, 'min', value),
         },
         noClear: { type: Boolean, default: false },
         multiple: { type: Boolean, default: false },
@@ -171,9 +171,9 @@ export default defineComponent({
         const dragging = ref(false);
         const componentMessages: Ref<StateMessage[]> = ref([]);
 
-        const { colorSchemeClass } = useColorScheme(name, colorScheme);
+        const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
         const { styleSetVariables } = useStyleSet<VsFileDropStyleSet>(
-            name,
+            componentName,
             styleSet,
             computed(() => ({ width: width.value, height: height.value })),
         );

--- a/packages/vlossom/src/components/vs-focus-trap/VsFocusTrap.vue
+++ b/packages/vlossom/src/components/vs-focus-trap/VsFocusTrap.vue
@@ -15,9 +15,9 @@ import {
 import { VsComponent } from '@/declaration';
 import { logUtil, stringUtil } from '@/utils';
 
-const name = VsComponent.VsFocusTrap;
+const componentName = VsComponent.VsFocusTrap;
 export default defineComponent({
-    name,
+    name: componentName,
     props: {
         focusLock: { type: Boolean, default: true },
         initialFocusRef: { type: Object, default: null },
@@ -142,9 +142,9 @@ export default defineComponent({
                 }
             });
 
-            const componentName = stringUtil.kebabCase(VsComponent.VsFocusTrap);
-            return h('div', { class: componentName }, [
-                h('div', { id: `${componentName}-anchor`, tabindex: -1, ref: focusTrapRef }),
+            const className = stringUtil.kebabCase(VsComponent.VsFocusTrap);
+            return h('div', { class: className }, [
+                h('div', { id: `${className}-anchor`, tabindex: -1, ref: focusTrapRef }),
                 cloneVNode(vNodes[0], { ref: wrapperRef }),
             ]);
         }

--- a/packages/vlossom/src/components/vs-footer/VsFooter.vue
+++ b/packages/vlossom/src/components/vs-footer/VsFooter.vue
@@ -15,9 +15,9 @@ import type { VsFooterStyleSet } from './types';
 
 import VsBar from '@/components/vs-bar/VsBar.vue';
 
-const name = VsComponent.VsFooter;
+const componentName = VsComponent.VsFooter;
 export default defineComponent({
-    name,
+    name: componentName,
     components: { VsBar },
     props: {
         ...getColorSchemeProps(),
@@ -30,14 +30,14 @@ export default defineComponent({
     setup(props) {
         const { colorScheme, styleSet, primary, position, height } = toRefs(props);
 
-        const { colorSchemeClass } = useColorScheme(name, colorScheme);
+        const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
         const additionalStyleSet: ComputedRef<Partial<VsFooterStyleSet>> = computed(() => {
             return objectUtil.shake({
                 position: position.value ? position.value : undefined,
                 height: height.value ? height.value : undefined,
             });
         });
-        const { componentStyleSet } = useStyleSet<VsFooterStyleSet>(name, styleSet, additionalStyleSet);
+        const { componentStyleSet } = useStyleSet<VsFooterStyleSet>(componentName, styleSet, additionalStyleSet);
         const computedStyleSet: ComputedRef<VsFooterStyleSet> = computed(() => {
             const isPositioned = position.value && ['absolute', 'fixed', 'sticky'].includes(position.value);
             return objectUtil.shake({

--- a/packages/vlossom/src/components/vs-form/VsForm.vue
+++ b/packages/vlossom/src/components/vs-form/VsForm.vue
@@ -12,9 +12,9 @@ import { FormStore } from '@/stores';
 
 import VsGrid from '@/components/vs-grid/VsGrid.vue';
 
-const name = VsComponent.VsForm;
+const componentName = VsComponent.VsForm;
 export default defineComponent({
-    name,
+    name: componentName,
     components: { VsGrid },
     props: {
         ...getGridProps(),

--- a/packages/vlossom/src/components/vs-grid/VsGrid.vue
+++ b/packages/vlossom/src/components/vs-grid/VsGrid.vue
@@ -12,9 +12,9 @@ import { getGridProps, getStyleSetProps } from '@/props';
 import { stringUtil, objectUtil } from '@/utils';
 import type { VsGridStyleSet } from './types';
 
-const name = VsComponent.VsGrid;
+const componentName = VsComponent.VsGrid;
 export default defineComponent({
-    name,
+    name: componentName,
     props: {
         ...getGridProps(),
         ...getStyleSetProps<VsGridStyleSet>(),
@@ -35,7 +35,7 @@ export default defineComponent({
             });
         });
 
-        const { styleSetVariables } = useStyleSet(name, styleSet, additionalStyleSet);
+        const { styleSetVariables } = useStyleSet(componentName, styleSet, additionalStyleSet);
 
         return {
             styleSetVariables,

--- a/packages/vlossom/src/components/vs-header/VsHeader.vue
+++ b/packages/vlossom/src/components/vs-header/VsHeader.vue
@@ -15,9 +15,9 @@ import type { VsHeaderStyleSet } from './types';
 
 import VsBar from '@/components/vs-bar/VsBar.vue';
 
-const name = VsComponent.VsHeader;
+const componentName = VsComponent.VsHeader;
 export default defineComponent({
-    name,
+    name: componentName,
     components: { VsBar },
     props: {
         ...getColorSchemeProps(),
@@ -30,14 +30,14 @@ export default defineComponent({
     setup(props) {
         const { colorScheme, styleSet, primary, position, height } = toRefs(props);
 
-        const { colorSchemeClass } = useColorScheme(name, colorScheme);
+        const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
         const additionalStyleSet: ComputedRef<Partial<VsHeaderStyleSet>> = computed(() => {
             return objectUtil.shake({
                 position: position.value ? position.value : undefined,
                 height: height.value ? height.value : undefined,
             });
         });
-        const { componentStyleSet } = useStyleSet<VsHeaderStyleSet>(name, styleSet, additionalStyleSet);
+        const { componentStyleSet } = useStyleSet<VsHeaderStyleSet>(componentName, styleSet, additionalStyleSet);
         const computedStyleSet: ComputedRef<VsHeaderStyleSet> = computed(() => {
             const isPositioned = position.value && ['absolute', 'fixed', 'sticky'].includes(position.value);
             return objectUtil.shake({

--- a/packages/vlossom/src/components/vs-image/VsImage.vue
+++ b/packages/vlossom/src/components/vs-image/VsImage.vue
@@ -24,9 +24,9 @@ import VsSkeleton from '@/components/vs-skeleton/VsSkeleton.vue';
 
 import type { VsImageStyleSet } from './types';
 
-const name = VsComponent.VsImage;
+const componentName = VsComponent.VsImage;
 export default defineComponent({
-    name,
+    name: componentName,
     components: { VsSkeleton },
     props: {
         ...getStyleSetProps<VsImageStyleSet>(),
@@ -40,7 +40,7 @@ export default defineComponent({
     setup(props, { emit }) {
         const { styleSet, src, fallback, lazy } = toRefs(props);
 
-        const { styleSetVariables } = useStyleSet<VsImageStyleSet>(name, styleSet);
+        const { styleSetVariables } = useStyleSet<VsImageStyleSet>(componentName, styleSet);
 
         const vsImageRef = ref(null);
 

--- a/packages/vlossom/src/components/vs-index-view/VsIndexView.vue
+++ b/packages/vlossom/src/components/vs-index-view/VsIndexView.vue
@@ -5,10 +5,10 @@ import { getResponsiveProps } from '@/props';
 
 import VsResponsive from '@/components/vs-responsive/VsResponsive.vue';
 
-const name = VsComponent.VsIndexView;
+const componentName = VsComponent.VsIndexView;
 
 export default defineComponent({
-    name,
+    name: componentName,
     props: {
         ...getResponsiveProps(),
         keepAlive: { type: Boolean, default: false },

--- a/packages/vlossom/src/components/vs-inner-scroll/VsInnerScroll.vue
+++ b/packages/vlossom/src/components/vs-inner-scroll/VsInnerScroll.vue
@@ -21,9 +21,9 @@ import { getStyleSetProps } from '@/props';
 import { useStyleSet } from '@/composables';
 import type { VsInnerScrollStyleSet } from './types';
 
-const name = VsComponent.VsInnerScroll;
+const componentName = VsComponent.VsInnerScroll;
 export default defineComponent({
-    name,
+    name: componentName,
     props: {
         ...getStyleSetProps<VsInnerScrollStyleSet>(),
         hideScroll: { type: Boolean, default: false },
@@ -31,7 +31,7 @@ export default defineComponent({
     setup(props) {
         const { styleSet } = toRefs(props);
 
-        const { styleSetVariables } = useStyleSet(name, styleSet);
+        const { styleSetVariables } = useStyleSet(componentName, styleSet);
 
         return { styleSetVariables };
     },

--- a/packages/vlossom/src/components/vs-input-wrapper/VsInputWrapper.vue
+++ b/packages/vlossom/src/components/vs-input-wrapper/VsInputWrapper.vue
@@ -49,9 +49,9 @@ import type { VsInputWrapperStyleSet } from './types';
 import VsResponsive from '@/components/vs-responsive/VsResponsive.vue';
 import VsMessage from '@/components/vs-message/VsMessage.vue';
 
-const name = VsComponent.VsInputWrapper;
+const componentName = VsComponent.VsInputWrapper;
 export default defineComponent({
-    name,
+    name: componentName,
     components: { VsResponsive, VsMessage },
     props: {
         ...getResponsiveProps(),
@@ -67,7 +67,7 @@ export default defineComponent({
     setup(props) {
         const { shake, styleSet, small } = toRefs(props);
 
-        const { componentStyleSet, styleSetVariables } = useStyleSet(name, styleSet);
+        const { componentStyleSet, styleSetVariables } = useStyleSet(componentName, styleSet);
 
         const messageSize = computed(() => {
             if (componentStyleSet.value?.messages?.fontSize) {

--- a/packages/vlossom/src/components/vs-input/VsInput.vue
+++ b/packages/vlossom/src/components/vs-input/VsInput.vue
@@ -79,10 +79,10 @@ import { useVsInputRules } from './vs-input-rules';
 import VsInputWrapper from '@/components/vs-input-wrapper/VsInputWrapper.vue';
 import VsRender from '@/components/vs-render/VsRender.vue';
 
-const name = VsComponent.VsInput;
+const componentName = VsComponent.VsInput;
 
 export default defineComponent({
-    name,
+    name: componentName,
     components: { VsInputWrapper, VsRender },
     props: {
         ...getInputProps<VsInputValueType>(),
@@ -93,12 +93,12 @@ export default defineComponent({
         max: {
             type: [Number, String],
             default: Number.MAX_SAFE_INTEGER,
-            validator: (value: number | string) => propsUtil.checkValidNumber(name, 'max', value),
+            validator: (value: number | string) => propsUtil.checkValidNumber(componentName, 'max', value),
         },
         min: {
             type: [Number, String],
             default: Number.MIN_SAFE_INTEGER,
-            validator: (value: number | string) => propsUtil.checkValidNumber(name, 'min', value),
+            validator: (value: number | string) => propsUtil.checkValidNumber(componentName, 'min', value),
         },
         noClear: { type: Boolean, default: false },
         type: { type: String as PropType<VsInputType>, default: 'text' },
@@ -138,8 +138,8 @@ export default defineComponent({
         const inputRef: TemplateRef<HTMLInputElement> = useTemplateRef('inputRef');
         const isNumberInput = computed(() => type.value === 'number');
 
-        const { colorSchemeClass } = useColorScheme(name, colorScheme);
-        const { styleSetVariables } = useStyleSet<VsInputStyleSet>(name, styleSet);
+        const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
+        const { styleSetVariables } = useStyleSet<VsInputStyleSet>(componentName, styleSet);
         const { modifyStringValue } = useStringModifier(modelModifiers);
         const { requiredCheck, maxCheck, minCheck } = useVsInputRules(required, max, min, type);
 

--- a/packages/vlossom/src/components/vs-label-value/VsLabelValue.vue
+++ b/packages/vlossom/src/components/vs-label-value/VsLabelValue.vue
@@ -22,9 +22,9 @@ import type { VsLabelValueStyleSet } from './types';
 
 import VsResponsive from '@/components/vs-responsive/VsResponsive.vue';
 
-const name = VsComponent.VsLabelValue;
+const componentName = VsComponent.VsLabelValue;
 export default defineComponent({
-    name,
+    name: componentName,
     components: { VsResponsive },
     props: {
         ...getResponsiveProps(),
@@ -36,9 +36,9 @@ export default defineComponent({
     setup(props) {
         const { colorScheme, styleSet, dense, primary } = toRefs(props);
 
-        const { colorSchemeClass } = useColorScheme(name, colorScheme);
+        const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { componentStyleSet, styleSetVariables } = useStyleSet<VsLabelValueStyleSet>(name, styleSet);
+        const { componentStyleSet, styleSetVariables } = useStyleSet<VsLabelValueStyleSet>(componentName, styleSet);
 
         const classObj = computed(() => ({
             'vs-dense': dense.value,

--- a/packages/vlossom/src/components/vs-layout/VsLayout.vue
+++ b/packages/vlossom/src/components/vs-layout/VsLayout.vue
@@ -9,9 +9,9 @@ import { defineComponent, provide } from 'vue';
 import { LayoutStore } from '@/stores';
 import { LAYOUT_STORE_KEY, VsComponent } from '@/declaration';
 
-const name = VsComponent.VsLayout;
+const componentName = VsComponent.VsLayout;
 export default defineComponent({
-    name,
+    name: componentName,
     setup() {
         const layoutStore = LayoutStore.getDefaultLayoutStore();
 

--- a/packages/vlossom/src/components/vs-loading/VsLoading.vue
+++ b/packages/vlossom/src/components/vs-loading/VsLoading.vue
@@ -16,9 +16,9 @@ import { useColorScheme, useStyleSet } from '@/composables';
 import { stringUtil, objectUtil } from '@/utils';
 import type { VsLoadingStyleSet } from './types';
 
-const name = VsComponent.VsLoading;
+const componentName = VsComponent.VsLoading;
 export default defineComponent({
-    name,
+    name: componentName,
     props: {
         ...getColorSchemeProps(),
         ...getStyleSetProps<VsLoadingStyleSet>(),
@@ -28,7 +28,7 @@ export default defineComponent({
     setup(props) {
         const { colorScheme, styleSet, width, height } = toRefs(props);
 
-        const { colorSchemeClass } = useColorScheme(name, colorScheme);
+        const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
         const additionalStyleSet = computed(() => {
             return objectUtil.shake({
@@ -37,7 +37,7 @@ export default defineComponent({
             });
         });
 
-        const { styleSetVariables } = useStyleSet(name, styleSet, additionalStyleSet);
+        const { styleSetVariables } = useStyleSet(componentName, styleSet, additionalStyleSet);
 
         return { colorSchemeClass, styleSetVariables };
     },

--- a/packages/vlossom/src/components/vs-message/VsMessage.vue
+++ b/packages/vlossom/src/components/vs-message/VsMessage.vue
@@ -15,9 +15,9 @@ import { messageIcons } from './icons';
 
 import VsRender from '@/components/vs-render/VsRender.vue';
 
-const name = VsComponent.VsMessage;
+const componentName = VsComponent.VsMessage;
 export default defineComponent({
-    name,
+    name: componentName,
     components: { VsRender },
     props: {
         size: { type: [String, Number], default: '1rem' },

--- a/packages/vlossom/src/components/vs-modal/VsModal.vue
+++ b/packages/vlossom/src/components/vs-modal/VsModal.vue
@@ -6,9 +6,9 @@ import { getOverlayProps } from '@/props';
 import type { VsModalNodeStyleSet } from './types';
 import { useVlossom } from '@/framework';
 
-const name = VsComponent.VsModal;
+const componentName = VsComponent.VsModal;
 export default defineComponent({
-    name,
+    name: componentName,
     props: {
         ...getColorSchemeProps(),
         ...getStyleSetProps<VsModalNodeStyleSet>(),

--- a/packages/vlossom/src/components/vs-modal/VsModalNode.vue
+++ b/packages/vlossom/src/components/vs-modal/VsModalNode.vue
@@ -26,9 +26,9 @@ import type { VsModalNodeStyleSet } from './types';
 import VsDimmed from '@/components/vs-dimmed/VsDimmed.vue';
 import VsFocusTrap from '@/components/vs-focus-trap/VsFocusTrap.vue';
 
-const name = VsComponent.VsModalNode;
+const componentName = VsComponent.VsModalNode;
 export default defineComponent({
-    name,
+    name: componentName,
     components: { VsDimmed, VsFocusTrap },
     props: {
         ...getColorSchemeProps(),
@@ -44,7 +44,7 @@ export default defineComponent({
     setup(props, { emit }) {
         const { colorScheme, styleSet, dimClose, size, id, escClose, callbacks } = toRefs(props);
 
-        const { colorSchemeClass } = useColorScheme(name, colorScheme);
+        const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
         const modalWidthSize: Record<Size, string> = {
             xs: '20%',
@@ -90,7 +90,7 @@ export default defineComponent({
         });
 
         const { styleSetVariables, componentStyleSet } = useStyleSet<VsModalNodeStyleSet>(
-            name,
+            componentName,
             styleSet,
             additionalStyleSet,
         );

--- a/packages/vlossom/src/components/vs-modal/VsModalView.vue
+++ b/packages/vlossom/src/components/vs-modal/VsModalView.vue
@@ -34,9 +34,9 @@ import type { ModalInfo } from '@/plugins';
 import VsModalNode from '@/components/vs-modal/VsModalNode.vue';
 import VsRender from '@/components/vs-render/VsRender.vue';
 
-const name = VsComponent.VsModalView;
+const componentName = VsComponent.VsModalView;
 export default defineComponent({
-    name,
+    name: componentName,
     components: { VsModalNode, VsRender },
     props: {
         container: { type: String, default: 'body' },

--- a/packages/vlossom/src/components/vs-page/VsPage.vue
+++ b/packages/vlossom/src/components/vs-page/VsPage.vue
@@ -18,16 +18,16 @@ import { VsComponent } from '@/declaration';
 import { getStyleSetProps } from '@/props';
 import type { VsPageStyleSet } from './types';
 
-const name = VsComponent.VsPage;
+const componentName = VsComponent.VsPage;
 export default defineComponent({
-    name,
+    name: componentName,
     props: {
         ...getStyleSetProps<VsPageStyleSet>(),
     },
     setup(props) {
         const { styleSet } = toRefs(props);
 
-        const { styleSetVariables } = useStyleSet<VsPageStyleSet>(name, styleSet);
+        const { styleSetVariables } = useStyleSet<VsPageStyleSet>(componentName, styleSet);
 
         return {
             styleSetVariables,

--- a/packages/vlossom/src/components/vs-pagination/VsPagination.vue
+++ b/packages/vlossom/src/components/vs-pagination/VsPagination.vue
@@ -97,9 +97,9 @@ import { paginationIcons } from './icons';
 import VsRender from '@/components/vs-render/VsRender.vue';
 import VsButton from '@/components/vs-button/VsButton.vue';
 
-const name = VsComponent.VsPagination;
+const componentName = VsComponent.VsPagination;
 export default defineComponent({
-    name,
+    name: componentName,
     components: { VsRender, VsButton },
     props: {
         ...getColorSchemeProps(),
@@ -114,7 +114,7 @@ export default defineComponent({
             validator: (value: number) => {
                 const isValid = value > 0;
                 if (!isValid) {
-                    logUtil.propError(name, 'length', 'length must be greater than 0');
+                    logUtil.propError(componentName, 'length', 'length must be greater than 0');
                 }
                 return isValid;
             },
@@ -126,7 +126,7 @@ export default defineComponent({
             validator: (value: number) => {
                 const isValid = value > 0;
                 if (!isValid) {
-                    logUtil.propError(name, 'showingLength', 'showingLength must be greater than 0');
+                    logUtil.propError(componentName, 'showingLength', 'showingLength must be greater than 0');
                 }
                 return isValid;
             },
@@ -140,10 +140,10 @@ export default defineComponent({
     setup(props, { emit }) {
         const { colorScheme, styleSet, modelValue, length, showingLength } = toRefs(props);
 
-        const { computedColorScheme, colorSchemeClass } = useColorScheme(name, colorScheme);
+        const { computedColorScheme, colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
         const { componentStyleSet, styleSetVariables } = useStyleSet<VsPaginationStyleSet>(
-            name,
+            componentName,
             styleSet,
             ref({
                 controlButton: { padding: '0.4rem' },

--- a/packages/vlossom/src/components/vs-progress/VsProgress.vue
+++ b/packages/vlossom/src/components/vs-progress/VsProgress.vue
@@ -15,9 +15,9 @@ import { VsComponent } from '@/declaration';
 import { getColorSchemeProps, getStyleSetProps } from '@/props';
 import type { VsProgressStyleSet } from './types';
 
-const name = VsComponent.VsProgress;
+const componentName = VsComponent.VsProgress;
 export default defineComponent({
-    name,
+    name: componentName,
     props: {
         ...getColorSchemeProps(),
         ...getStyleSetProps<VsProgressStyleSet>(),
@@ -42,9 +42,9 @@ export default defineComponent({
     setup(props) {
         const { colorScheme, styleSet } = toRefs(props);
 
-        const { colorSchemeClass } = useColorScheme(name, colorScheme);
+        const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { styleSetVariables } = useStyleSet<VsProgressStyleSet>(name, styleSet);
+        const { styleSetVariables } = useStyleSet<VsProgressStyleSet>(componentName, styleSet);
 
         const { value, max } = toRefs(props);
 

--- a/packages/vlossom/src/components/vs-render/VsRender.vue
+++ b/packages/vlossom/src/components/vs-render/VsRender.vue
@@ -2,9 +2,9 @@
 import { defineComponent, h, toRefs, type Component, type PropType } from 'vue';
 import { VsComponent } from '@/declaration';
 
-const name = VsComponent.VsRender;
+const componentName = VsComponent.VsRender;
 export default defineComponent({
-    name,
+    name: componentName,
     props: {
         content: {
             type: [String, Object, Function] as PropType<string | Component>,

--- a/packages/vlossom/src/components/vs-responsive/VsResponsive.vue
+++ b/packages/vlossom/src/components/vs-responsive/VsResponsive.vue
@@ -10,9 +10,9 @@ import { getResponsiveProps } from '@/props';
 import { VsComponent } from '@/declaration';
 import { useResponsive } from './composables/responsive-composable';
 
-const name = VsComponent.VsResponsive;
+const componentName = VsComponent.VsResponsive;
 export default defineComponent({
-    name,
+    name: componentName,
     props: {
         ...getResponsiveProps(),
         tag: { type: String, default: 'div' },

--- a/packages/vlossom/src/components/vs-search-input/VsSearchInput.vue
+++ b/packages/vlossom/src/components/vs-search-input/VsSearchInput.vue
@@ -70,9 +70,9 @@ import type { VsInputRef, VsInputStyleSet } from '@/components/vs-input/types';
 import VsInput from '@/components/vs-input/VsInput.vue';
 import VsToggle from '@/components/vs-toggle/VsToggle.vue';
 
-const name = VsComponent.VsSearchInput;
+const componentName = VsComponent.VsSearchInput;
 export default defineComponent({
-    name,
+    name: componentName,
     components: { VsInput, VsToggle },
     props: {
         ...getColorSchemeProps(),
@@ -99,8 +99,8 @@ export default defineComponent({
         const isCaseSensitiveOn = ref(caseSensitive.value);
         const isRegexOn = ref(regex.value);
 
-        const { computedColorScheme } = useColorScheme(name, colorScheme);
-        const { componentStyleSet, styleSetVariables } = useStyleSet<VsSearchInputStyleSet>(name, styleSet);
+        const { computedColorScheme } = useColorScheme(componentName, colorScheme);
+        const { componentStyleSet, styleSetVariables } = useStyleSet<VsSearchInputStyleSet>(componentName, styleSet);
 
         const computedStyleSet: ComputedRef<VsInputStyleSet> = computed(() => {
             return {

--- a/packages/vlossom/src/components/vs-skeleton/VsSkeleton.vue
+++ b/packages/vlossom/src/components/vs-skeleton/VsSkeleton.vue
@@ -14,9 +14,9 @@ import { getColorSchemeProps, getStyleSetProps } from '@/props';
 import { useColorScheme, useStyleSet } from '@/composables';
 import type { VsSkeletonStyleSet } from './types';
 
-const name = VsComponent.VsSkeleton;
+const componentName = VsComponent.VsSkeleton;
 export default defineComponent({
-    name,
+    name: componentName,
     props: {
         ...getColorSchemeProps(),
         ...getStyleSetProps<VsSkeletonStyleSet>(),
@@ -24,9 +24,9 @@ export default defineComponent({
     setup(props) {
         const { colorScheme, styleSet } = toRefs(props);
 
-        const { colorSchemeClass } = useColorScheme(name, colorScheme);
+        const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { styleSetVariables } = useStyleSet<VsSkeletonStyleSet>(name, styleSet);
+        const { styleSetVariables } = useStyleSet<VsSkeletonStyleSet>(componentName, styleSet);
 
         return {
             colorSchemeClass,

--- a/packages/vlossom/src/components/vs-steps/VsSteps.vue
+++ b/packages/vlossom/src/components/vs-steps/VsSteps.vue
@@ -71,9 +71,9 @@ import VsResponsive from '@/components/vs-responsive/VsResponsive.vue';
 import type { VsStepsStyleSet } from './types';
 import { objectUtil } from '@/utils';
 
-const name = VsComponent.VsSteps;
+const componentName = VsComponent.VsSteps;
 export default defineComponent({
-    name,
+    name: componentName,
     components: { VsResponsive },
     props: {
         ...getResponsiveProps(),
@@ -97,7 +97,7 @@ export default defineComponent({
     emits: ['update:modelValue', 'change'],
     setup(props, { emit }) {
         const { colorScheme, styleSet, width, height, disabled, gap, steps, modelValue, vertical } = toRefs(props);
-        const { colorSchemeClass } = useColorScheme(name, colorScheme);
+        const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
         const gapCount = computed(() => steps.value.length - 1);
 
@@ -110,7 +110,7 @@ export default defineComponent({
             });
         });
 
-        const { styleSetVariables } = useStyleSet<VsStepsStyleSet>(name, styleSet, additionalStyleSet);
+        const { styleSetVariables } = useStyleSet<VsStepsStyleSet>(componentName, styleSet, additionalStyleSet);
 
         const stepRefs: Ref<HTMLElement[]> = ref([]);
 

--- a/packages/vlossom/src/components/vs-switch/VsSwitch.vue
+++ b/packages/vlossom/src/components/vs-switch/VsSwitch.vue
@@ -60,10 +60,10 @@ import type { VsSwitchStyleSet } from './types';
 
 import VsInputWrapper from '@/components/vs-input-wrapper/VsInputWrapper.vue';
 
-const name = VsComponent.VsSwitch;
+const componentName = VsComponent.VsSwitch;
 
 export default defineComponent({
-    name,
+    name: componentName,
     components: { VsInputWrapper },
     props: {
         ...getColorSchemeProps(),
@@ -107,9 +107,9 @@ export default defineComponent({
 
         const switchRef: TemplateRef<HTMLInputElement> = useTemplateRef('switchRef');
 
-        const { colorSchemeClass } = useColorScheme(name, colorScheme);
+        const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { componentStyleSet, styleSetVariables } = useStyleSet<VsSwitchStyleSet>(name, styleSet);
+        const { componentStyleSet, styleSetVariables } = useStyleSet<VsSwitchStyleSet>(componentName, styleSet);
 
         const inputValue = ref(modelValue.value);
 

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.vue
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.vue
@@ -74,9 +74,9 @@ import { vsTabsIcons } from './icons';
 import VsResponsive from '@/components/vs-responsive/VsResponsive.vue';
 import { objectUtil, stringUtil } from '@/utils';
 
-const name = VsComponent.VsTabs;
+const componentName = VsComponent.VsTabs;
 export default defineComponent({
-    name,
+    name: componentName,
     components: { VsButton, VsResponsive },
     props: {
         ...getResponsiveProps(),
@@ -105,7 +105,7 @@ export default defineComponent({
     setup(props, { emit }) {
         const { colorScheme, styleSet, height, dense, disabled, primary, scrollButtons, tabs, modelValue, vertical } =
             toRefs(props);
-        const { colorSchemeClass } = useColorScheme(name, colorScheme);
+        const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
         const tabsWrapRef: Ref<HTMLElement | null> = ref(null);
         const tabRefs: Ref<HTMLElement[]> = ref([]);
@@ -116,7 +116,7 @@ export default defineComponent({
                 height: height.value === 'auto' ? undefined : stringUtil.toStringSize(height.value),
             });
         });
-        const { styleSetVariables } = useStyleSet<VsTabsStyleSet>(name, styleSet, additionalStyleSet);
+        const { styleSetVariables } = useStyleSet<VsTabsStyleSet>(componentName, styleSet, additionalStyleSet);
 
         const {
             selectedIndex,

--- a/packages/vlossom/src/components/vs-text-wrap/VsTextWrap.vue
+++ b/packages/vlossom/src/components/vs-text-wrap/VsTextWrap.vue
@@ -39,9 +39,9 @@ import type { VsTextWrapStyleSet } from './types';
 import { checkIcon, copyIcon, linkIcon } from './icons';
 import VsRender from '@/components/vs-render/VsRender.vue';
 
-const name = VsComponent.VsTextWrap;
+const componentName = VsComponent.VsTextWrap;
 export default defineComponent({
-    name,
+    name: componentName,
     components: { VsRender },
     props: {
         ...getStyleSetProps<VsTextWrapStyleSet>(),
@@ -53,7 +53,7 @@ export default defineComponent({
     setup(props, { emit }) {
         const { styleSet, link, width } = toRefs(props);
         const { styleSetVariables } = useStyleSet<VsTextWrapStyleSet>(
-            name,
+            componentName,
             styleSet,
             computed(() => ({ width: width.value })),
         );

--- a/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
+++ b/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
@@ -53,10 +53,10 @@ import { useVsTextareaRules } from './vs-textarea-rules';
 import { propsUtil } from '@/utils';
 import type { StringModifiers } from '@/declaration';
 
-const name = VsComponent.VsTextarea;
+const componentName = VsComponent.VsTextarea;
 
 export default defineComponent({
-    name,
+    name: componentName,
     components: { VsInputWrapper },
     props: {
         ...getInputProps<VsTextareaValueType>(),
@@ -67,12 +67,12 @@ export default defineComponent({
         max: {
             type: [Number, String],
             default: Number.MAX_SAFE_INTEGER,
-            validator: (value: number | string) => propsUtil.checkValidNumber(name, 'max', value),
+            validator: (value: number | string) => propsUtil.checkValidNumber(componentName, 'max', value),
         },
         min: {
             type: [Number, String],
             default: Number.MIN_SAFE_INTEGER,
-            validator: (value: number | string) => propsUtil.checkValidNumber(name, 'min', value),
+            validator: (value: number | string) => propsUtil.checkValidNumber(componentName, 'min', value),
         },
         // v-model
         modelValue: { type: String, default: '' },
@@ -104,8 +104,8 @@ export default defineComponent({
         const textareaRef: TemplateRef<HTMLTextAreaElement> = useTemplateRef('textareaRef');
         const inputValue: Ref<VsTextareaValueType> = ref(modelValue.value);
 
-        const { colorSchemeClass } = useColorScheme(name, colorScheme);
-        const { styleSetVariables } = useStyleSet<VsTextareaStyleSet>(name, styleSet);
+        const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
+        const { styleSetVariables } = useStyleSet<VsTextareaStyleSet>(componentName, styleSet);
         const { modifyStringValue } = useStringModifier(modelModifiers);
         const { requiredCheck, maxCheck, minCheck } = useVsTextareaRules(required, max, min);
 

--- a/packages/vlossom/src/components/vs-theme-button/VsThemeButton.vue
+++ b/packages/vlossom/src/components/vs-theme-button/VsThemeButton.vue
@@ -26,9 +26,9 @@ import { themeDarkIcon, themeLightIcon } from './icons';
 
 import VsToggle from '@/components/vs-toggle/VsToggle.vue';
 
-const name = VsComponent.VsThemeButton;
+const componentName = VsComponent.VsThemeButton;
 export default defineComponent({
-    name,
+    name: componentName,
     components: { VsToggle },
     props: {
         ...getColorSchemeProps(),
@@ -40,11 +40,8 @@ export default defineComponent({
         const $vs = useVlossom();
 
         const { colorScheme, styleSet } = toRefs(props);
-
-        const { colorSchemeClass } = useColorScheme(name, colorScheme);
-
-        const { componentStyleSet, styleSetVariables } = useStyleSet<VsThemeButtonStyleSet>(name, styleSet);
-
+        const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
+        const { componentStyleSet, styleSetVariables } = useStyleSet<VsThemeButtonStyleSet>(componentName, styleSet);
         const isDarkTheme: Ref<boolean> = computed(() => $vs.theme === 'dark');
 
         function changeTheme(isDark: boolean) {

--- a/packages/vlossom/src/components/vs-toast/VsToast.vue
+++ b/packages/vlossom/src/components/vs-toast/VsToast.vue
@@ -30,9 +30,9 @@ import type { VsToastStyleSet } from './types';
 import VsRender from '@/components/vs-render/VsRender.vue';
 import VsButton from '@/components/vs-button/VsButton.vue';
 
-const name = VsComponent.VsToast;
+const componentName = VsComponent.VsToast;
 export default defineComponent({
-    name,
+    name: componentName,
     components: { VsRender, VsButton },
     props: {
         ...getColorSchemeProps(),
@@ -45,9 +45,9 @@ export default defineComponent({
     setup(props, { emit }) {
         const { colorScheme, styleSet, autoClose, timeout } = toRefs(props);
 
-        const { computedColorScheme, colorSchemeClass } = useColorScheme(name, colorScheme);
+        const { computedColorScheme, colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { styleSetVariables } = useStyleSet<VsToastStyleSet>(name, styleSet);
+        const { styleSetVariables } = useStyleSet<VsToastStyleSet>(componentName, styleSet);
 
         const holdToClose = ref(false);
         let timer: any = null;

--- a/packages/vlossom/src/components/vs-toast/VsToastView.vue
+++ b/packages/vlossom/src/components/vs-toast/VsToastView.vue
@@ -33,9 +33,9 @@ import type { ToastInfo } from '@/plugins';
 import VsToast from './VsToast.vue';
 import VsRender from '@/components/vs-render/VsRender.vue';
 
-const name = VsComponent.VsToastView;
+const componentName = VsComponent.VsToastView;
 export default defineComponent({
-    name,
+    name: componentName,
     components: { VsToast, VsRender },
     props: {
         container: { type: String, default: 'body' },

--- a/packages/vlossom/src/components/vs-toggle/VsToggle.vue
+++ b/packages/vlossom/src/components/vs-toggle/VsToggle.vue
@@ -28,9 +28,9 @@ import type { VsToggleStyleSet } from './types';
 
 import VsButton from '@/components/vs-button/VsButton.vue';
 
-const name = VsComponent.VsToggle;
+const componentName = VsComponent.VsToggle;
 export default defineComponent({
-    name,
+    name: componentName,
     components: { VsButton },
     props: {
         ...getColorSchemeProps(),
@@ -44,9 +44,9 @@ export default defineComponent({
     setup(props, { emit }) {
         const { colorScheme, styleSet, modelValue, disabled } = toRefs(props);
 
-        const { colorSchemeClass } = useColorScheme(name, colorScheme);
+        const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { componentStyleSet, styleSetVariables } = useStyleSet<VsToggleStyleSet>(name, styleSet);
+        const { componentStyleSet, styleSetVariables } = useStyleSet<VsToggleStyleSet>(componentName, styleSet);
 
         const isToggled = ref(modelValue.value);
 

--- a/packages/vlossom/src/components/vs-tooltip/VsTooltip.vue
+++ b/packages/vlossom/src/components/vs-tooltip/VsTooltip.vue
@@ -48,9 +48,9 @@ import { getColorSchemeProps, getStyleSetProps } from '@/props';
 import { stringUtil } from '@/utils';
 import type { VsTooltipStyleSet } from './types';
 
-const name = VsComponent.VsTooltip;
+const componentName = VsComponent.VsTooltip;
 export default defineComponent({
-    name,
+    name: componentName,
     props: {
         ...getColorSchemeProps(),
         ...getStyleSetProps<VsTooltipStyleSet>(),
@@ -99,9 +99,9 @@ export default defineComponent({
         const triggerRef: Ref<HTMLElement | null> = ref(null);
         const tooltipRef: Ref<HTMLElement | null> = ref(null);
 
-        const { colorSchemeClass } = useColorScheme(name, colorScheme);
+        const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { styleSetVariables } = useStyleSet<VsTooltipStyleSet>(name, styleSet);
+        const { styleSetVariables } = useStyleSet<VsTooltipStyleSet>(componentName, styleSet);
 
         const { appendOverlayDom } = useOverlayDom();
 

--- a/packages/vlossom/src/components/vs-visible-render/VsVisibleRender.vue
+++ b/packages/vlossom/src/components/vs-visible-render/VsVisibleRender.vue
@@ -19,9 +19,9 @@ import {
 import { VsComponent } from '@/declaration';
 import { domUtil, logUtil, stringUtil } from '@/utils';
 
-const name = VsComponent.VsVisibleRender;
+const componentName = VsComponent.VsVisibleRender;
 export default defineComponent({
-    name,
+    name: componentName,
     props: {
         disabled: { type: Boolean, default: false },
         height: { type: [String, Number] },
@@ -33,7 +33,7 @@ export default defineComponent({
             validator: (value: number) => {
                 const isValid = value >= 0 && value <= 1;
                 if (!isValid) {
-                    logUtil.propError(name, 'threshold', 'invalid threshold value');
+                    logUtil.propError(componentName, 'threshold', 'invalid threshold value');
                     return false;
                 }
                 return true;


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Refactor (refactor)

## Summary

컴포넌트 내 `name` 변수를 `componentName`으로 변경합니다.

## Description

컴포넌트 내 `name` 변수를 다음과 같이 변경해 `getInputProps`의 `name` 속성과 중복되는 문제를 수정합니다.

```ts
const compoentName = VsComponent.VsXXX
export default definedComponent({
    name: componentName,
    ...
});
```

- Closes #165 