### PR TITLE
feat(VsTable): modify 'slots' and color-scheme propagation

### DIFF
--- a/packages/vlossom/src/components/vs-table/README.ko.md
+++ b/packages/vlossom/src/components/vs-table/README.ko.md
@@ -74,6 +74,20 @@ const selected = ref([]);
 </template>
 ```
 
+### 빈 상태
+
+`items`가 비어있을 때 기본 "NO DATA" 자리표시자 대신 표시할 내용을 `empty` 슬롯으로 제공합니다. `loading`이 true이면 로딩 인디케이터가 이 슬롯보다 우선 표시됩니다.
+
+```html
+<template>
+    <vs-table :columns="columns" :items="[]">
+        <template #empty>
+            <div>일치하는 결과가 없습니다.</div>
+        </template>
+    </vs-table>
+</template>
+```
+
 ### 서버 모드
 
 ```html
@@ -199,6 +213,7 @@ interface VsTablePaginationOptions {
 | `body-[key]`   | 특정 컬럼 키의 커스텀 바디 셀                                  |
 | `select`       | 선택 컬럼 셀의 커스텀 내용                                     |
 | `expand`       | 확장 행 패널의 커스텀 내용. `expandable`이 활성화된 경우 이 슬롯이 있어야 확장 UI가 렌더링됩니다 |
+| `empty`        | 행이 없을 때 표시할 커스텀 내용. 미제공 시 기본 "NO DATA" 자리표시자가 사용됩니다 |
 
 ## 메서드
 

--- a/packages/vlossom/src/components/vs-table/README.ko.md
+++ b/packages/vlossom/src/components/vs-table/README.ko.md
@@ -62,9 +62,11 @@ const selected = ref([]);
 
 ### 확장 행
 
+`expandable`은 기본값이 `true`이지만, 확장 UI(토글 버튼과 확장 패널)는 `expand` 슬롯이 제공된 경우에만 렌더링됩니다. 확장 기능 자체를 끄려면 `:expandable="false"`로 명시하세요.
+
 ```html
 <template>
-    <vs-table :columns="columns" :items="items" expandable>
+    <vs-table :columns="columns" :items="items">
         <template #expand="{ item }">
             <div>{{ item.detail }}</div>
         </template>
@@ -98,7 +100,7 @@ const selected = ref([]);
 | `items`           | `VsTableItem[]`                                | `[]`     | 데이터 행                               |
 | `dense`           | `boolean`                                      | `false`  | 셀 패딩 축소                            |
 | `draggable`       | `boolean`                                      | `false`  | 드래그 앤 드롭 행 재정렬 활성화         |
-| `expandable`      | `boolean \| (item, index?, items?) => boolean` | `false`  | 확장 행 활성화                          |
+| `expandable`      | `boolean \| (item, index?, items?) => boolean` | `true`   | 확장 행 활성화. `expand` 슬롯이 제공된 경우에만 확장 UI가 렌더링됩니다 |
 | `loading`         | `boolean`                                      | `false`  | 로딩 상태 표시 및 검색 비활성화         |
 | `noVirtualScroll` | `boolean`                                      | `false`  | 가상 스크롤 최적화 비활성화             |
 | `page`            | `number`                                       |          | 현재 페이지 인덱스(0부터 시작), v-model |
@@ -196,7 +198,7 @@ interface VsTablePaginationOptions {
 | `header-[key]` | 특정 컬럼 키의 커스텀 헤더 셀                                  |
 | `body-[key]`   | 특정 컬럼 키의 커스텀 바디 셀                                  |
 | `select`       | 선택 컬럼 셀의 커스텀 내용                                     |
-| `expand`       | 확장 행 패널의 커스텀 내용                                     |
+| `expand`       | 확장 행 패널의 커스텀 내용. `expandable`이 활성화된 경우 이 슬롯이 있어야 확장 UI가 렌더링됩니다 |
 
 ## 메서드
 

--- a/packages/vlossom/src/components/vs-table/README.md
+++ b/packages/vlossom/src/components/vs-table/README.md
@@ -74,6 +74,20 @@ const selected = ref([]);
 </template>
 ```
 
+### Empty State
+
+Provide an `empty` slot to replace the default "NO DATA" placeholder when `items` is empty. When `loading` is true, the loading indicator takes priority over this slot.
+
+```html
+<template>
+    <vs-table :columns="columns" :items="[]">
+        <template #empty>
+            <div>No matching results.</div>
+        </template>
+    </vs-table>
+</template>
+```
+
 ### Server Mode
 
 ```html
@@ -199,6 +213,7 @@ interface VsTablePaginationOptions {
 | `body-[key]`   | Custom body cell for a specific column key                                      |
 | `select`       | Custom content for the selection column cell                                    |
 | `expand`       | Custom content for the expanded row panel. Required to render the expand UI when `expandable` is enabled |
+| `empty`        | Custom content shown when there are no rows. Falls back to the default "NO DATA" placeholder when omitted |
 
 ## Methods
 

--- a/packages/vlossom/src/components/vs-table/README.md
+++ b/packages/vlossom/src/components/vs-table/README.md
@@ -62,9 +62,11 @@ const selected = ref([]);
 
 ### Expandable Rows
 
+`expandable` is `true` by default, but the expand UI (toggle button and expanded panel) is rendered only when the `expand` slot is provided. Pass `:expandable="false"` to disable expansion entirely.
+
 ```html
 <template>
-    <vs-table :columns="columns" :items="items" expandable>
+    <vs-table :columns="columns" :items="items">
         <template #expand="{ item }">
             <div>{{ item.detail }}</div>
         </template>
@@ -98,7 +100,7 @@ const selected = ref([]);
 | `items`           | `VsTableItem[]`                                | `[]`     | Data rows                                   |
 | `dense`           | `boolean`                                      | `false`  | Reduces cell padding                        |
 | `draggable`       | `boolean`                                      | `false`  | Enables drag-and-drop row reordering        |
-| `expandable`      | `boolean \| (item, index?, items?) => boolean` | `false`  | Enables expandable rows                     |
+| `expandable`      | `boolean \| (item, index?, items?) => boolean` | `true`   | Enables expandable rows. Expand UI is rendered only when an `expand` slot is provided |
 | `loading`         | `boolean`                                      | `false`  | Shows loading state and disables search     |
 | `noVirtualScroll` | `boolean`                                      | `false`  | Disables virtual scroll optimization        |
 | `page`            | `number`                                       |          | Current page index (0-based), v-model       |
@@ -196,7 +198,7 @@ interface VsTablePaginationOptions {
 | `header-[key]` | Custom header cell for a specific column key                                    |
 | `body-[key]`   | Custom body cell for a specific column key                                      |
 | `select`       | Custom content for the selection column cell                                    |
-| `expand`       | Custom content for the expanded row panel                                       |
+| `expand`       | Custom content for the expanded row panel. Required to render the expand UI when `expandable` is enabled |
 
 ## Methods
 

--- a/packages/vlossom/src/components/vs-table/VsTable.vue
+++ b/packages/vlossom/src/components/vs-table/VsTable.vue
@@ -12,6 +12,7 @@
                 <vs-search-input
                     ref="searchInputRef"
                     v-bind="searchOptions"
+                    :color-scheme="computedColorScheme"
                     :style-set="componentStyleSet.search"
                     :disabled="loading"
                     @search="searchRows"
@@ -403,6 +404,7 @@ export default defineComponent({
         return {
             TABLE_DRAG_WRAPPER_CLASS,
             colorSchemeClass,
+            computedColorScheme,
             componentStyleSet,
             classObj,
             headerRef,

--- a/packages/vlossom/src/components/vs-table/VsTable.vue
+++ b/packages/vlossom/src/components/vs-table/VsTable.vue
@@ -186,7 +186,7 @@ export default defineComponent({
             type: [Boolean, Function] as PropType<
                 boolean | ((item: VsTableItem, index?: number, items?: VsTableItem[]) => boolean)
             >,
-            default: false,
+            default: true,
         },
         state: {
             type: [String, Function] as PropType<

--- a/packages/vlossom/src/components/vs-table/VsTable.vue
+++ b/packages/vlossom/src/components/vs-table/VsTable.vue
@@ -116,7 +116,13 @@ import {
     type VsTablePaginationOptions,
     type VsTablePageSizeOptions,
 } from './types';
-import { DEFAULT_PAGE_SIZE, DEFAULT_PAGE_SIZE_OPTIONS, TABLE_DRAG_WRAPPER_CLASS } from './constants';
+import {
+    DEFAULT_PAGE_SIZE,
+    DEFAULT_PAGE_SIZE_OPTIONS,
+    TABLE_DRAG_WRAPPER_CLASS,
+    VS_TABLE_BODY_SLOT_PREFIXES,
+    VS_TABLE_HEADER_SLOT_PREFIXES,
+} from './constants';
 import { getRowItem } from './models/table-model';
 
 import type { VsSearchInputRef } from './../vs-search-input/types';
@@ -307,12 +313,12 @@ export default defineComponent({
 
         const headerSlots = computed(() =>
             Object.keys(slots).filter((slotName) =>
-                ['header', 'select', 'expand'].some((whitelist) => slotName.startsWith(whitelist)),
+                VS_TABLE_HEADER_SLOT_PREFIXES.some((whitelist) => slotName.startsWith(whitelist)),
             ),
         );
         const bodySlots = computed(() =>
             Object.keys(slots).filter((slotName) =>
-                ['body', 'select', 'expand', 'empty'].some((whitelist) => slotName.startsWith(whitelist)),
+                VS_TABLE_BODY_SLOT_PREFIXES.some((whitelist) => slotName.startsWith(whitelist)),
             ),
         );
         const classObj = computed(() => ({

--- a/packages/vlossom/src/components/vs-table/VsTable.vue
+++ b/packages/vlossom/src/components/vs-table/VsTable.vue
@@ -312,7 +312,7 @@ export default defineComponent({
         );
         const bodySlots = computed(() =>
             Object.keys(slots).filter((slotName) =>
-                ['body', 'select', 'expand'].some((whitelist) => slotName.startsWith(whitelist)),
+                ['body', 'select', 'expand', 'empty'].some((whitelist) => slotName.startsWith(whitelist)),
             ),
         );
         const classObj = computed(() => ({

--- a/packages/vlossom/src/components/vs-table/VsTable.vue
+++ b/packages/vlossom/src/components/vs-table/VsTable.vue
@@ -307,7 +307,7 @@ export default defineComponent({
 
         const headerSlots = computed(() =>
             Object.keys(slots).filter((slotName) =>
-                ['header', 'select'].some((whitelist) => slotName.startsWith(whitelist)),
+                ['header', 'select', 'expand'].some((whitelist) => slotName.startsWith(whitelist)),
             ),
         );
         const bodySlots = computed(() =>

--- a/packages/vlossom/src/components/vs-table/VsTableBody.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableBody.vue
@@ -28,7 +28,7 @@
             <td class="vs-table-td vs-table-no-data-cell" colspan="100%">
                 <div class="vs-table-no-data">
                     <template v-if="loading">
-                        <vs-loading />
+                        <vs-loading :color-scheme />
                     </template>
                     <template v-else>
                         <vs-render :content="tableIcons.noData" />
@@ -41,8 +41,9 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, inject, ref, watch } from 'vue';
-import { type VsTableBodyCell } from './types';
+import { computed, defineComponent, inject, ref, watch, type ComputedRef } from 'vue';
+import type { ColorScheme } from '@/declaration';
+import { TABLE_COLOR_SCHEME_TOKEN, type VsTableBodyCell } from './types';
 import { tableIcons } from './icons';
 import { DEFAULT_SORTABLE_OPTIONS, TABLE_DRAG_WRAPPER_CLASS } from './constants';
 import { TABLE_COMPOSABLE_TOKEN, type TableComposable } from './composables/table-composable';
@@ -64,6 +65,7 @@ export default defineComponent({
     emits: ['click-cell', 'select-row', 'expand-row', 'drag'],
     setup(props, { slots, emit }) {
         const { bodyCells, loading } = inject<TableComposable>(TABLE_COMPOSABLE_TOKEN)!;
+        const colorScheme = inject<ComputedRef<ColorScheme | undefined>>(TABLE_COLOR_SCHEME_TOKEN);
 
         const bodySlots = computed(() =>
             Object.keys(slots).filter((slotName) =>
@@ -118,6 +120,7 @@ export default defineComponent({
             DEFAULT_SORTABLE_OPTIONS,
             TABLE_DRAG_WRAPPER_CLASS,
             bodySlots,
+            colorScheme,
             displayedBodyCells,
             loading,
             tableIcons,

--- a/packages/vlossom/src/components/vs-table/VsTableBody.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableBody.vue
@@ -48,7 +48,7 @@ import { computed, defineComponent, inject, ref, watch, type ComputedRef } from 
 import type { ColorScheme } from '@/declaration';
 import { TABLE_COLOR_SCHEME_TOKEN, type VsTableBodyCell } from './types';
 import { tableIcons } from './icons';
-import { DEFAULT_SORTABLE_OPTIONS, TABLE_DRAG_WRAPPER_CLASS } from './constants';
+import { DEFAULT_SORTABLE_OPTIONS, TABLE_DRAG_WRAPPER_CLASS, VS_TABLE_BODY_SLOT_PREFIXES } from './constants';
 import { TABLE_COMPOSABLE_TOKEN, type TableComposable } from './composables/table-composable';
 import draggable from 'vuedraggable/src/vuedraggable';
 import type { SortableEvent } from 'sortablejs';
@@ -72,7 +72,7 @@ export default defineComponent({
 
         const bodySlots = computed(() =>
             Object.keys(slots).filter((slotName) =>
-                ['body', 'select', 'expand', 'empty'].some((whitelist) => slotName.startsWith(whitelist)),
+                VS_TABLE_BODY_SLOT_PREFIXES.some((whitelist) => slotName.startsWith(whitelist)),
             ),
         );
 

--- a/packages/vlossom/src/components/vs-table/VsTableBody.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableBody.vue
@@ -30,6 +30,9 @@
                     <template v-if="loading">
                         <vs-loading :color-scheme />
                     </template>
+                    <template v-else-if="$slots['empty']">
+                        <slot name="empty" />
+                    </template>
                     <template v-else>
                         <vs-render :content="tableIcons.noData" />
                         <p class="vs-table-no-data-text">NO DATA</p>
@@ -69,7 +72,7 @@ export default defineComponent({
 
         const bodySlots = computed(() =>
             Object.keys(slots).filter((slotName) =>
-                ['body', 'select', 'expand'].some((whitelist) => slotName.startsWith(whitelist)),
+                ['body', 'select', 'expand', 'empty'].some((whitelist) => slotName.startsWith(whitelist)),
             ),
         );
 

--- a/packages/vlossom/src/components/vs-table/VsTableBodyRow.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableBodyRow.vue
@@ -14,7 +14,7 @@
                 :data-label="getHeaderLabel(cell.colIdx, cell.colKey)"
                 @click.prevent.stop="clickCell(cell, $event)"
             >
-                <vs-skeleton v-if="loading" :style-set="skeletonStyleSet" />
+                <vs-skeleton v-if="loading" :color-scheme :style-set="skeletonStyleSet" />
                 <template v-else>
                     <slot
                         :name="findMatchingSlotName(cell)"
@@ -45,9 +45,15 @@
 import { defineComponent, inject, computed, type ComputedRef, type PropType, toRefs, type CSSProperties } from 'vue';
 import { stringUtil } from '@/utils';
 import { useStateClass } from '@/composables';
-import type { UIState } from '@/declaration';
+import type { ColorScheme, UIState } from '@/declaration';
 import type { VsSkeletonStyleSet } from './../vs-skeleton/types';
-import { TABLE_STYLE_SET_TOKEN, type VsTableBodyCell, type VsTableStyleSet, type VsTableColumnDef } from './types';
+import {
+    TABLE_COLOR_SCHEME_TOKEN,
+    TABLE_STYLE_SET_TOKEN,
+    type VsTableBodyCell,
+    type VsTableStyleSet,
+    type VsTableColumnDef,
+} from './types';
 import { TABLE_COMPOSABLE_TOKEN, type TableComposable } from './composables/table-composable';
 import { getRowItem } from './models/table-model';
 
@@ -91,6 +97,8 @@ export default defineComponent({
             dense,
         } = inject<TableComposable>(TABLE_COMPOSABLE_TOKEN)!;
         const tableStyleSet = inject<ComputedRef<VsTableStyleSet>>(TABLE_STYLE_SET_TOKEN);
+        const colorScheme = inject<ComputedRef<ColorScheme | undefined>>(TABLE_COLOR_SCHEME_TOKEN);
+
         const state = computed<UIState>(() => {
             return stateFn.value(getRowItem(cells.value), rowIndex.value, items?.value);
         });
@@ -102,7 +110,8 @@ export default defineComponent({
             }
             return selectedItems.value.includes(getRowItem(props.cells));
         });
-        const showExpand = computed(() =>  anyExpandable.value && !!slots.expand);
+
+        const showExpand = computed(() => anyExpandable.value && !!slots.expand);
 
         const classObj = computed(() => ({
             'vs-selected': isSelected.value,
@@ -230,6 +239,7 @@ export default defineComponent({
 
         return {
             anyExpandable,
+            colorScheme,
             draggable,
             loading,
             classObj,

--- a/packages/vlossom/src/components/vs-table/VsTableBodyRow.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableBodyRow.vue
@@ -30,8 +30,8 @@
                 </template>
             </td>
         </template>
-        <vs-table-expand-cell :cells :rowIdx @expand-row="expandRow" />
-        <td v-if="anyExpandable" class="vs-table-td vs-table-expanded-row">
+        <vs-table-expand-cell v-if="showExpand" :cells :rowIdx @expand-row="expandRow" />
+        <td v-if="showExpand" class="vs-table-td vs-table-expanded-row">
             <vs-table-expanded-panel :cells :rowIdx>
                 <template #expand="slotData">
                     <slot name="expand" v-bind="slotData" />
@@ -102,6 +102,7 @@ export default defineComponent({
             }
             return selectedItems.value.includes(getRowItem(props.cells));
         });
+        const showExpand = computed(() =>  anyExpandable.value && !!slots.expand);
 
         const classObj = computed(() => ({
             'vs-selected': isSelected.value,
@@ -233,6 +234,7 @@ export default defineComponent({
             loading,
             classObj,
             rowStyle,
+            showExpand,
             skeletonStyleSet,
             getCellStyle,
             stateClasses,

--- a/packages/vlossom/src/components/vs-table/VsTableExpandCell.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableExpandCell.vue
@@ -1,6 +1,6 @@
 <template>
-    <template v-if="isBodyRow(cells)">
-        <td v-if="anyExpandable" class="vs-table-td vs-table-expand-handle" :style="cellStyle">
+    <template v-if="isVsTableBodyRow(cells)">
+        <td class="vs-table-td vs-table-expand-handle" :style="cellStyle">
             <vs-button
                 v-if="isExpandable(cells, rowIdx)"
                 :color-scheme
@@ -27,7 +27,7 @@
         </td>
     </template>
     <template v-else>
-        <th v-if="anyExpandable" class="vs-table-th vs-table-expand-handle" :style="cellStyle" />
+        <th class="vs-table-th vs-table-expand-handle" :style="cellStyle" />
     </template>
 </template>
 
@@ -59,7 +59,7 @@ export default defineComponent({
     },
     emits: ['expand-row'],
     setup(_props, { emit }) {
-        const { anyExpandable, isExpanded, expandable, toggleExpand, items, loading, primary } =
+        const { isExpanded, expandable, toggleExpand, items, loading, primary } =
             inject<TableComposable>(TABLE_COMPOSABLE_TOKEN)!;
         const tableStyleSet = inject<ComputedRef<VsTableStyleSet>>(TABLE_STYLE_SET_TOKEN);
         const colorScheme = inject<ComputedRef<ColorScheme | undefined>>(TABLE_COLOR_SCHEME_TOKEN);
@@ -78,9 +78,8 @@ export default defineComponent({
         }
 
         return {
-            isBodyRow: isVsTableBodyRow,
+            isVsTableBodyRow,
             isExpandable,
-            anyExpandable,
             isExpanded,
             expandRow,
             tableIcons,

--- a/packages/vlossom/src/components/vs-table/VsTableHeader.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableHeader.vue
@@ -34,7 +34,7 @@
                         </div>
                     </slot>
                 </th>
-                <vs-table-expand-cell :cells="headerCells" :rowIdx="HEADER_ROW_INDEX" />
+                <vs-table-expand-cell v-if="showExpand" :cells="headerCells" :rowIdx="HEADER_ROW_INDEX" />
             </tr>
         </template>
     </thead>
@@ -72,6 +72,7 @@ export default defineComponent({
             inject<TableComposable>(TABLE_COMPOSABLE_TOKEN)!;
         const tableStyleSet = inject<ComputedRef<VsTableStyleSet>>(TABLE_STYLE_SET_TOKEN);
 
+        const showExpand = computed(() => anyExpandable.value && !!slots.expand);
         const cellStyle = computed<CSSProperties | undefined>(() => tableStyleSet?.value?.cell);
         const gridStyle = computed<CSSProperties | undefined>(() => {
             const cols: string[] = [];
@@ -176,6 +177,7 @@ export default defineComponent({
             HEADER_ROW_INDEX,
             headerCells,
             findMatchingSlotName,
+            showExpand,
             clickCell,
             selectRow,
             getSortIcon,

--- a/packages/vlossom/src/components/vs-table/__stories__/vs-table.stories.ts
+++ b/packages/vlossom/src/components/vs-table/__stories__/vs-table.stories.ts
@@ -72,7 +72,8 @@ const meta: Meta<typeof VsTable> = {
         },
         expandable: {
             control: { type: 'boolean' },
-            description: '행 확장을 활성화하거나 조건부 함수로 제어합니다.',
+            description:
+                '행 확장을 활성화하거나 조건부 함수로 제어합니다. 기본값은 `true`이지만, 확장 UI는 `expand` 슬롯이 제공된 경우에만 렌더링됩니다.',
         },
         colorScheme,
     },

--- a/packages/vlossom/src/components/vs-table/__stories__/vs-table.stories.ts
+++ b/packages/vlossom/src/components/vs-table/__stories__/vs-table.stories.ts
@@ -308,6 +308,31 @@ export const Expandable: Story = {
     },
 };
 
+export const Empty: Story = {
+    render: () => ({
+        components: { VsTable },
+        setup() {
+            return { columns: baseColumns };
+        },
+        template: `
+            <vs-table :columns="columns" :items="[]">
+                <template #empty>
+                    <div class="p-4 text-center text-sm text-slate-500">
+                        일치하는 결과가 없습니다.
+                    </div>
+                </template>
+            </vs-table>
+        `,
+    }),
+    parameters: {
+        docs: {
+            description: {
+                story: 'items가 비어있을 때 기본 "NO DATA" 자리표시자 대신 empty 슬롯 내용을 표시합니다.',
+            },
+        },
+    },
+};
+
 export const StickyHeader: Story = {
     render: () => ({
         components: { VsTable },

--- a/packages/vlossom/src/components/vs-table/__tests__/vs-table.test.ts
+++ b/packages/vlossom/src/components/vs-table/__tests__/vs-table.test.ts
@@ -184,6 +184,9 @@ describe('VsTable', () => {
         it('expandable이 true면 확장 버튼을 클릭하면 expand-row를 발생시킨다', async () => {
             const wrapper = mountTable({
                 props: { expandable: true },
+                slots: {
+                    expand: () => h('div'),
+                },
             });
 
             await nextTick();
@@ -198,6 +201,43 @@ describe('VsTable', () => {
             expect(cells).toHaveLength(defaultColumns.length);
             expect(cells[0]).toMatchObject({ colKey: 'name', value: 'Alice', rowIdx: 0, colIdx: 0 });
             expect(cells[0].item).toStrictEqual(tableItems[0]);
+        });
+
+        it('expand 슬롯이 없으면 expandable이 true여도 확장 버튼이 렌더링되지 않는다', async () => {
+            const wrapper = mountTable({
+                props: { expandable: true },
+            });
+
+            await nextTick();
+
+            expect(wrapper.findAll('tbody tr button')).toHaveLength(0);
+            expect(wrapper.find('.vs-table-expand-handle').exists()).toBe(false);
+        });
+
+        it('expandable이 false이면 expand 슬롯이 있어도 확장 UI가 렌더링되지 않는다', async () => {
+            const wrapper = mountTable({
+                props: { expandable: false },
+                slots: {
+                    expand: () => h('div'),
+                },
+            });
+
+            await nextTick();
+
+            expect(wrapper.findAll('tbody tr button')).toHaveLength(0);
+            expect(wrapper.find('.vs-table-expand-handle').exists()).toBe(false);
+        });
+
+        it('expandable prop을 지정하지 않아도 expand 슬롯만 있으면 확장 UI가 렌더링된다 (기본값 true)', async () => {
+            const wrapper = mountTable({
+                slots: {
+                    expand: ({ item }: { item: VsTableItem }) => h('div', {}, String(item.name)),
+                },
+            });
+
+            await nextTick();
+
+            expect(wrapper.findAll('tbody tr button')).toHaveLength(tableItems.length);
         });
     });
 
@@ -415,6 +455,9 @@ describe('VsTable', () => {
         it('expand 버튼 클릭 시 expand-row 이벤트를 발생시킨다', async () => {
             const wrapper = mountTable({
                 props: { expandable: true },
+                slots: {
+                    expand: () => h('div'),
+                },
             });
 
             await nextTick();

--- a/packages/vlossom/src/components/vs-table/__tests__/vs-table.test.ts
+++ b/packages/vlossom/src/components/vs-table/__tests__/vs-table.test.ts
@@ -101,6 +101,46 @@ describe('VsTable', () => {
         });
     });
 
+    describe('empty slot', () => {
+        it('items가 비어있고 empty 슬롯이 제공되면 슬롯 내용이 렌더링된다', async () => {
+            const wrapper = mountTable({
+                props: { items: [] },
+                slots: {
+                    empty: '<div data-testid="empty-slot">No matching results</div>',
+                },
+            });
+
+            await nextTick();
+
+            expect(wrapper.find('[data-testid="empty-slot"]').exists()).toBe(true);
+            expect(wrapper.find('[data-testid="empty-slot"]').text()).toBe('No matching results');
+            expect(wrapper.find('.vs-table-no-data-text').exists()).toBe(false);
+        });
+
+        it('items가 비어있고 empty 슬롯이 없으면 기본 NO DATA 자리표시자가 렌더링된다', async () => {
+            const wrapper = mountTable({
+                props: { items: [] },
+            });
+
+            await nextTick();
+
+            expect(wrapper.find('.vs-table-no-data-text').text()).toBe('NO DATA');
+        });
+
+        it('loading이면 empty 슬롯보다 로딩 인디케이터가 우선 표시된다', async () => {
+            const wrapper = mountTable({
+                props: { items: [], loading: true },
+                slots: {
+                    empty: '<div data-testid="empty-slot">No matching results</div>',
+                },
+            });
+
+            await nextTick();
+
+            expect(wrapper.find('[data-testid="empty-slot"]').exists()).toBe(false);
+        });
+    });
+
     describe('다양한 방식의 Cell Slot과 Slot 우선순위', () => {
         it('`header-${colKey}` Slot이 기본 렌더링보다 우선한다', async () => {
             const wrapper = mountTable({

--- a/packages/vlossom/src/components/vs-table/constants.ts
+++ b/packages/vlossom/src/components/vs-table/constants.ts
@@ -37,3 +37,6 @@ export const DEFAULT_SORTABLE_OPTIONS: Partial<SortableOptions> = {
     invertSwap: true,
     invertedSwapThreshold: 0.65,
 } as const;
+
+export const VS_TABLE_HEADER_SLOT_PREFIXES = ['header', 'select', 'expand'] as const;
+export const VS_TABLE_BODY_SLOT_PREFIXES = ['body', 'select', 'expand', 'empty'] as const;


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)
-   [x] Fix Bug (fix)

## Summary

- new slot 'empty', modify expand slot, expandable props's behavior and fix color-scheme propagation

## Description

- 'expandable' prop의 동작 방식을 변경합니다.
    - 'expand' slot이 존재해야만 expand 버튼과 영역을 제공합니다.
    - 기존에 기본으로 제공하던 expand 영역의 UI가 없습니다.
- vlossom 세팅 과정에서 VsTable color-scheme을 세팅했을 때, 값이 하위 vlossom 컴퍼넌트로 전파되지 않던 이슈를 수정합니다.
- 'empty' slot을 추가합니다. "no data"가 표기되던 영역을 대체할 수 있습니다.

## Related Tickets & Documents
- Closes #411, #425, #426 

