### PR TITLE
style(vlossom): set Pretendard as default font

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ Vlossom is a vibrant and versatile [Vue](https://vuejs.org/) UI library designed
         <img src="https://img.shields.io/npm/l/vlossom.svg" alt="License">
     </a>
 </p>
+
+## Credit
+
+- **[Pretendard](https://github.com/orioncactus/pretendard)** - Default font ([SIL Open Font License 1.1](https://github.com/orioncactus/pretendard/blob/main/LICENSE))

--- a/packages/vlossom/src/styles/base.css
+++ b/packages/vlossom/src/styles/base.css
@@ -8,8 +8,8 @@ body {
     @apply relative min-h-screen min-w-full leading-[1.5] font-normal;
     background-color: var(--vs-app-bg);
     font-family:
-        'Noto Sans',
-        'Nanum Gothic',
+        'Pretendard Variable',
+        Pretendard,
         -apple-system,
         BlinkMacSystemFont,
         system-ui,

--- a/packages/vlossom/src/styles/index.css
+++ b/packages/vlossom/src/styles/index.css
@@ -1,3 +1,5 @@
+@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css');
+
 @import 'tailwindcss';
 
 @custom-variant dark (&:where(.vs-dark, .vs-dark *));


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Feature (feat)
- [x] Update Docs (docs)

## Summary

Pretendard를 Vlossom의 기본 폰트로 설정합니다.

## Description

**Before**

<img width="912" height="686" alt="1" src="https://github.com/user-attachments/assets/ddb941c6-f8a8-4628-9af3-17b154d23785" />

**After**

<img width="912" height="686" alt="1" src="https://github.com/user-attachments/assets/604ef436-097f-4b34-a6c0-7a3ffa8736d3" />

**변경 사항**

- `src/styles/index.css`에 Pretendard Variable CDN import 추가
- font-family에서 Pretendard를 최우선으로 설정, 기존 Noto Sans, Nanum Gothic 제거 (Pretendard가 한글 지원)
- Credit 섹션에 Pretendard 명시
- SIL Open Font License 1.1 준수 (폰트 파일을 번들링해 직접 배포하지 않으므로 라이선스 파일 미포함, README에 출처 명시)

## Related Tickets & Documents

- Closes #260