### PR TITLE
fix(VsTabs): fix VsTabs divider style bug

### DIFF
--- a/packages/vlossom/src/components/vs-tabs/VsTabs.css
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.css
@@ -17,7 +17,7 @@
     height: var(--vs-tabs-height, var(--vs-comp-height-md));
 
     .vs-tabs-wrap {
-        @apply relative flex w-full overflow-auto pb-1;
+        @apply relative flex w-full overflow-auto;
 
         .vs-tab-list {
             @apply relative m-0 flex flex-1 list-none flex-nowrap items-center;
@@ -96,10 +96,10 @@
         height: var(--vs-tabs-height, auto);
 
         .vs-tabs-wrap {
-            @apply h-full flex-col pr-1 pb-0;
+            @apply h-full flex-col;
 
             .vs-tab-list {
-                @apply flex-col items-stretch;
+                @apply h-auto flex-col items-stretch;
 
                 border-right: var(--vs-tabs-divider, 1px solid var(--tab-border-color));
                 border-bottom: 0;


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Fix Bug (fix)

## Summary

이슈: #416 

VsTabs vertical 모드에서 height 제한 + 탭 개수가 많을 경우, 오른쪽 divider가 탭 콘텐츠 끝까지 이어지지 않고 중간에서 끊기는 버그를 수정합니다.

## Description

### 버그 발생 원인

1. `.vs-tab-list`에 base 스타일로`height: var(--vs-tabs-height)` 가 적용됨
2. vertical 모드에서 height 값이 prop을 통해 주어질 경우 `.vs-tab-list`에 위 속성이 그대로 적용되어 박스 높이가 height 값으로 고정됨
3. 주어진 height 값을 초과할 정도로 탭 개수가 많아져도, `.vs-tab-list` 박스의 높이는 여전히 height 값과 동일함. 여기서 VsTabs의 divider가 `.vs-tab-list`의 right border이기 때문에 버그가 발생함.

### 변경 사항

1. `.vs-tab-list`(vertical)에 `h-auto`를 추가하여 `.vs-tab-list`가 탭 콘텐츠 전체를 감싸도록 변경합니다.
2. 커스텀 시 방해가 되는 불필요한 패딩들을 제거합니다.