### PR TITLE
fix(storybook): update Storybook configuration to fix storybook build error

### DIFF
--- a/packages/vlossom/vite.config.common.ts
+++ b/packages/vlossom/vite.config.common.ts
@@ -2,7 +2,7 @@ import { fileURLToPath, URL } from 'node:url';
 import vue from '@vitejs/plugin-vue';
 import tailwindcss from '@tailwindcss/vite';
 
-// 공통 설정 (vueDevTools 제외 - Storybook 호환성)
+// 공통 설정 (Storybook 호환성 문제로 vueDevTools 제외)
 export const commonConfig = {
     plugins: [vue(), tailwindcss()],
     resolve: {

--- a/packages/vlossom/vite.config.dev.ts
+++ b/packages/vlossom/vite.config.dev.ts
@@ -1,7 +1,0 @@
-import vueDevTools from 'vite-plugin-vue-devtools';
-import { commonConfig } from './vite.config.common';
-
-export const devConfig = {
-    ...commonConfig,
-    plugins: [...commonConfig.plugins, vueDevTools()],
-};

--- a/packages/vlossom/vite.config.playground.ts
+++ b/packages/vlossom/vite.config.playground.ts
@@ -1,13 +1,15 @@
 import { defineConfig } from 'vite';
 import { fileURLToPath, URL } from 'node:url';
 import { visualizer } from 'rollup-plugin-visualizer';
-import { devConfig } from './vite.config.dev';
+import { commonConfig } from './vite.config.common';
+import vueDevTools from 'vite-plugin-vue-devtools';
 
 // https://vite.dev/config/
 export default defineConfig({
-    ...devConfig,
+    ...commonConfig,
     plugins: [
-        ...devConfig.plugins,
+        ...commonConfig.plugins,
+        vueDevTools(),
         visualizer({
             filename: 'visualizer-playground.html',
         }),


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Fix Bug (fix)

## Summary

Storybook 10 + Vite 7 + vite-plugin-vue-devtools v8 조합에서 발생하는 빌드 에러를 수정합니다.

## Description

### 문제

Storybook 실행 시 `vite-plugin-vue-devtools`가 내부적으로 사용하는 `vite-plugin-inspect`에서 다음 에러가 발생했습니다.

```
Error: Can not found environment context for client
at InspectContextVite.getEnvContext
```

### 원인

`vite-plugin-vue-devtools` v8+가 Storybook의 Vite 환경 설정 전에 로드되면서 `vite-plugin-inspect`의 환경 컨텍스트를 찾지 못함

### 해결

- `vite.config.common.ts`: Storybook 프로세스 실행 시 `vueDevTools` 플러그인 제외
- `.storybook/main.ts`, `.storybook-chromatic/main.ts`: `@storybook/addon-vitest` 제거 및 `vite-plugin-inspect` 필터링 추가

### 변경 파일

- `packages/vlossom/vite.config.common.ts`
- `packages/vlossom/.storybook/main.ts`
- `packages/vlossom/.storybook-chromatic/main.ts`

## Related Tickets & Documents

- Related Issue: https://github.com/storybookjs/storybook/issues/32462
- Related Issue: https://github.com/vuejs/devtools/issues/703