### PR TITLE
fix(VsDrawer): adjust z-index for improved overlay behavior

### DIFF
--- a/packages/vlossom/src/components/vs-drawer/README.md
+++ b/packages/vlossom/src/components/vs-drawer/README.md
@@ -153,6 +153,7 @@ interface VsDrawerStyleSet {
     position?: 'absolute' | 'fixed';
     size?: string;
     boxShadow?: string;
+    zIndex?: number;
 
     dimmed?: {
         backgroundColor?: string;

--- a/packages/vlossom/src/components/vs-drawer/VsDrawer.css
+++ b/packages/vlossom/src/components/vs-drawer/VsDrawer.css
@@ -10,10 +10,12 @@
     --vs-drawer-position: initial;
     --vs-drawer-size: initial;
     --vs-drawer-boxShadow: initial;
+    --vs-drawer-zIndex: initial;
 
-    @apply pointer-events-none top-0 left-0 z-100 h-full w-full overflow-hidden;
+    @apply pointer-events-none top-0 left-0 h-full w-full overflow-hidden;
 
     position: var(--vs-drawer-position, absolute);
+    z-index: var(--vs-drawer-zIndex, 100);
 
     .vs-drawer-content {
         @apply pointer-events-auto absolute;

--- a/packages/vlossom/src/components/vs-drawer/types.ts
+++ b/packages/vlossom/src/components/vs-drawer/types.ts
@@ -14,6 +14,7 @@ export interface VsDrawerStyleSet extends BoxStyleSet {
     position?: 'absolute' | 'fixed';
     size?: string;
     boxShadow?: string;
+    zIndex?: number;
 
     dimmed?: VsDimmedStyleSet;
 }


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary

`vs-drawer`에 `z-index`를 설정해 어떤 경우에도 메인 컨텐츠에 의해 `vs-drawer`의 컨텐츠가 가려지는 것을 방지합니다.

- close #247 