### PR TITLE
feat(VsTable, util): add 'crush' util and refine table search

### DIFF
--- a/packages/vlossom/src/components/vs-table/composables/table-search-composable.ts
+++ b/packages/vlossom/src/components/vs-table/composables/table-search-composable.ts
@@ -1,28 +1,30 @@
 import { computed, type ComputedRef, type Ref } from 'vue';
 import type { VsSearchInputRef } from '@/components';
-import type { VsTableBodyCell, VsTableColumnDef } from '../types';
+import { objectUtil } from '@/utils';
+import { getRowItem, type VsTableBodyCell, type VsTableColumnDef } from '../types';
 
 export function useTableSearch(ref: Ref<VsSearchInputRef | null>, columns: ComputedRef<VsTableColumnDef[] | null>) {
-    const searchColumnKeyList = computed<string[]>(() => {
+    const skipKeyList = computed<string[]>(() => {
         if (!columns.value) {
             return [];
         }
-        return columns.value.filter((col) => !col.skipSearch).map((column) => column.key);
+        return columns.value.filter((col) => col.skipSearch).map((column) => column.key);
     });
 
     function matchBySearch(row: VsTableBodyCell[]): boolean {
         if (!ref.value) {
             return true;
         }
-        const matchFn = ref.value.match;
+        const item = getRowItem(row);
+        if (!item) {
+            return false;
+        }
+        const brushedItem = objectUtil.omit(item, skipKeyList.value);
+        const crushedItem = objectUtil.crush(brushedItem);
+        const search = ref.value.match;
 
-        return row.some((cell) => {
-            if (!searchColumnKeyList.value.includes(cell.colKey)) {
-                return false;
-            }
-            const cellValue = cell.value ? String(cell.value) : '';
-            return matchFn(cellValue);
-        });
+        const flattenedItemText = Object.values(crushedItem).join(' ');
+        return search(flattenedItemText);
     }
 
     return {

--- a/packages/vlossom/src/utils/object-util.ts
+++ b/packages/vlossom/src/utils/object-util.ts
@@ -1,7 +1,8 @@
-import { assign, get, isEmpty, isEqual, isObject, omit, shake } from 'radash';
+import { assign, crush, get, isEmpty, isEqual, isObject, omit, shake } from 'radash';
 
 export const objectUtil = {
     assign,
+    crush,
     get,
     isEmpty,
     isEqual,


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)
-   [x] Refactor (refactor)

## Summary

1. table search 검색할 대상이 되는 text를 계산하는 로직을 변경합니다.
2. radash에서 `crush` util 함수를 가져오고 내보냅니다.

## Description

table의 검색 로직을 변경합니다.

> **화면에 출력되는 값을 기준으로 검색하던 로직에서, 입력된 데이터의 데이터를 기준으로 검색하는 로직으로 변경되었음**

| before | after |
| --- | --- |
| cell의 value(transformed)를 기준으로 match 함수를 동작함         |  row(item)가 가진 요소의 모든 value를 join한 값에 match 함수를 동작함     |
| cell의 헤더에 해당하는 column 정보에 `skipSearch`가 있다면 검색 대상에서 제외함        |     row(item)의 요소에서 column 정보에 해당하는 key에 대한 값을 모두 제외함   |


## Related Tickets & Documents

- Closes #382 

