### PR TITLE
feat(VsTable): add table toolbar slot & clean up vs-table styles with class names

### DIFF
--- a/packages/vlossom/src/components/vs-input-wrapper/VsInputWrapper.css
+++ b/packages/vlossom/src/components/vs-input-wrapper/VsInputWrapper.css
@@ -1,6 +1,8 @@
 @reference 'tailwindcss';
 
 .vs-input-wrapper {
+    @apply relative w-full;
+
     .vs-label {
         @apply flex items-center;
 

--- a/packages/vlossom/src/components/vs-table/README.ko.md
+++ b/packages/vlossom/src/components/vs-table/README.ko.md
@@ -120,6 +120,8 @@ const selected = ref([]);
 ```typescript
 interface VsTableStyleSet {
     component?: CSSProperties;
+    toolbar?: CSSProperties;
+    search?: VsSearchInputStyleSet;
     header?: CSSProperties;
     row?: CSSProperties;
     selectedRow?: CSSProperties;

--- a/packages/vlossom/src/components/vs-table/README.ko.md
+++ b/packages/vlossom/src/components/vs-table/README.ko.md
@@ -191,6 +191,7 @@ type VsTableItem = Record<string, any>;
 
 | 슬롯 | 설명 |
 | ---- | ---- |
+| `toolbar` | 검색 입력창 왼쪽 영역; 액션 버튼이나 커스텀 컨트롤 배치에 사용 |
 | `caption` | 테이블 캡션 내용 |
 | `header-[key]` | 특정 컬럼 키의 커스텀 헤더 셀 |
 | `body-[key]` | 특정 컬럼 키의 커스텀 바디 셀 |

--- a/packages/vlossom/src/components/vs-table/README.md
+++ b/packages/vlossom/src/components/vs-table/README.md
@@ -120,6 +120,8 @@ const selected = ref([]);
 ```typescript
 interface VsTableStyleSet {
     component?: CSSProperties;
+    toolbar?: CSSProperties;
+    search?: VsSearchInputStyleSet;
     header?: CSSProperties;
     row?: CSSProperties;
     selectedRow?: CSSProperties;

--- a/packages/vlossom/src/components/vs-table/README.md
+++ b/packages/vlossom/src/components/vs-table/README.md
@@ -191,6 +191,7 @@ type VsTableItem = Record<string, any>;
 
 | Slot | Description |
 | ---- | ----------- |
+| `toolbar` | Area to the left of the search input; use for action buttons or custom controls |
 | `caption` | Table caption content |
 | `header-[key]` | Custom header cell for a specific column key |
 | `body-[key]` | Custom body cell for a specific column key |

--- a/packages/vlossom/src/components/vs-table/VsTable.css
+++ b/packages/vlossom/src/components/vs-table/VsTable.css
@@ -123,8 +123,19 @@
         }
     }
 
-    .vs-table-search-input {
-        @apply mb-2 flex justify-end;
+    .vs-table-toolbar {
+        @apply mb-2 flex items-end justify-between gap-4;
+
+        .vs-table-toolbar-start {
+            @apply flex-1;
+            min-width: 0;
+        }
+
+        .vs-table-search-input {
+            @apply flex items-end justify-end;
+            flex-shrink: 0;
+            width: 18rem;
+        }
     }
 
     &.vs-responsive {

--- a/packages/vlossom/src/components/vs-table/VsTable.css
+++ b/packages/vlossom/src/components/vs-table/VsTable.css
@@ -7,17 +7,15 @@
 
     /* ── Containers ── */
     > .vs-table-toolbar {
-        @apply mb-2 flex items-end justify-between gap-4;
+        @apply mb-2 items-end;
+        height: auto;
 
         > .vs-table-toolbar-start {
-            @apply flex-1;
             min-width: 0;
         }
 
         > .vs-table-search-input {
-            @apply flex items-end justify-end;
-            flex-shrink: 0;
-            width: 18rem;
+            @apply mt-2 flex items-end justify-end;
         }
     }
 

--- a/packages/vlossom/src/components/vs-table/VsTable.css
+++ b/packages/vlossom/src/components/vs-table/VsTable.css
@@ -5,11 +5,23 @@
 
     @apply relative w-full;
 
-    .vs-table-content {
-        @apply min-w-full overflow-x-auto;
+    /* ── Containers ── */
+    > .vs-table-toolbar {
+        @apply mb-2 flex items-end justify-between gap-4;
+
+        > .vs-table-toolbar-start {
+            @apply flex-1;
+            min-width: 0;
+        }
+
+        > .vs-table-search-input {
+            @apply flex items-end justify-end;
+            flex-shrink: 0;
+            width: 18rem;
+        }
     }
 
-    .vs-table-sticky-wrapper {
+    > .vs-table-sticky-wrapper {
         @apply pointer-events-none sticky w-full overflow-hidden;
         z-index: var(--vs-table-sticky-header-z-index);
         padding-bottom: 1rem;
@@ -19,35 +31,79 @@
             box-shadow: 0 0 0.8rem 0 var(--vs-cs-shadow-color);
             background-color: var(--vs-no-color);
 
-            th {
+            .vs-table-th {
                 border-bottom: 1px solid var(--vs-cs-line);
             }
         }
     }
 
-    table {
+    > .vs-table-content {
+        @apply min-w-full overflow-x-auto;
+    }
+
+    /* ── Table structure ── */
+    .vs-table-table {
         @apply mx-auto min-w-full;
         border-collapse: separate;
         border-spacing: 0;
     }
 
-    tr {
+    .vs-table-header-row,
+    .vs-table-body-row {
         @apply grid;
     }
 
-    thead tr {
+    .vs-table-thead > .vs-table-header-row {
         border-top-right-radius: calc(var(--vs-radius-ratio) * var(--vs-radius-md));
         border-top-left-radius: calc(var(--vs-radius-ratio) * var(--vs-radius-md));
         background-color: var(--vs-cs-bg-colored);
+    }
 
-        th {
-            grid-row: 1;
-            color: var(--vs-cs-font-colored);
-            font-weight: var(--vs-font-weight);
+    .vs-table-th {
+        @apply flex items-center;
+        grid-row: 1;
+        border-top: 1px solid var(--vs-cs-line);
+        padding: 0.6rem 0.8rem;
+        color: var(--vs-cs-font-colored);
+        font-weight: var(--vs-font-weight);
+        text-align: left;
+
+        &:first-child {
+            border-left: 1px solid var(--vs-cs-line);
+            border-top-left-radius: calc(var(--vs-radius-ratio) * var(--vs-radius-md));
+        }
+
+        &:last-child {
+            border-right: 1px solid var(--vs-cs-line);
+            border-top-right-radius: calc(var(--vs-radius-ratio) * var(--vs-radius-md));
+        }
+
+        > * {
+            @apply w-full;
         }
     }
 
-    tbody tr {
+    .vs-table-td {
+        @apply flex items-center;
+        grid-row: 1;
+        border-top: 1px solid var(--vs-cs-line);
+        padding: 0.6rem 0.8rem;
+        text-align: left;
+
+        > * {
+            @apply w-full;
+        }
+    }
+
+    .vs-table-th,
+    .vs-table-td {
+        * {
+            min-height: unset;
+        }
+    }
+
+    /* ── Body rows ── */
+    .vs-table-draggable-wrapper > .vs-table-body-row {
         @apply transition-colors duration-250 ease-in-out;
 
         &.vs-stated {
@@ -63,11 +119,11 @@
             border-bottom: 1px solid var(--vs-cs-line);
         }
 
-        > td:not(.vs-table-expanded-row) {
-            grid-row: 1;
+        &:hover {
+            background-color: var(--vs-cs-bg-area-colored);
         }
 
-        > td.vs-table-expanded-row {
+        > .vs-table-td.vs-table-expanded-row {
             grid-row: 2;
             grid-column: 1 / -1;
             border: none;
@@ -79,93 +135,23 @@
                 white-space: pre-wrap;
             }
         }
-
-        &:hover {
-            background-color: var(--vs-cs-bg-area-colored);
-        }
     }
 
-    th {
-        @apply flex items-center;
-        border-top: 1px solid var(--vs-cs-line);
-        padding: 0.6rem 0.8rem;
-        text-align: left;
-
-        &:first-child {
-            border-left: 1px solid var(--vs-cs-line);
-            border-top-left-radius: calc(var(--vs-radius-ratio) * var(--vs-radius-md));
-        }
-        &:last-child {
-            border-right: 1px solid var(--vs-cs-line);
-            border-top-right-radius: calc(var(--vs-radius-ratio) * var(--vs-radius-md));
-        }
-
-        > * {
-            @apply w-full;
-        }
+    /* ── No data ── */
+    .vs-table-no-data-cell {
+        height: 12rem;
     }
 
-    td {
-        @apply flex items-center;
-        border-top: 1px solid var(--vs-cs-line);
-        padding: 0.6rem 0.8rem;
-        text-align: left;
-
-        > * {
-            @apply w-full;
-        }
+    .vs-table-no-data {
+        @apply flex flex-col items-center justify-center;
+        color: var(--vs-cs-font-colored);
     }
 
-    th,
-    td {
-        * {
-            min-height: unset;
-        }
+    .vs-table-no-data-text {
+        @apply text-xl font-bold;
     }
 
-    .vs-table-toolbar {
-        @apply mb-2 flex items-end justify-between gap-4;
-
-        .vs-table-toolbar-start {
-            @apply flex-1;
-            min-width: 0;
-        }
-
-        .vs-table-search-input {
-            @apply flex items-end justify-end;
-            flex-shrink: 0;
-            width: 18rem;
-        }
-    }
-
-    &.vs-responsive {
-        @apply w-full;
-        container-type: inline-size;
-    }
-
-    &.vs-dense {
-        th,
-        td {
-            @apply px-[0.375rem] py-[0.5rem];
-            * {
-                font-size: var(--vs-font-size-sm);
-            }
-        }
-
-        td.vs-table-expanded-row {
-            @apply px-0 py-0;
-        }
-    }
-
-    &.vs-primary {
-        thead tr th {
-            border-color: var(--vs-cs-line);
-            background-color: var(--vs-cs-bg-primary);
-            color: var(--vs-cs-font-primary);
-            font-weight: var(--vs-font-weight-bold);
-        }
-    }
-
+    /* ── Draggable ── */
     .vs-table-draggable-wrapper {
         /* display: contents를 사용하는 이유:
            - draggable의 wrapper 엘리먼트가 DOM 구조상 table, tr, tbody 등과 섞이면서 table 레이아웃이 깨지는 문제를 막기 위해
@@ -174,106 +160,174 @@
         display: contents;
     }
 
-    th.vs-table-drag-handle {
+    /* ── Handle cells ── */
+    .vs-table-th.vs-table-drag-handle {
         @apply w-6 px-0!;
+
         svg {
             @apply hidden;
         }
     }
-    td.vs-table-drag-handle {
+
+    .vs-table-td.vs-table-drag-handle {
         @apply w-6 cursor-grab px-0!;
         color: var(--vs-cs-line);
     }
 
-    th.vs-table-expand-handle {
+    .vs-table-th.vs-table-expand-handle,
+    .vs-table-td.vs-table-expand-handle {
         width: 3.6rem;
     }
-    td.vs-table-expand-handle {
-        width: 3.6rem;
+
+    /* ── Pagination ── */
+    .vs-table-pagination {
+        @apply flex items-center justify-between py-4;
+        container-type: inline-size;
+    }
+
+    .vs-table-pagination-info {
+        @apply flex items-center gap-4;
+    }
+
+    .vs-total-items {
+        @apply text-sm whitespace-nowrap opacity-70;
+        color: var(--vs-cs-font);
+    }
+
+    .vs-table-caption {
+        @apply caption-bottom;
+    }
+
+    /* ── Modifiers ── */
+    &.vs-responsive {
+        @apply w-full;
+        container-type: inline-size;
+    }
+
+    &.vs-dense {
+        .vs-table-th,
+        .vs-table-td {
+            @apply px-[0.375rem] py-[0.5rem];
+            * {
+                font-size: var(--vs-font-size-sm);
+            }
+        }
+
+        .vs-table-td.vs-table-expanded-row {
+            @apply px-0 py-0;
+        }
+    }
+
+    &.vs-primary {
+        .vs-table-thead > .vs-table-header-row > .vs-table-th {
+            border-color: var(--vs-cs-line);
+            background-color: var(--vs-cs-bg-primary);
+            color: var(--vs-cs-font-primary);
+            font-weight: var(--vs-font-weight-bold);
+        }
     }
 }
 
-/* Pagination */
-.vs-table-pagination {
-    @apply flex items-center justify-between py-4;
-    container-type: inline-size;
-}
-
-.vs-table-pagination-info {
-    @apply flex items-center gap-4;
-}
-
-.vs-total-items {
-    @apply text-sm whitespace-nowrap opacity-70;
-    color: var(--vs-cs-font);
-}
-
-caption {
-    @apply caption-bottom;
-}
-
+/* ── Responsive layout ── */
 @container (max-width: 1024px) {
-    .vs-table {
-        &.vs-responsive {
-            .vs-table-content {
-                @apply overflow-x-visible;
-            }
+    .vs-table.vs-responsive {
+        > .vs-table-content {
+            @apply overflow-x-visible;
+        }
 
-            table {
-                @apply min-w-full;
-            }
+        .vs-table-table {
+            @apply min-w-full;
+        }
 
-            tbody,
-            th,
-            td,
-            tr {
-                @apply block w-full border-x-0;
-            }
+        .vs-table-draggable-wrapper,
+        .vs-table-tbody,
+        .vs-table-th,
+        .vs-table-td,
+        .vs-table-body-row,
+        .vs-table-header-row {
+            @apply block w-full border-x-0;
+        }
 
-            thead {
-                @apply absolute m-0 block h-1 w-1 overflow-hidden border-0;
-            }
+        .vs-table-thead {
+            @apply absolute m-0 block h-1 w-1 overflow-hidden border-0;
+        }
 
-            tbody tr {
-                @apply mx-0 mb-3 border border-solid;
-                border: 0.0325rem solid var(--vs-cs-line);
-            }
+        .vs-table-draggable-wrapper > .vs-table-body-row {
+            @apply mx-0 mb-3 border border-solid;
+            border: 0.0325rem solid var(--vs-cs-line);
+        }
 
-            td {
-                @apply grid gap-2 border-r-0 border-b border-l-0 border-dashed p-3;
-                grid-column: minmax(6rem, 9rem) 1fr;
-            }
+        .vs-table-td {
+            @apply grid gap-2 border-r-0 border-b border-l-0 border-dashed p-3;
+            grid-column: minmax(6rem, 9rem) 1fr;
+        }
 
-            td:first-child {
-                @apply border-t-0;
-            }
+        .vs-table-td:first-child {
+            @apply border-t-0;
+        }
 
-            td:last-child {
-                @apply border-b-0;
-            }
+        .vs-table-td:last-child {
+            @apply border-b-0;
+        }
 
-            td::before {
-                @apply font-bold;
-                content: attr(data-label);
-            }
+        .vs-table-td::before {
+            @apply font-bold;
+            content: attr(data-label);
+        }
 
-            td.vs-table-drag-handle {
-                @apply w-6 px-0 py-1;
-            }
+        .vs-table-td.vs-table-drag-handle {
+            @apply w-6 px-0 py-1;
+        }
 
-            &.vs-dense {
-                td,
-                th {
-                    @apply px-[0.375rem] py-[0.5rem];
-                    * {
-                        font-size: var(--vs-font-size-sm);
-                    }
+        &.vs-dense {
+            .vs-table-td,
+            .vs-table-th {
+                @apply px-[0.375rem] py-[0.5rem];
+                * {
+                    font-size: var(--vs-font-size-sm);
                 }
             }
         }
 
-        .vs-table-pagination {
-            @apply flex-col-reverse items-center justify-center gap-2;
+        .vs-table {
+            .vs-table-draggable-wrapper,
+            .vs-table-tbody,
+            .vs-table-th,
+            .vs-table-td,
+            .vs-table-body-row,
+            .vs-table-header-row {
+                @apply grid border-x-[revert];
+            }
+
+            .vs-table-thead {
+                @apply static m-0 block h-auto w-auto overflow-visible border-0;
+            }
+
+            .vs-table-draggable-wrapper > .vs-table-body-row {
+                @apply mx-0 mb-0 border-0;
+                border: revert;
+            }
+
+            .vs-table-td {
+                @apply flex border-0 border-t border-solid p-[0.6rem_0.8rem];
+                grid-column: revert;
+            }
+
+            .vs-table-td:first-child {
+                @apply border-t;
+            }
+
+            .vs-table-td:last-child {
+                @apply border-b-0;
+            }
+
+            .vs-table-td::before {
+                content: none;
+            }
         }
+    }
+
+    .vs-table .vs-table-pagination {
+        @apply flex-col-reverse items-center justify-center gap-2;
     }
 }

--- a/packages/vlossom/src/components/vs-table/VsTable.vue
+++ b/packages/vlossom/src/components/vs-table/VsTable.vue
@@ -1,10 +1,14 @@
 <template>
     <div :class="['vs-table', colorSchemeClass, classObj]" :style="componentStyleSet.component">
-        <div v-if="search || $slots['toolbar']" class="vs-table-toolbar">
-            <div class="vs-table-toolbar-start" :style="componentStyleSet.toolbar">
+        <vs-grid v-if="search || $slots['toolbar']" class="vs-table-toolbar" :column-gap="'1rem'">
+            <vs-responsive
+                class="vs-table-toolbar-start"
+                :grid="{ sm: 12, md: search ? 10 : 12 }"
+                :style="componentStyleSet.toolbar"
+            >
                 <slot name="toolbar" />
-            </div>
-            <div v-if="search" class="vs-table-search-input">
+            </vs-responsive>
+            <vs-responsive v-if="search" class="vs-table-search-input" :grid="{ sm: 12, md: 2 }">
                 <vs-search-input
                     ref="searchInputRef"
                     v-bind="searchOptions"
@@ -12,8 +16,8 @@
                     :disabled="loading"
                     @search="searchRows"
                 />
-            </div>
-        </div>
+            </vs-responsive>
+        </vs-grid>
 
         <div
             v-if="useStickyHeader"
@@ -117,6 +121,8 @@ import { DEFAULT_PAGE_SIZE, DEFAULT_PAGE_SIZE_OPTIONS, TABLE_DRAG_WRAPPER_CLASS 
 import type { VsSearchInputRef } from '../vs-search-input/types';
 
 import VsSearchInput from '@/components/vs-search-input/VsSearchInput.vue';
+import VsGrid from '@/components/vs-grid/VsGrid.vue';
+import VsResponsive from '@/components/vs-responsive/VsResponsive.vue';
 import VsTableHeader from './VsTableHeader.vue';
 import VsTableBody from './VsTableBody.vue';
 import VsTablePagination from './VsTablePagination.vue';
@@ -125,7 +131,7 @@ const componentName = VsComponent.VsTable;
 
 export default defineComponent({
     name: componentName,
-    components: { VsTableHeader, VsTableBody, VsSearchInput, VsTablePagination },
+    components: { VsTableHeader, VsTableBody, VsSearchInput, VsTablePagination, VsGrid, VsResponsive },
     props: {
         ...getColorSchemeProps(),
         ...getStyleSetProps<VsTableStyleSet>(),

--- a/packages/vlossom/src/components/vs-table/VsTable.vue
+++ b/packages/vlossom/src/components/vs-table/VsTable.vue
@@ -21,7 +21,7 @@
             class="vs-table-sticky-wrapper"
             :style="{ top: stickyHeaderTop }"
         >
-            <table>
+            <table class="vs-table-table">
                 <vs-table-header class="vs-table-sticky-header" @click-cell="clickCell" @select-row="selectRow">
                     <template v-for="name in headerSlots" #[name]="slotData">
                         <slot :name v-bind="slotData || {}" />
@@ -36,8 +36,8 @@
                 :selector="`.${TABLE_DRAG_WRAPPER_CLASS}`"
                 root-margin="150px"
             >
-                <table>
-                    <caption v-if="$slots['caption']">
+                <table class="vs-table-table">
+                    <caption v-if="$slots['caption']" class="vs-table-caption">
                         <slot name="caption" />
                     </caption>
                     <vs-table-header

--- a/packages/vlossom/src/components/vs-table/VsTable.vue
+++ b/packages/vlossom/src/components/vs-table/VsTable.vue
@@ -1,13 +1,19 @@
 <template>
     <div :class="['vs-table', colorSchemeClass, classObj]" :style="componentStyleSet.component">
-        <vs-search-input
-            v-if="search"
-            ref="searchInputRef"
-            class="vs-table-search-input"
-            v-bind="searchOptions"
-            :disabled="loading"
-            @search="searchRows"
-        />
+        <div v-if="search || $slots['toolbar']" class="vs-table-toolbar">
+            <div class="vs-table-toolbar-start" :style="componentStyleSet.toolbar">
+                <slot name="toolbar" />
+            </div>
+            <div v-if="search" class="vs-table-search-input">
+                <vs-search-input
+                    ref="searchInputRef"
+                    v-bind="searchOptions"
+                    :style-set="componentStyleSet.search"
+                    :disabled="loading"
+                    @search="searchRows"
+                />
+            </div>
+        </div>
 
         <div
             v-if="useStickyHeader"

--- a/packages/vlossom/src/components/vs-table/VsTableBody.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableBody.vue
@@ -3,7 +3,7 @@
         tag="tbody"
         v-model="displayedBodyCells"
         v-bind="DEFAULT_SORTABLE_OPTIONS"
-        :class="TABLE_DRAG_WRAPPER_CLASS"
+        :class="[TABLE_DRAG_WRAPPER_CLASS, 'vs-table-body']"
         :item-key="getRowId"
         :disabled="loading"
         @update="handleDragUpdate"

--- a/packages/vlossom/src/components/vs-table/VsTableBody.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableBody.vue
@@ -23,12 +23,12 @@
         </template>
     </draggable>
 
-    <tbody v-if="displayedBodyCells.length === 0">
-        <tr>
-            <td colspan="100%" class="h-52">
-                <div class="flex flex-col items-center justify-center text-gray-700">
+    <tbody class="vs-table-tbody" v-if="displayedBodyCells.length === 0">
+        <tr class="vs-table-body-row">
+            <td class="vs-table-td vs-table-no-data-cell" colspan="100%">
+                <div class="vs-table-no-data">
                     <vs-render :content="tableIcons.noData" />
-                    <p class="text-xl font-bold">NO DATA</p>
+                    <p class="vs-table-no-data-text">NO DATA</p>
                 </div>
             </td>
         </tr>

--- a/packages/vlossom/src/components/vs-table/VsTableBodyRow.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableBodyRow.vue
@@ -1,5 +1,5 @@
 <template>
-    <tr :class="[classObj, stateClasses]" :style="rowStyle">
+    <tr :class="['vs-table-body-row', classObj, stateClasses]" :style="rowStyle">
         <vs-table-drag-cell :cells :rowIdx />
         <vs-table-checkbox-cell :cells :rowIdx @select-row="selectRow">
             <template #select="slotData">
@@ -8,6 +8,7 @@
         </vs-table-checkbox-cell>
         <template v-for="(cell, index) in cells" :key="cell.id">
             <td
+                class="vs-table-td"
                 :id="cell.id"
                 :style="getCellStyle(index)"
                 :data-label="getHeaderLabel(cell.colIdx, cell.colKey)"
@@ -30,7 +31,7 @@
             </td>
         </template>
         <vs-table-expand-cell :cells :rowIdx @expand-row="expandRow" />
-        <td v-if="anyExpandable" class="vs-table-expanded-row">
+        <td v-if="anyExpandable" class="vs-table-td vs-table-expanded-row">
             <vs-table-expanded-panel :cells :rowIdx>
                 <template #expand="slotData">
                     <slot name="expand" v-bind="slotData" />

--- a/packages/vlossom/src/components/vs-table/VsTableCheckboxCell.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableCheckboxCell.vue
@@ -1,6 +1,6 @@
 <template>
     <template v-if="isBodyRow(cells)">
-        <td v-if="anySelectable" :style="cellStyle" @click.prevent.stop="selectRow(cells, $event)">
+        <td class="vs-table-td" v-if="anySelectable" :style="cellStyle" @click.prevent.stop="selectRow(cells, $event)">
             <slot name="select" :item="getRowItem(cells)" :value="isSelected(cells)" :rowIdx>
                 <vs-checkbox
                     v-if="isRowSelectable(cells, rowIdx)"
@@ -16,7 +16,7 @@
     </template>
 
     <template v-else>
-        <th v-if="anySelectable" :style="cellStyle" @click.prevent.stop="selectRow(cells, $event)">
+        <th class="vs-table-th" v-if="anySelectable" :style="cellStyle" @click.prevent.stop="selectRow(cells, $event)">
             <slot name="select" :item="null" :value="isSelected(cells)" :rowIdx="HEADER_ROW_INDEX">
                 <vs-checkbox
                     :style-set="headerCheckboxStyle"

--- a/packages/vlossom/src/components/vs-table/VsTableDragCell.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableDragCell.vue
@@ -1,5 +1,5 @@
 <template>
-    <component v-if="draggable" :is="tag" :class="TABLE_DRAG_HANDLE_CLASS" :style="cellStyle">
+    <component v-if="draggable" :is="tag" :class="[cellTypeClass, TABLE_DRAG_HANDLE_CLASS]" :style="cellStyle">
         <vs-render :content="tableIcons.dragHandle" />
     </component>
 </template>
@@ -35,12 +35,14 @@ export default defineComponent({
         const tableStyleSet = inject<ComputedRef<VsTableStyleSet>>(TABLE_STYLE_SET_TOKEN);
 
         const tag = computed<VsTableTag>(() => (isVsTableBodyRow(cells.value) ? 'td' : 'th'));
+        const cellTypeClass = computed(() => (isVsTableBodyRow(cells.value) ? 'vs-table-td' : 'vs-table-th'));
         const cellStyle = computed(() => tableStyleSet?.value?.cell);
 
         return {
             TABLE_DRAG_HANDLE_CLASS,
             tableIcons,
             tag,
+            cellTypeClass,
             cellStyle,
             draggable,
         };

--- a/packages/vlossom/src/components/vs-table/VsTableExpandCell.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableExpandCell.vue
@@ -1,6 +1,6 @@
 <template>
     <template v-if="isBodyRow(cells)">
-        <td v-if="anyExpandable" class="vs-table-expand-handle" :style="cellStyle">
+        <td v-if="anyExpandable" class="vs-table-td vs-table-expand-handle" :style="cellStyle">
             <vs-button
                 v-if="isExpandable(cells, rowIdx)"
                 :color-scheme
@@ -27,7 +27,7 @@
         </td>
     </template>
     <template v-else>
-        <th v-if="anyExpandable" class="vs-table-expand-handle" :style="cellStyle" />
+        <th v-if="anyExpandable" class="vs-table-th vs-table-expand-handle" :style="cellStyle" />
     </template>
 </template>
 

--- a/packages/vlossom/src/components/vs-table/VsTableHeader.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableHeader.vue
@@ -1,7 +1,7 @@
 <template>
-    <thead>
+    <thead class="vs-table-thead">
         <template v-if="headerCells.length">
-            <tr :style="headerStyle">
+            <tr class="vs-table-header-row" :style="headerStyle">
                 <vs-table-drag-cell :cells="headerCells" :rowIdx="HEADER_ROW_INDEX" />
                 <vs-table-checkbox-cell :cells="headerCells" :rowIdx="HEADER_ROW_INDEX" @select-row="selectRow">
                     <template #select="slotData">
@@ -9,6 +9,7 @@
                     </template>
                 </vs-table-checkbox-cell>
                 <th
+                    class="vs-table-th"
                     v-for="(header, index) in headerCells"
                     :key="header.id"
                     :id="header.id"

--- a/packages/vlossom/src/components/vs-table/types.ts
+++ b/packages/vlossom/src/components/vs-table/types.ts
@@ -1,6 +1,7 @@
 import type { CSSProperties } from 'vue';
 import type { SizeProp, TextAlignment, VerticalAlignment } from '@/declaration';
 import type VsTable from './VsTable.vue';
+import type { VsSearchInputStyleSet } from '@/components/vs-search-input/types';
 
 declare module 'vue' {
     interface GlobalComponents {
@@ -13,6 +14,8 @@ export const TABLE_COLOR_SCHEME_TOKEN = Symbol('TABLE_COLOR_SCHEME_TOKEN');
 
 export interface VsTableStyleSet {
     component?: CSSProperties;
+    toolbar?: CSSProperties;
+    search?: VsSearchInputStyleSet;
     header?: CSSProperties;
     row?: CSSProperties;
     selectedRow?: CSSProperties;


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)
-   [x] Fix Bug (fix)

## Description
- vs-table search 왼쪽 영역을 slot으로 제공
<img width="1354" height="232" alt="image" src="https://github.com/user-attachments/assets/c2fd955c-4dcd-407b-8493-a6684654a452" />

- vs-table CSS 스타일 정리 (nested 구조 정리)
- 다른 내부 element에 영향 주지 않기 위해서 html element selector 쓰지 않게 class name 부여
- vs-table 안에 expand로 vs-table이 있는 경우 스타일 이슈 확인 완료

<img width="1348" height="387" alt="image" src="https://github.com/user-attachments/assets/a0ef9151-d79d-4cb8-acd3-ccc1a83bbc91" />

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
