### PR TITLE
refactor(VsThemeButton): replace v-html with VsRender component in VsThemeButton

### DIFF
--- a/packages/vlossom/src/components/vs-theme-button/VsThemeButton.vue
+++ b/packages/vlossom/src/components/vs-theme-button/VsThemeButton.vue
@@ -10,8 +10,12 @@
         :loading="loading"
         @toggle="changeTheme"
     >
-        <i class="vs-theme-icon vs-theme-light" :class="{ 'vs-on': !isDarkTheme }" v-html="themeLightIcon" />
-        <i class="vs-theme-icon vs-theme-dark" :class="{ 'vs-on': isDarkTheme }" v-html="themeDarkIcon" />
+        <i class="vs-theme-icon vs-theme-light" :class="{ 'vs-on': !isDarkTheme }">
+            <vs-render :content="themeLightIcon" />
+        </i>
+        <i class="vs-theme-icon vs-theme-dark" :class="{ 'vs-on': isDarkTheme }">
+            <vs-render :content="themeDarkIcon" />
+        </i>
     </vs-toggle>
 </template>
 
@@ -24,12 +28,13 @@ import { useColorScheme, useStyleSet } from '@/composables';
 import type { VsThemeButtonStyleSet } from './types';
 import { themeDarkIcon, themeLightIcon } from './icons';
 
+import VsRender from '@/components/vs-render/VsRender.vue';
 import VsToggle from '@/components/vs-toggle/VsToggle.vue';
 
 const componentName = VsComponent.VsThemeButton;
 export default defineComponent({
     name: componentName,
-    components: { VsToggle },
+    components: { VsToggle, VsRender },
     props: {
         ...getColorSchemeProps(),
         ...getStyleSetProps<VsThemeButtonStyleSet>(),
@@ -38,7 +43,6 @@ export default defineComponent({
     emits: ['change'],
     setup(props, { emit }) {
         const $vs = useVlossom();
-
         const { colorScheme, styleSet } = toRefs(props);
         const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
         const { componentStyleSet, styleSetVariables } = useStyleSet<VsThemeButtonStyleSet>(componentName, styleSet);


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Refactor (refactor)

## Summary

`VsThemeButton`의 아이콘 렌더링 방식을 `v-html`에서 `VsRender` 컴포넌트로 변경합니다.

## Description

- 테마 아이콘의 렌더링 방식을 변경합니다.


- Closes #172 
