### PR TITLE
fix(VsTabs): add resize observer for responsive tab height adjustment

### DIFF
--- a/packages/vlossom/src/components/vs-tabs/VsTabs.css
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.css
@@ -1,14 +1,5 @@
 @reference 'tailwindcss';
 
-@keyframes vs-tabs-display-check {
-    from {
-        opacity: 0.99;
-    }
-    to {
-        opacity: 1;
-    }
-}
-
 .vs-tabs {
     --vs-tabs-backgroundColor: initial;
     --vs-tabs-border: initial;
@@ -32,8 +23,6 @@
 
     .vs-tabs-wrap {
         @apply relative flex w-full overflow-auto pb-1;
-
-        animation: vs-tabs-display-check 0.001s;
 
         .vs-tab-list {
             @apply relative m-0 flex flex-1 list-none flex-nowrap items-center;

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.vue
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.vue
@@ -61,9 +61,9 @@ import {
     onUnmounted,
     nextTick,
     type Ref,
-    type CSSProperties,
     type PropType,
     type ComputedRef,
+    onUpdated,
 } from 'vue';
 import { useColorScheme, useStyleSet, useIndexSelector } from '@/composables';
 import { getColorSchemeProps, getStyleSetProps, getResponsiveProps } from '@/props';
@@ -110,24 +110,13 @@ export default defineComponent({
         const tabsWrapRef: Ref<HTMLElement | null> = ref(null);
         const tabRefs: Ref<HTMLElement[]> = ref([]);
         const visibleTabCount = ref(0);
-        const indicatorStyle = ref<CSSProperties | null>(null);
+        const indicatorStyle = ref<Record<string, string> | null>(null);
         const additionalStyleSet: ComputedRef<Partial<VsTabsStyleSet>> = computed(() => {
             return objectUtil.shake({
                 height: height.value === 'auto' ? undefined : stringUtil.toStringSize(height.value),
             });
         });
         const { styleSetVariables } = useStyleSet<VsTabsStyleSet>(componentName, styleSet, additionalStyleSet);
-
-        function handleResize() {
-            calculateVisibleTabCount();
-            updateIndicatorPosition();
-        }
-
-        function handleDisplayChange(event: AnimationEvent) {
-            if (event.animationName === 'vs-tabs-display-check') {
-                handleResize();
-            }
-        }
 
         const {
             selectedIndex,
@@ -220,19 +209,28 @@ export default defineComponent({
             }
         }
 
+        function handleResize() {
+            calculateVisibleTabCount();
+            updateIndicatorPosition();
+        }
+
         onMounted(() => {
             selectedIndex.value = findActiveIndexForwardFrom(modelValue.value);
             calculateVisibleTabCount();
             nextTick(() => {
                 updateIndicatorPosition();
             });
-
-            tabsWrapRef.value?.addEventListener('animationstart', handleDisplayChange);
             window.addEventListener('resize', handleResize);
         });
 
+        onUpdated(() => {
+            calculateVisibleTabCount();
+            nextTick(() => {
+                updateIndicatorPosition();
+            });
+        });
+
         onUnmounted(() => {
-            tabsWrapRef.value?.removeEventListener('animationstart', handleDisplayChange);
             window.removeEventListener('resize', handleResize);
         });
 


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary

`v-show`로 숨겨진 `vs-tabs`가 표시될 때 indicator가 올바르게 렌더링되지 않는 버그를 수정합니다.

## Description

display: none → display: block 전환 시 CSS animation이 재시작되는 특성을 이용해, `animationstart` 이벤트 발생 시 indicator의 위치를 재계산합니다.

## Screenshots or Recordings

#### 테스트 코드

```html
<template>
    <vs-tabs v-model="parentTab" :tabs="['test1', 'test2', 'test3']" />
    <vs-tabs v-show="parentTab === 1" v-model="childTab" :tabs="['View 1', 'View 2', 'View 3']" />
</template>

<script lang="ts">
import { defineComponent, ref } from 'vue';

export default defineComponent({
    name: 'App',
    setup() {
        const parentTab = ref(0);
        const childTab = ref(1);
        return { parentTab, childTab };
    },
});
</script>
```

![vs-tabs-indicator](https://github.com/user-attachments/assets/e137eb04-a01c-4e71-993c-2fc4b8f82e9d)

- Closes #231 
