### PR TITLE
fix(VsFileDrop, VsTextWrap): apply objectUtil.shake() to additionalStyleSet in VsFileDrop and VsTextWrap

### DIFF
--- a/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
+++ b/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
@@ -104,7 +104,7 @@ import { computed, defineComponent, ref, toRefs, useTemplateRef, type PropType, 
 import { VsComponent, type Breakpoints, type StateMessage } from '@/declaration';
 import { useColorScheme, useStyleSet, useInput, useStateClass } from '@/composables';
 import { getInputProps, getResponsiveProps, getColorSchemeProps, getStyleSetProps } from '@/props';
-import { stringUtil, propsUtil } from '@/utils';
+import { stringUtil, propsUtil, objectUtil } from '@/utils';
 import { closeIcon } from '@/icons';
 import { attachFileIcon } from './icons';
 import type { FileDropValueType, VsFileDropStyleSet } from './types';
@@ -173,11 +173,19 @@ export default defineComponent({
         const componentMessages: Ref<StateMessage[]> = ref([]);
 
         const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
-        const { styleSetVariables } = useStyleSet<VsFileDropStyleSet>(
-            componentName,
-            styleSet,
-            computed(() => ({ width: width.value, height: height.value })),
-        );
+        const additionalStyleSet = computed(() => {
+            return objectUtil.shake({
+                width:
+                    width.value === undefined || objectUtil.isObject(width.value)
+                        ? undefined
+                        : stringUtil.toStringSize(width.value as string | number),
+                height:
+                    height.value === undefined || objectUtil.isObject(height.value)
+                        ? undefined
+                        : stringUtil.toStringSize(height.value as string | number),
+            });
+        });
+        const { styleSetVariables } = useStyleSet<VsFileDropStyleSet>(componentName, styleSet, additionalStyleSet);
         const { requiredCheck, maxCheck, minCheck, acceptCheck, verifyMultipleFileUpload } = useVsFileDropRules(
             required,
             max,

--- a/packages/vlossom/src/components/vs-text-wrap/VsTextWrap.vue
+++ b/packages/vlossom/src/components/vs-text-wrap/VsTextWrap.vue
@@ -34,7 +34,7 @@ import { computed, defineComponent, ref, toRefs, type PropType, type Ref } from 
 import { VsComponent } from '@/declaration';
 import { getStyleSetProps } from '@/props';
 import { useStyleSet } from '@/composables';
-import { clipboardUtil, logUtil } from '@/utils';
+import { clipboardUtil, logUtil, objectUtil, stringUtil } from '@/utils';
 import type { VsTextWrapStyleSet } from './types';
 import { checkIcon, copyIcon, linkIcon } from './icons';
 import VsRender from '@/components/vs-render/VsRender.vue';
@@ -52,11 +52,17 @@ export default defineComponent({
     emits: ['copied'],
     setup(props, { emit }) {
         const { styleSet, link, width } = toRefs(props);
-        const { styleSetVariables } = useStyleSet<VsTextWrapStyleSet>(
-            componentName,
-            styleSet,
-            computed(() => ({ width: width.value })),
-        );
+
+        const additionalStyleSet = computed(() => {
+            return objectUtil.shake({
+                width:
+                    width.value === undefined || objectUtil.isObject(width.value)
+                        ? undefined
+                        : stringUtil.toStringSize(width.value as string | number),
+            });
+        });
+
+        const { styleSetVariables } = useStyleSet<VsTextWrapStyleSet>(componentName, styleSet, additionalStyleSet);
 
         const contentsRef: Ref<HTMLElement | null> = ref(null);
         const copied = ref(false);


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Fix Bug (fix)

## Summary

VsFileDrop, VsTextWrap 컴포넌트에서 `style-set` prop의 값이 `additionalStyleSet`에 의해 덮어씌워지는 버그 수정

## Description

`objectUtil.shake()`를 사용하여 `undefined`/빈 값을 필터링하도록 수정했습니다.

- `additionalStyleSet`을 `objectUtil.shake()`로 감싸고, width/height가 undefined이거나 반응형 객체인 경우 undefined를 반환하도록 조건 추가

## Related Tickets & Documents

- Closes #277
