### PR TITLE
fix(VsTable): support literal column key values in slot names

### DIFF
--- a/packages/vlossom/src/components/vs-table/VsTableBodyRow.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableBodyRow.vue
@@ -205,7 +205,6 @@ export default defineComponent({
             const candidatePriority = [
                 `body-${id}`,
                 `body-${colKey}`,
-                `body-${stringUtil.kebabCase(colKey)}`,
                 `body-col${colIdx}-row${rowIdx}`,
                 `body-row${rowIdx}`,
                 `body-col${colIdx}`,

--- a/packages/vlossom/src/components/vs-table/VsTableBodyRow.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableBodyRow.vue
@@ -204,6 +204,7 @@ export default defineComponent({
 
             const candidatePriority = [
                 `body-${id}`,
+                `body-${colKey}`,
                 `body-${stringUtil.kebabCase(colKey)}`,
                 `body-col${colIdx}-row${rowIdx}`,
                 `body-row${rowIdx}`,

--- a/packages/vlossom/src/components/vs-table/VsTableHeader.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableHeader.vue
@@ -139,7 +139,6 @@ export default defineComponent({
             const candidatePriority = [
                 `header-${id}`,
                 `header-${colKey}`,
-                `header-${stringUtil.kebabCase(colKey)}`,
                 `header-col${colIdx}-row${rowIdx}`,
                 `header-row${rowIdx}`,
                 `header-col${colIdx}`,

--- a/packages/vlossom/src/components/vs-table/VsTableHeader.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableHeader.vue
@@ -138,6 +138,7 @@ export default defineComponent({
             const { id, colIdx, rowIdx, colKey } = header;
             const candidatePriority = [
                 `header-${id}`,
+                `header-${colKey}`,
                 `header-${stringUtil.kebabCase(colKey)}`,
                 `header-col${colIdx}-row${rowIdx}`,
                 `header-row${rowIdx}`,

--- a/packages/vlossom/src/components/vs-table/__tests__/vs-table.test.ts
+++ b/packages/vlossom/src/components/vs-table/__tests__/vs-table.test.ts
@@ -221,26 +221,6 @@ describe('VsTable', () => {
             expect(headerTextsOf(wrapper)).toEqual(['HEAD-firstName', 'lastName']);
             expect(bodyTextsOf(wrapper)).toEqual(['FIRST-Alice', 'Kim', 'FIRST-Bob', 'Park']);
         });
-
-        it('literal colKey와 kebab-case Slot이 모두 있으면 literal Slot이 우선한다', async () => {
-            // given
-            const camelCaseColumns = ['firstName'];
-            const camelCaseItems = [{ id: '1', firstName: 'Alice' }];
-
-            // when
-            const wrapper = mountTable({
-                props: { columns: camelCaseColumns, items: camelCaseItems },
-                slots: {
-                    'body-firstName': () => 'LITERAL',
-                    'body-first-name': () => 'KEBAB',
-                },
-            });
-
-            await nextTick();
-
-            // then
-            expect(bodyTextsOf(wrapper)).toEqual(['LITERAL']);
-        });
     });
 
     describe('expandable', () => {

--- a/packages/vlossom/src/components/vs-table/__tests__/vs-table.test.ts
+++ b/packages/vlossom/src/components/vs-table/__tests__/vs-table.test.ts
@@ -197,6 +197,50 @@ describe('VsTable', () => {
             expect(headerTextsOf(wrapper)).toEqual(['HEADER-0-name', 'HEADER-1-age']);
             expect(bodyTextsOf(wrapper)).toEqual(['BODY-1', 'BODY-1', 'BODY-2', 'BODY-2']);
         });
+
+        it('camelCase colKey가 literal 형태의 Slot 이름과 매칭된다', async () => {
+            // given
+            const camelCaseColumns = ['firstName', 'lastName'];
+            const camelCaseItems = [
+                { id: '1', firstName: 'Alice', lastName: 'Kim' },
+                { id: '2', firstName: 'Bob', lastName: 'Park' },
+            ];
+
+            // when
+            const wrapper = mountTable({
+                props: { columns: camelCaseColumns, items: camelCaseItems },
+                slots: {
+                    'header-firstName': ({ item }: { item: VsTableColumnDef }) => `HEAD-${item.key}`,
+                    'body-firstName': ({ item }: { item: VsTableBodyCell['item'] }) => `FIRST-${item.firstName}`,
+                },
+            });
+
+            await nextTick();
+
+            // then
+            expect(headerTextsOf(wrapper)).toEqual(['HEAD-firstName', 'lastName']);
+            expect(bodyTextsOf(wrapper)).toEqual(['FIRST-Alice', 'Kim', 'FIRST-Bob', 'Park']);
+        });
+
+        it('literal colKey와 kebab-case Slot이 모두 있으면 literal Slot이 우선한다', async () => {
+            // given
+            const camelCaseColumns = ['firstName'];
+            const camelCaseItems = [{ id: '1', firstName: 'Alice' }];
+
+            // when
+            const wrapper = mountTable({
+                props: { columns: camelCaseColumns, items: camelCaseItems },
+                slots: {
+                    'body-firstName': () => 'LITERAL',
+                    'body-first-name': () => 'KEBAB',
+                },
+            });
+
+            await nextTick();
+
+            // then
+            expect(bodyTextsOf(wrapper)).toEqual(['LITERAL']);
+        });
     });
 
     describe('expandable', () => {


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary

`VsTable`이 전달된 데이터의 key 이름을 그대로 사용하는 slot을 제공합니다. 

## Description

헤더와 바디에서 모두 제공됩니다.

```vue
<template>
	<vs-table>
		<template #body-revisionId="{ value }">
		    {{ value }}
		    <router-link :to="`/step-up/revisions/${value}`">
		        {{ value ? `#${value}` : '-' }}
		    </router-link>
		</template>
	</vs-table>
</template>

<script>
const items = [
    {
        timestamp: '2024-06-01 12:00:00',
        type: 'Create',
        revisionId: 'abc123',
        user: 'John Doe',
        comment: 'Initial creation of the item.',
    },
    {
        timestamp: '2024-06-02 14:30:00',
        type: 'Update',
        revisionId: 'def456 ',
        user: 'Jane Smith',
        comment: 'Updated the item with new information.',
    },
];
// ...
</script>
```


## Screenshots or Recordings

<img width="1368" height="379" alt="image" src="https://github.com/user-attachments/assets/392c0486-bfc8-4309-9c9c-c5e6083c1452" />


## Related Tickets & Documents

- Closes #431 

