### PR TITLE
fix(VsTextWrap): move width style from contents to wrapper element

### DIFF
--- a/packages/vlossom/src/components/vs-text-wrap/VsTextWrap.css
+++ b/packages/vlossom/src/components/vs-text-wrap/VsTextWrap.css
@@ -12,11 +12,10 @@
     --vs-text-wrap-linkIcon-color: initial;
 
     @apply relative inline-flex items-center overflow-x-auto;
+    width: var(--vs-text-wrap-width, 100%);
 
     .vs-text-wrap-contents {
         @apply relative truncate;
-
-        width: var(--vs-text-wrap-width, 100%);
     }
 
     .vs-text-wrap-buttons {


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary

VsTextWrap 컴포넌트의 width 스타일 적용 위치를 수정합니다.

## Description

`--vs-text-wrap-width` CSS 변수의 적용 위치를 `.vs-text-wrap-contents`에서 부모 요소인 `.vs-text-wrap`으로 이동합니다. 이를 통해 버튼 영역(복사/링크 버튼)을 width 계산에 포함시키고, 버튼과 텍스트 사이에서 의도치 않은 gap이 발생하지 않도록 합니다.

Close #258 
