### PR TITLE
fix(VsModalNode, VsSwitch): change width to "auto" for Safari 

### DIFF
--- a/packages/vlossom/src/components/vs-modal/VsModalNode.css
+++ b/packages/vlossom/src/components/vs-modal/VsModalNode.css
@@ -9,23 +9,14 @@
         @apply pointer-events-auto absolute top-1/2 left-1/2 overflow-auto;
 
         transform: translate(-50%, -50%);
-        /* opacity: 1;
+        opacity: 1;
         box-shadow: var(--vs-area-shadow-outer);
         border: none;
         border-radius: calc(var(--vs-radius-ratio) * var(--vs-radius-md));
         background-color: var(--vs-area-bg);
         padding: 1.8rem 2.4rem;
-        width: fit-content;
-        height: fit-content;
-        color: var(--vs-font-color); */
-        opacity: var(--vs-modal-node-opacity, 1);
-        box-shadow: var(--vs-modal-node-boxShadow, var(--vs-area-shadow-outer));
-        border: var(--vs-modal-node-border, none);
-        border-radius: var(--vs-modal-node-borderRadius, calc(var(--vs-radius-ratio) * var(--vs-radius-md)));
-        background-color: var(--vs-modal-node-backgroundColor, var(--vs-area-bg));
-        padding: var(--vs-modal-node-padding, 1.8rem 2.4rem);
-        width: var(--vs-modal-node-width, auto);
-        height: var(--vs-modal-node-height, auto);
-        color: var(--vs-modal-node-fontColor, var(--vs-font-color));
+        width: auto;
+        height: auto;
+        color: var(--vs-font-color);
     }
 }

--- a/packages/vlossom/src/components/vs-switch/VsSwitch.css
+++ b/packages/vlossom/src/components/vs-switch/VsSwitch.css
@@ -13,12 +13,9 @@
         border-radius: 1.5rem;
         background-color: var(--vs-area-bg);
 
-        /* width: fit-content;
+        width: auto;
         height: 2rem;
-        color: var(--vs-font-color); */
-        width: var(--vs-switch-width, auto);
-        height: var(--vs-switch-height, 2rem);
-        color: var(--vs-switch-fontColor, var(--vs-font-color));
+        color: var(--vs-font-color);
         font-size: var(--vs-font-size-sm);
 
         .vs-status-label {


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary

사파리 브라우저에서 발생할 수 있는 `fit-content` 이슈를 `auto`로 설정하여 방지합니다.

## Description

Safari 브라우저가 높이의 순환 참조 구조에서 발생하는 문제를 해결하는 방식으로 인하여 이슈가 발생할 수 있는 점을 확인하였슴니다

box layout 크기(height, width)의 순환 의존 문제는 아래와 같은 경우 발생하게 됩니다.
"부모가 height 혹은 width에 fit-content 를 사용함" -> 이 말은 자식의 높이 혹은 너비에 의존하겠다는 의미
"자식의 height 혹은 width가 % 값을 사용함" -> 이 말은 부모의 높이 혹은 너비에 의존하겠다는 의미

순환 문제가 발생하면 CSS 엔진들은 instrict하게 돌아가는데,
1. Webkit은 이걸 만나면 `0`으로 처리
2. Blick(Chrome CSS engine)는 이걸 `auto`로 처리 

결과적으로 Layout에 노출되는 모습이 브라우저에 따라 달라지게 됩니다.

[WebKit/WebCore - Safari CSS Engine Height 계산, 사용할 수 있는 height 값이 없으면 0으로 흐릅니다](https://github.com/WebKit/WebKit/blob/8ed662421aadc7eca974f03354918d867e44ff52/Source/WebCore/rendering/RenderBox.cpp#L3748)

## Screenshots or Recordings

<img width="852" height="408" alt="image" src="https://github.com/user-attachments/assets/ab0d64f4-0785-4e5f-9c1b-bd0180742558" />

## Related Tickets & Documents
- Related Issue #329 