### PR TITLE
refactor: apply focus-within, focus-visible mixin class

### DIFF
--- a/packages/vlossom/src/components/vs-accordion/VsAccordion.vue
+++ b/packages/vlossom/src/components/vs-accordion/VsAccordion.vue
@@ -54,7 +54,7 @@ export default defineComponent({
         const isOpen = ref(open.value || modelValue.value);
 
         const classObj = computed(() => ({
-            'vs-focusable': !disabled.value,
+            'vs-focus-visible': !disabled.value,
             'vs-disabled': disabled.value,
             'vs-primary': primary.value,
         }));

--- a/packages/vlossom/src/components/vs-accordion/__tests__/vs-accordion.test.ts
+++ b/packages/vlossom/src/components/vs-accordion/__tests__/vs-accordion.test.ts
@@ -45,12 +45,12 @@ describe('VsAccordion', () => {
             });
         }
 
-        it('disabled가 false일 때 vs-focusable 클래스가 적용되어야 한다', () => {
+        it('disabled가 false일 때 vs-focus-visible 클래스가 적용되어야 한다', () => {
             // given, when
             mountWithDisabled(false);
 
             // then
-            expect(wrapper.classes()).toContain('vs-focusable');
+            expect(wrapper.classes()).toContain('vs-focus-visible');
             expect(wrapper.classes()).not.toContain('vs-disabled');
             expect(wrapper.attributes('tabindex')).toBe('0');
         });
@@ -61,7 +61,7 @@ describe('VsAccordion', () => {
 
             // then
             expect(wrapper.classes()).toContain('vs-disabled');
-            expect(wrapper.classes()).not.toContain('vs-focusable');
+            expect(wrapper.classes()).not.toContain('vs-focus-visible');
             expect(wrapper.attributes('tabindex')).toBe('-1');
         });
 

--- a/packages/vlossom/src/components/vs-button/VsButton.vue
+++ b/packages/vlossom/src/components/vs-button/VsButton.vue
@@ -45,7 +45,7 @@ export default defineComponent({
         const { componentStyleSet, styleSetVariables } = useStyleSet<VsButtonStyleSet>(componentName, styleSet);
 
         const classObj = computed(() => ({
-            'vs-focusable': !disabled.value && !loading.value,
+            'vs-focus-visible': !disabled.value && !loading.value,
             'vs-circle': circle.value,
             'vs-disabled': disabled.value,
             'vs-ghost': ghost.value,

--- a/packages/vlossom/src/components/vs-checkbox/VsCheckbox.vue
+++ b/packages/vlossom/src/components/vs-checkbox/VsCheckbox.vue
@@ -185,7 +185,7 @@ export default defineComponent({
         const classObj = computed(() => ({
             'vs-checked': isChecked.value,
             'vs-disabled': computedDisabled.value,
-            'vs-focusable': !computedDisabled.value && !computedReadonly.value,
+            'vs-focus-visible': !computedDisabled.value && !computedReadonly.value,
             'vs-indeterminate': indeterminate.value,
             'vs-readonly': computedReadonly.value,
             'vs-small': small.value,

--- a/packages/vlossom/src/components/vs-file-drop/VsFileDrop.css
+++ b/packages/vlossom/src/components/vs-file-drop/VsFileDrop.css
@@ -21,8 +21,7 @@
     width: var(--vs-file-drop-width, 100%);
     height: var(--vs-file-drop-height, auto);
 
-    &:hover,
-    &:focus-within {
+    &:hover {
         outline: 1px solid var(--vs-line-color) !important;
         outline-offset: 2px !important;
     }

--- a/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
+++ b/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
@@ -218,7 +218,8 @@ export default defineComponent({
 
         const classObj = computed(() => ({
             'vs-small': small.value,
-            'vs-focusable': !computedDisabled.value && !computedReadonly.value,
+            'vs-focus-visible': !computedDisabled.value && !computedReadonly.value,
+            'vs-focus-within': !computedDisabled.value && !computedReadonly.value,
             'vs-disabled': computedDisabled.value,
             'vs-readonly': computedReadonly.value,
             'vs-dragging': dragging.value,

--- a/packages/vlossom/src/components/vs-input/VsInput.css
+++ b/packages/vlossom/src/components/vs-input/VsInput.css
@@ -73,11 +73,6 @@
         }
     }
 
-    &:focus-within {
-        outline: 1px solid var(--vs-line-color) !important;
-        outline-offset: 2px !important;
-    }
-
     &.vs-small {
         height: var(--vs-input-height, var(--vs-default-comp-height-sm));
         font-size: var(--vs-input-fontSize, var(--vs-font-size-sm));

--- a/packages/vlossom/src/components/vs-input/VsInput.vue
+++ b/packages/vlossom/src/components/vs-input/VsInput.vue
@@ -197,7 +197,8 @@ export default defineComponent({
 
         const classObj = computed(() => ({
             'vs-small': small.value,
-            'vs-focusable': !computedDisabled.value && !computedReadonly.value,
+            'vs-focus-visible': !computedDisabled.value && !computedReadonly.value,
+            'vs-focus-within': !computedDisabled.value && !computedReadonly.value,
             'vs-disabled': computedDisabled.value,
             'vs-readonly': computedReadonly.value,
         }));

--- a/packages/vlossom/src/components/vs-input/__tests__/vs-input.test.ts
+++ b/packages/vlossom/src/components/vs-input/__tests__/vs-input.test.ts
@@ -98,7 +98,7 @@ describe('VsInput', () => {
             expect(vsInput.classes()).toContain('vs-readonly');
         });
 
-        it('disabled나 readonly가 아닐 때 vs-focusable 클래스가 추가되어야 한다', () => {
+        it('disabled나 readonly가 아닐 때 vs-focus-visible 클래스가 추가되어야 한다', () => {
             // given
             const wrapper = mount(VsInput, {
                 props: {
@@ -109,7 +109,7 @@ describe('VsInput', () => {
 
             // then
             const vsInput = wrapper.find('.vs-input');
-            expect(vsInput.classes()).toContain('vs-focusable');
+            expect(vsInput.classes()).toContain('vs-focus-visible');
         });
 
         it('small prop이 true일 때 vs-small 클래스가 추가되어야 한다', () => {

--- a/packages/vlossom/src/components/vs-radio/VsRadio.css
+++ b/packages/vlossom/src/components/vs-radio/VsRadio.css
@@ -44,7 +44,7 @@
         }
     }
 
-    &.vs-focusable {
+    &.vs-focus-visible {
         .vs-radio-input:focus-visible + .vs-radio-label {
             &:before {
                 outline: 1px solid var(--vs-line-color) !important;

--- a/packages/vlossom/src/components/vs-radio/VsRadio.vue
+++ b/packages/vlossom/src/components/vs-radio/VsRadio.vue
@@ -157,7 +157,7 @@ export default defineComponent({
 
         const classObj = computed(() => ({
             'vs-disabled': computedDisabled.value,
-            'vs-focusable': !computedDisabled.value && !computedReadonly.value,
+            'vs-focus-visible': !computedDisabled.value && !computedReadonly.value,
             'vs-readonly': computedReadonly.value,
             'vs-small': small.value,
         }));

--- a/packages/vlossom/src/components/vs-textarea/VsTextarea.css
+++ b/packages/vlossom/src/components/vs-textarea/VsTextarea.css
@@ -1,45 +1,36 @@
 @reference 'tailwindcss';
 
 .vs-textarea {
+    --vs-textarea-height: initial;
+
     --vs-textarea-backgroundColor: initial;
     --vs-textarea-border: initial;
     --vs-textarea-borderRadius: initial;
     --vs-textarea-padding: initial;
     --vs-textarea-opacity: initial;
+
     --vs-textarea-fontColor: initial;
     --vs-textarea-fontSize: initial;
     --vs-textarea-fontWeight: initial;
-    --vs-textarea-height: initial;
+
     --vs-textarea-resize: initial;
 
+    @apply relative flex w-full overflow-hidden;
+
+    opacity: var(--vs-textarea-opacity, 1);
+    outline: none;
+    border: var(--vs-textarea-border, solid 1px var(--vs-line-color));
     border-radius: var(--vs-textarea-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius)));
-
-    textarea {
-        @apply relative flex w-full overflow-hidden;
-
-        opacity: var(--vs-textarea-opacity, 1);
-        border: var(--vs-textarea-border, solid 1px var(--vs-line-color));
-        border-radius: var(--vs-textarea-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius)));
-        background-color: var(--vs-textarea-backgroundColor, var(--vs-no-color));
-        padding: var(--vs-textarea-padding, 0.3rem 0.6rem);
-        height: var(--vs-textarea-height, 6rem);
-        resize: var(--vs-textarea-resize, vertical);
-        color: var(--vs-textarea-fontColor, var(--vs-font-color));
-        font-weight: var(--vs-textarea-fontWeight, var(--vs-font-weight));
-        font-size: var(--vs-textarea-fontSize, var(--vs-font-size));
-
-        &:focus-within {
-            outline: 1px solid var(--vs-line-color) !important;
-            outline-offset: 2px !important;
-        }
-    }
+    background-color: var(--vs-textarea-backgroundColor, var(--vs-no-color));
+    padding: var(--vs-textarea-padding, 0.3rem 0.6rem);
+    min-height: var(--vs-textarea-height, 6rem);
+    resize: var(--vs-textarea-resize, vertical);
+    color: var(--vs-textarea-fontColor, var(--vs-font-color));
+    font-weight: var(--vs-textarea-fontWeight, var(--vs-font-weight));
+    font-size: var(--vs-textarea-fontSize, var(--vs-font-size));
 
     &.vs-small {
-        height: var(--vs-textarea-height, 3rem);
+        min-height: var(--vs-textarea-height, 3rem);
         font-size: var(--vs-textarea-fontSize, var(--vs-font-size-sm));
-
-        textarea {
-            font-size: var(--vs-textarea-fontSize, var(--vs-font-size-sm));
-        }
     }
 }

--- a/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
+++ b/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
@@ -18,23 +18,23 @@
             <slot name="label" />
         </template>
 
-        <div :class="['vs-textarea', colorSchemeClass, classObj, stateClasses]" :style="styleSetVariables">
-            <textarea
-                ref="textareaRef"
-                :id="computedId"
-                :disabled="computedDisabled"
-                :readonly="computedReadonly"
-                :name
-                :placeholder="placeholder"
-                :value="inputValue"
-                :aria-required="required"
-                :autocomplete="autocomplete ? 'on' : 'off'"
-                @input.stop="updateValue"
-                @focus.stop="onFocus"
-                @blur.stop="onBlur"
-                @change.stop
-            />
-        </div>
+        <textarea
+            ref="textareaRef"
+            :id="computedId"
+            :class="['vs-textarea', colorSchemeClass, classObj, stateClasses]"
+            :style="styleSetVariables"
+            :disabled="computedDisabled"
+            :readonly="computedReadonly"
+            :name
+            :placeholder="placeholder"
+            :value="inputValue"
+            :aria-required="required"
+            :autocomplete="autocomplete ? 'on' : 'off'"
+            @input.stop="updateValue"
+            @focus.stop="onFocus"
+            @blur.stop="onBlur"
+            @change.stop
+        />
 
         <template #messages v-if="!noMessages">
             <slot name="messages" />
@@ -155,7 +155,7 @@ export default defineComponent({
             'vs-small': small.value,
             'vs-disabled': computedDisabled.value,
             'vs-readonly': computedReadonly.value,
-            'vs-focusable': !computedDisabled.value && !computedReadonly.value,
+            'vs-focus-visible': !computedDisabled.value && !computedReadonly.value,
         }));
 
         const { stateClasses } = useStateClass(computedState);

--- a/packages/vlossom/src/components/vs-textarea/__tests__/vs-textarea.test.ts
+++ b/packages/vlossom/src/components/vs-textarea/__tests__/vs-textarea.test.ts
@@ -115,7 +115,7 @@ describe('VsTextarea', () => {
             expect(vsTextarea.classes()).toContain('vs-readonly');
         });
 
-        it('disabled나 readonly가 아닐 때 vs-focusable 클래스가 추가되어야 한다', () => {
+        it('disabled나 readonly가 아닐 때 vs-focus-visible 클래스가 추가되어야 한다', () => {
             // given
             const wrapper = mount(VsTextarea, {
                 props: {
@@ -126,7 +126,7 @@ describe('VsTextarea', () => {
 
             // then
             const vsTextarea = wrapper.find('.vs-textarea');
-            expect(vsTextarea.classes()).toContain('vs-focusable');
+            expect(vsTextarea.classes()).toContain('vs-focus-visible');
         });
 
         it('small prop이 true일 때 vs-small 클래스가 추가되어야 한다', () => {

--- a/packages/vlossom/src/styles/mixin.css
+++ b/packages/vlossom/src/styles/mixin.css
@@ -8,7 +8,8 @@
         @apply pointer-events-none cursor-default;
     }
 
-    .vs-focusable:focus-visible {
+    .vs-focus-visible:focus-visible,
+    .vs-focus-within:focus-within {
         outline: 1px solid var(--vs-line-color) !important;
         outline-offset: 2px !important;
     }


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Refactor (refactor)

## Summary
focus 상태에 사용할 mixin class를 정리

## Description
- focus-visible은 mixin에 저장되어 있었으나 이름을 명확하게 focus-visible로 변경
- focus-within이 mixin으로 정의되지 않은 상태로 여기저기 쓰이고 있었음
- textarea에 불필요한 wrapper div 제거하면서 style 정리

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
