### PR TITLE
fix(VsLabelValue): remove flex basis

### DIFF
--- a/packages/vlossom/src/components/vs-label-value/VsLabelValue.css
+++ b/packages/vlossom/src/components/vs-label-value/VsLabelValue.css
@@ -12,7 +12,6 @@
         &.vs-label {
             @apply wrap-break-word whitespace-nowrap;
 
-            flex-basis: 20%;
             align-items: center;
             border-right: var(--vs-label-value-border, 1px solid var(--vs-cs-line));
             background-color: var(--vs-cs-bg);
@@ -69,7 +68,7 @@
             @apply justify-start;
 
             &.vs-label {
-                @apply basis-auto border-r-0;
+                @apply border-r-0;
                 border-bottom: var(--vs-label-value-border, 1px solid var(--vs-cs-line));
             }
         }
@@ -91,7 +90,7 @@
                 @apply justify-start;
 
                 &.vs-label {
-                    @apply basis-auto border-r-0;
+                    @apply border-r-0;
                     border-bottom: var(--vs-label-value-border, 1px solid var(--vs-cs-line));
                 }
             }


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
vs-label-value에서 label의 width가 label contents에 맞춥니다

## Description
- flex-basis로 label 크기를 고정하는 게 기본이 아니라서 제거
- style-set에서 label.width로도 크기 조정 가능해짐

<img width="330" height="215" alt="image" src="https://github.com/user-attachments/assets/44e19318-c470-4f97-9344-b6eabeb0a8d0" />

<img width="395" height="137" alt="image" src="https://github.com/user-attachments/assets/901e07ce-9da0-4bb3-8271-32f2ecba7181" />
