### PR TITLE
refactor(variables): add `-md` suffix to default size CSS variables

### DIFF
--- a/packages/vlossom/src/components/vs-accordion/VsAccordion.css
+++ b/packages/vlossom/src/components/vs-accordion/VsAccordion.css
@@ -19,7 +19,7 @@
 
     opacity: var(--vs-accordion-opacity, 1);
     border: var(--vs-accordion-border, 1px solid var(--vs-line-color));
-    border-radius: var(--vs-accordion-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius)));
+    border-radius: var(--vs-accordion-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius-md)));
     width: var(--vs-accordion-width, 100%);
     color: var(--vs-accordion-expand-fontColor, var(--vs-comp-font));
 

--- a/packages/vlossom/src/components/vs-avatar/VsAvatar.css
+++ b/packages/vlossom/src/components/vs-avatar/VsAvatar.css
@@ -14,7 +14,7 @@
 
     opacity: var(--vs-avatar-opacity, 1);
     border: var(--vs-avatar-border, 1px solid var(--vs-line-color));
-    border-radius: var(--vs-avatar-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius)));
+    border-radius: var(--vs-avatar-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius-md)));
     background-color: var(--vs-avatar-backgroundColor, var(--vs-comp-bg));
     width: var(--vs-avatar-width, 3.6rem);
     height: var(--vs-avatar-height, 3.6rem);

--- a/packages/vlossom/src/components/vs-block/VsBlock.css
+++ b/packages/vlossom/src/components/vs-block/VsBlock.css
@@ -21,7 +21,7 @@
     container-type: inline-size;
     box-shadow: var(--vs-block-boxShadow, var(--vs-area-shadow-outer));
     border: var(--vs-block-border, 1px solid var(--vs-line-color));
-    border-radius: var(--vs-block-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius)));
+    border-radius: var(--vs-block-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius-md)));
     background-color: var(--vs-block-backgroundColor, var(--vs-area-bg));
     width: var(--vs-block-width, auto);
     height: var(--vs-block-height, auto);

--- a/packages/vlossom/src/components/vs-button/VsButton.css
+++ b/packages/vlossom/src/components/vs-button/VsButton.css
@@ -16,10 +16,10 @@
 
     opacity: var(--vs-button-opacity, 1);
     border: var(--vs-button-border, 1px solid var(--vs-line-color));
-    border-radius: var(--vs-button-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius)));
+    border-radius: var(--vs-button-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius-md)));
     background-color: var(--vs-button-backgroundColor, var(--vs-comp-bg));
     width: var(--vs-button-width, auto);
-    height: var(--vs-button-height, var(--vs-default-comp-height));
+    height: var(--vs-button-height, var(--vs-default-comp-height-md));
     color: var(--vs-button-fontColor, var(--vs-comp-font));
 
     .vs-button-loading {
@@ -94,8 +94,8 @@
 
     &.vs-circle {
         @apply rounded-full;
-        width: var(--vs-button-width, var(--vs-default-comp-height));
-        height: var(--vs-button-height, var(--vs-default-comp-height));
+        width: var(--vs-button-width, var(--vs-default-comp-height-md));
+        height: var(--vs-button-height, var(--vs-default-comp-height-md));
 
         &.vs-small {
             width: var(--vs-button-width, var(--vs-default-comp-height-sm));

--- a/packages/vlossom/src/components/vs-checkbox/VsCheckbox.css
+++ b/packages/vlossom/src/components/vs-checkbox/VsCheckbox.css
@@ -8,7 +8,7 @@
     --vs-checkbox-height: initial;
 
     @apply relative flex items-center justify-start;
-    min-height: var(--vs-checkbox-height, var(--vs-default-comp-height));
+    min-height: var(--vs-checkbox-height, var(--vs-default-comp-height-md));
 
     .vs-checkbox-wrap {
         @apply relative flex flex-nowrap items-center justify-start select-none;

--- a/packages/vlossom/src/components/vs-file-drop/VsFileDrop.css
+++ b/packages/vlossom/src/components/vs-file-drop/VsFileDrop.css
@@ -16,7 +16,7 @@
     @apply relative box-border hover:brightness-110 active:brightness-120;
     opacity: var(--vs-file-drop-opacity, 1);
     border: var(--vs-file-drop-border, solid 1px var(--vs-line-color));
-    border-radius: var(--vs-file-drop-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius)));
+    border-radius: var(--vs-file-drop-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius-md)));
     background-color: var(--vs-file-drop-backgroundColor, var(--vs-no-color));
     width: var(--vs-file-drop-width, 100%);
     height: var(--vs-file-drop-height, auto);
@@ -73,7 +73,7 @@
                     @apply truncate;
 
                     color: var(--vs-font-color);
-                    font-size: var(--vs-font-size);
+                    font-size: var(--vs-font-size-md);
                 }
 
                 .vs-file-drop-file-size {

--- a/packages/vlossom/src/components/vs-input/VsInput.css
+++ b/packages/vlossom/src/components/vs-input/VsInput.css
@@ -22,12 +22,12 @@
     @apply relative box-border flex items-center overflow-hidden;
     opacity: var(--vs-input-opacity, 1);
     border: var(--vs-input-border, solid 1px var(--vs-line-color));
-    border-radius: var(--vs-input-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius)));
+    border-radius: var(--vs-input-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius-md)));
     background-color: var(--vs-input-backgroundColor, var(--vs-no-color));
-    height: var(--vs-input-height, var(--vs-default-comp-height));
+    height: var(--vs-input-height, var(--vs-default-comp-height-md));
     color: var(--vs-input-fontColor, var(--vs-font-color));
     font-weight: var(--vs-input-fontWeight, var(--vs-font-weight));
-    font-size: var(--vs-input-fontSize, var(--vs-font-size));
+    font-size: var(--vs-input-fontSize, var(--vs-font-size-md));
 
     input {
         @apply w-full border-none bg-transparent outline-none;
@@ -35,7 +35,7 @@
         padding: var(--vs-input-padding, 0 0.8rem);
         color: var(--vs-input-fontColor, var(--vs-font-color));
         font-weight: var(--vs-input-fontWeight, var(--vs-font-weight));
-        font-size: var(--vs-input-fontSize, var(--vs-font-size));
+        font-size: var(--vs-input-fontSize, var(--vs-font-size-md));
     }
 
     .vs-prepend,

--- a/packages/vlossom/src/components/vs-label-value/VsLabelValue.css
+++ b/packages/vlossom/src/components/vs-label-value/VsLabelValue.css
@@ -39,7 +39,7 @@
             padding: var(--vs-label-value-label-padding, 0.6rem 1.2rem);
             color: var(--vs-label-value-label-fontColor, var(--vs-comp-font));
             font-weight: var(--vs-label-value-label-fontWeight, 500);
-            font-size: var(--vs-label-value-label-fontSize, var(--vs-font-size));
+            font-size: var(--vs-label-value-label-fontSize, var(--vs-font-size-md));
         }
 
         &.vs-value {
@@ -50,7 +50,7 @@
             padding: var(--vs-label-value-value-padding, 0.6rem 1.2rem);
             color: var(--vs-label-value-value-fontColor, var(--vs-comp-font));
             font-weight: var(--vs-label-value-value-fontWeight, 500);
-            font-size: var(--vs-label-value-value-fontSize, var(--vs-font-size));
+            font-size: var(--vs-label-value-value-fontSize, var(--vs-font-size-md));
         }
     }
 

--- a/packages/vlossom/src/components/vs-modal/VsModalNode.css
+++ b/packages/vlossom/src/components/vs-modal/VsModalNode.css
@@ -25,7 +25,7 @@
         opacity: var(--vs-modal-node-opacity, 1);
         box-shadow: var(--vs-modal-node-boxShadow, var(--vs-area-shadow-outer));
         border: var(--vs-modal-node-border, none);
-        border-radius: var(--vs-modal-node-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius)));
+        border-radius: var(--vs-modal-node-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius-md)));
         background-color: var(--vs-modal-node-backgroundColor, var(--vs-area-bg));
         padding: var(--vs-modal-node-padding, 1.8rem 2.4rem);
         width: var(--vs-modal-node-width, fit-content);

--- a/packages/vlossom/src/components/vs-progress/VsProgress.css
+++ b/packages/vlossom/src/components/vs-progress/VsProgress.css
@@ -22,7 +22,7 @@
     @apply overflow-hidden;
 
     border: var(--vs-progress-border, 1px solid var(--vs-line-color));
-    border-radius: var(--vs-progress-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius)));
+    border-radius: var(--vs-progress-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius-md)));
     background-color: var(--vs-progress-backgroundColor, var(--vs-comp-bg));
 }
 

--- a/packages/vlossom/src/components/vs-radio/VsRadio.css
+++ b/packages/vlossom/src/components/vs-radio/VsRadio.css
@@ -7,7 +7,7 @@
     --vs-radio-radioSize: initial;
 
     @apply relative flex items-center;
-    min-height: var(--vs-radio-height, var(--vs-default-comp-height));
+    min-height: var(--vs-radio-height, var(--vs-default-comp-height-md));
 
     .vs-radio-wrap {
         @apply relative flex cursor-pointer flex-nowrap items-center justify-start select-none;

--- a/packages/vlossom/src/components/vs-search-input/VsSearchInput.css
+++ b/packages/vlossom/src/components/vs-search-input/VsSearchInput.css
@@ -11,9 +11,9 @@
         .vs-search-input-toggle {
             @apply cursor-pointer;
 
-            width: calc(var(--vs-search-input-height, var(--vs-default-comp-height)) * 0.8);
-            height: calc(var(--vs-search-input-height, var(--vs-default-comp-height)) * 0.8);
-            font-size: calc(var(--vs-search-input-height, var(--vs-default-comp-height)) * 0.4);
+            width: calc(var(--vs-search-input-height, var(--vs-default-comp-height-md)) * 0.8);
+            height: calc(var(--vs-search-input-height, var(--vs-default-comp-height-md)) * 0.8);
+            font-size: calc(var(--vs-search-input-height, var(--vs-default-comp-height-md)) * 0.4);
 
             &.vs-small {
                 width: calc(var(--vs-search-input-height, var(--vs-default-comp-height-sm)) * 0.8);

--- a/packages/vlossom/src/components/vs-steps/VsSteps.css
+++ b/packages/vlossom/src/components/vs-steps/VsSteps.css
@@ -70,7 +70,7 @@
                 @apply absolute top-3/2 left-1/2 -translate-x-1/2 whitespace-nowrap;
 
                 color: var(--vs-font-color);
-                font-size: var(--vs-font-size);
+                font-size: var(--vs-font-size-md);
             }
 
             &:focus {

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.css
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.css
@@ -10,7 +10,7 @@
     --vs-tabs-height: initial;
     --vs-tabs-gap: initial;
 
-    --tab-radius: var(--vs-tabs-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius)));
+    --tab-radius: var(--vs-tabs-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius-md)));
     --tab-border: var(--vs-tabs-border, 1px solid transparent);
     --tab-border-color: var(--vs-line-color);
     --tab-bg: var(--vs-tabs-backgroundColor, var(--vs-comp-bg));
@@ -19,7 +19,7 @@
     @apply relative flex items-center gap-2 select-none;
 
     opacity: var(--vs-tabs-opacity, 1);
-    height: var(--vs-tabs-height, var(--vs-default-comp-height));
+    height: var(--vs-tabs-height, var(--vs-default-comp-height-md));
 
     .vs-tabs-wrap {
         @apply relative flex w-full overflow-auto pb-1;
@@ -28,7 +28,7 @@
             @apply relative m-0 flex flex-1 list-none flex-nowrap items-center;
 
             border-bottom: 1px solid var(--tab-border-color);
-            height: var(--vs-tabs-height, var(--vs-default-comp-height));
+            height: var(--vs-tabs-height, var(--vs-default-comp-height-md));
 
             .vs-tab-item {
                 @apply relative flex h-full cursor-pointer items-center justify-center bg-transparent text-center whitespace-nowrap;
@@ -44,7 +44,7 @@
 
                 color: var(--vs-font-color);
                 font-weight: var(--vs-font-weight);
-                font-size: var(--vs-font-size);
+                font-size: var(--vs-font-size-md);
 
                 &:not(:last-child) {
                     margin-right: var(--vs-tabs-gap, 0.1rem);

--- a/packages/vlossom/src/components/vs-textarea/VsTextarea.css
+++ b/packages/vlossom/src/components/vs-textarea/VsTextarea.css
@@ -20,14 +20,14 @@
     opacity: var(--vs-textarea-opacity, 1);
     outline: none;
     border: var(--vs-textarea-border, solid 1px var(--vs-line-color));
-    border-radius: var(--vs-textarea-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius)));
+    border-radius: var(--vs-textarea-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius-md)));
     background-color: var(--vs-textarea-backgroundColor, var(--vs-no-color));
     padding: var(--vs-textarea-padding, 0.3rem 0.6rem);
     min-height: var(--vs-textarea-height, 6rem);
     resize: var(--vs-textarea-resize, vertical);
     color: var(--vs-textarea-fontColor, var(--vs-font-color));
     font-weight: var(--vs-textarea-fontWeight, var(--vs-font-weight));
-    font-size: var(--vs-textarea-fontSize, var(--vs-font-size));
+    font-size: var(--vs-textarea-fontSize, var(--vs-font-size-md));
 
     &.vs-small {
         min-height: var(--vs-textarea-height, 3rem);

--- a/packages/vlossom/src/components/vs-tooltip/VsTooltip.css
+++ b/packages/vlossom/src/components/vs-tooltip/VsTooltip.css
@@ -18,7 +18,7 @@
 
         opacity: var(--vs-tooltip-opacity, 1);
         border: var(--vs-tooltip-border, 0.1rem solid var(--vs-primary-comp-bg));
-        border-radius: var(--vs-tooltip-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius)));
+        border-radius: var(--vs-tooltip-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius-md)));
         background-color: var(--vs-tooltip-backgroundColor, var(--vs-area-bg));
         padding: var(--vs-tooltip-padding, 0.2rem 0.6rem);
         width: var(--vs-tooltip-width, auto);

--- a/packages/vlossom/src/styles/base.css
+++ b/packages/vlossom/src/styles/base.css
@@ -1,6 +1,6 @@
 body {
     color: var(--vs-no-color-inverse);
-    font-size: var(--vs-font-size);
+    font-size: var(--vs-font-size-md);
 }
 
 html,

--- a/packages/vlossom/src/styles/variables.css
+++ b/packages/vlossom/src/styles/variables.css
@@ -22,14 +22,14 @@
 
         --vs-font-size-xs: 0.6rem;
         --vs-font-size-sm: 0.8rem;
-        --vs-font-size: 1rem;
+        --vs-font-size-md: 1rem;
         --vs-font-size-lg: 1.2rem;
         --vs-font-size-xl: 1.4rem;
 
         --vs-radius-ratio: 1;
         --vs-radius-xs: 0.2rem;
         --vs-radius-sm: 0.3rem;
-        --vs-radius: 0.4rem;
+        --vs-radius-md: 0.4rem;
         --vs-radius-lg: 0.5rem;
         --vs-radius-xl: 0.6rem;
 
@@ -39,7 +39,7 @@
 
         --vs-default-comp-height-xs: 1.4rem;
         --vs-default-comp-height-sm: 1.6rem;
-        --vs-default-comp-height: 2rem;
+        --vs-default-comp-height-md: 2rem;
         --vs-default-comp-height-lg: 2.4rem;
         --vs-default-comp-height-xl: 2.8rem;
     }


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Refactor (refactor)\

## Summary

기본 크기 옵션을 가진 CSS 변수들에 `-md` 접미사를 추가하고, 해당 변수들이 사용되고 있는 파일들을 수정합니다.

## Description

**변경 사항**

| Before                     | After                         |
| -------------------------- | ----------------------------- |
| `--vs-font-size`           | `--vs-font-size-md`           |
| `--vs-radius`              | `--vs-radius-md`              |
| `--vs-default-comp-height` | `--vs-default-comp-height-md` |

## Related Tickets & Documents

- Closes #278 

