### PR TITLE
fix(VsButton): fix vs-loading color on primary

### DIFF
--- a/packages/vlossom/src/components/vs-button/VsButton.vue
+++ b/packages/vlossom/src/components/vs-button/VsButton.vue
@@ -45,6 +45,9 @@ export default defineComponent({
         const baseStyleSet: ComputedRef<VsButtonStyleSet> = computed(() => {
             return {
                 loading: {
+                    variables: {
+                        color: primary.value ? 'var(--vs-cs-font-primary)' : undefined,
+                    },
                     component: {
                         width: '30%',
                         height: '60%',


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
vs-button primary, loading에서 loading 잘 안 보이는 이슈 해결

## Description
- style-set에 primary 상태일 때 색상을 넣어서 해결

## Screenshots
<img width="351" height="54" alt="image" src="https://github.com/user-attachments/assets/9703eed1-a947-4600-84bf-8e75ae109873" />
<img width="364" height="52" alt="image" src="https://github.com/user-attachments/assets/cd51b2d9-a18f-4910-bf2c-8d720de2009b" />

