### PR TITLE
fix(color-scheme): add missing default color scheme fallback

### DIFF
--- a/packages/vlossom/src/composables/color-scheme-composable.ts
+++ b/packages/vlossom/src/composables/color-scheme-composable.ts
@@ -9,7 +9,7 @@ export function useColorScheme(component: VsComponent | string, colorScheme: Ref
         () =>
             colorScheme.value ||
             optionsStore.colorScheme.value[component] ||
-            optionsStore.colorScheme.value.default ||
+            optionsStore.colorScheme.value.fallback ||
             undefined,
     );
 

--- a/packages/vlossom/src/declaration/types.ts
+++ b/packages/vlossom/src/declaration/types.ts
@@ -7,7 +7,7 @@ export type ColorScheme = (typeof COLORS)[number];
 
 export type Theme = 'light' | 'dark';
 
-export type GlobalColorSchemes = { default?: ColorScheme } & { [key in VsComponent]?: ColorScheme } & {
+export type GlobalColorSchemes = { [key in VsComponent]?: ColorScheme } & { fallback?: ColorScheme } & {
     [key: string]: ColorScheme;
 };
 


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
default color-scheme 적용 버그 수정

## Description
- VlossomOptions에서 default color-scheme을 받는데 적용을 안 해주고 있었음
- color-scheme-composable에서 fallback

```ts
const $vs = useVlossom();
$vs.colorScheme = { default: 'blue' };
```
기본적으로는 Vlossom 초기화할 때 넣어주겠지만 나중에 추가하려면 이렇게 쓰는게 좀 열받긴 함
그렇지만 당장은 interface 변경하지 않을 생각임

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
