### PR TITLE
feat(VsSelect): change initial focus with search option

### DIFF
--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -360,6 +360,7 @@ export default defineComponent({
             getFocusableElements,
             openOptions,
             closeOptions,
+            focusTrigger: focus,
             toggleSelectAll,
             selectOptionItem,
         });
@@ -439,11 +440,14 @@ export default defineComponent({
                     addMouseMoveListener();
 
                     const selectedId = selectedOptionIds.value[0];
-                    if (selectedId) {
-                        if (optionsListRef.value?.hasScroll()) {
-                            optionsListRef.value?.scrollToItem(selectedId);
-                        }
+                    if (selectedId && optionsListRef.value?.hasScroll()) {
+                        optionsListRef.value?.scrollToItem(selectedId);
+                    }
 
+                    if (isUsingSearch.value) {
+                        searchInputRef.value?.focus();
+                        updateFocusIndex(0);
+                    } else if (selectedId) {
                         const targetFocusIndex = getFocusableElements().findIndex(
                             (element) => element.dataset['id'] === selectedId,
                         );

--- a/packages/vlossom/src/components/vs-select/composables/select-keyboard-composable.ts
+++ b/packages/vlossom/src/components/vs-select/composables/select-keyboard-composable.ts
@@ -12,6 +12,7 @@ interface UseSelectKeyboardParams {
     getFocusableElements: () => HTMLElement[];
     openOptions: () => void;
     closeOptions: () => void;
+    focusTrigger: () => void;
     toggleSelectAll: () => void;
     selectOptionItem: (optionItem: OptionItem) => void;
 }
@@ -26,6 +27,7 @@ export function useSelectKeyboard({
     getFocusableElements,
     openOptions,
     closeOptions,
+    focusTrigger,
     toggleSelectAll,
     selectOptionItem,
 }: UseSelectKeyboardParams) {
@@ -137,6 +139,7 @@ export function useSelectKeyboard({
                 e.preventDefault();
                 e.stopPropagation();
                 closeOptions();
+                focusTrigger();
             },
         };
     });


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary
vs-select를 열고 닫을 때 focus 위치 개선합니다

## Description
- options가 열렸을 때 search 옵션을 사용하면 search에 focus가 가도록 동작 추가 (search 옵션을 사용하지 않으면 선택된 첫 아이템에 focus)
- options가 닫힐 때 vs-select 자체에 focus가 가도록 변경