### PR TITLE
refactor(VsTabs): replace onUpdated with ResizeObserver

### DIFF
--- a/packages/vlossom/src/components/vs-tabs/VsTabs.vue
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.vue
@@ -63,7 +63,6 @@ import {
     type Ref,
     type PropType,
     type ComputedRef,
-    onUpdated,
 } from 'vue';
 import { useColorScheme, useStyleSet, useIndexSelector } from '@/composables';
 import { getColorSchemeProps, getStyleSetProps, getResponsiveProps } from '@/props';
@@ -217,24 +216,22 @@ export default defineComponent({
             updateIndicatorPosition();
         }
 
+        let resizeObserver: ResizeObserver | null = null;
+
         onMounted(() => {
             selectedIndex.value = findActiveIndexForwardFrom(modelValue.value);
-            calculateVisibleTabCount();
-            nextTick(() => {
-                updateIndicatorPosition();
-            });
-            window.addEventListener('resize', handleResize);
-        });
 
-        onUpdated(() => {
-            calculateVisibleTabCount();
-            nextTick(() => {
-                updateIndicatorPosition();
-            });
+            if (tabsWrapRef.value) {
+                resizeObserver = new ResizeObserver(handleResize);
+                resizeObserver.observe(tabsWrapRef.value);
+            }
         });
 
         onUnmounted(() => {
-            window.removeEventListener('resize', handleResize);
+            if (resizeObserver) {
+                resizeObserver.disconnect();
+                resizeObserver = null;
+            }
         });
 
         watch(


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Fix Bug (fix)
- [x] Refactor (refactor)

## Summary

VsTabs가 숨겨진 상태에서 마운트되었을 때 indicator 스타일이 깨지는 버그를 수정합니다.

## Description

### 문제

`vs-index-view`의 `keep-alive` 모드에서 VsTabs가 포함된 컴포넌트가 처음에 숨겨진 상태로 마운트되면, 해당 탭을 선택해서 보이게 되었을 때 다음 문제가 발생합니다.

- indicator가 맨 왼쪽에 `width: 0`, `left: 0`으로 납작하게 표시됨
- 스크롤 버튼이 불필요하게 노출됨

### 원인

`keep-alive` 모드에서 모든 자식 컴포넌트가 동시에 마운트되지만, 현재 선택되지 않은 인덱스는 vs-index-view가 생성한 외부 wrapper div에 `display: none`이 적용됩니다. 이 때문에 `onMounted`에서 `offsetWidth`, `clientWidth` 등이 모두 0을 반환하여 초기 계산이 잘못됩니다.

여기서 `display` 변경이 VsTabs 자체가 아닌 **외부 wrapper div에 적용되므로** VsTabs의 반응형 상태 변화로 인식되지 않아, 기존의 `onUpdated` 훅을 통한 방식으로는 감지가 불가능합니다.

### 해결 방법

`ResizeObserver`를 사용하여 `tabsWrapRef` 요소의 크기 변화를 감지하도록 변경힙니다.

## Related Tickets & Documents

- Closes #262 
