### PR TITLE
feat(VsLayout): add layout prop on vs-layout children

### DIFF
--- a/packages/vlossom/playground/App.vue
+++ b/packages/vlossom/playground/App.vue
@@ -1,6 +1,6 @@
 <template>
     <vs-layout class="flex min-h-screen flex-col">
-        <vs-header position="sticky" :style-set="basicBarStyleSet">
+        <vs-header layout position="sticky" :style-set="basicBarStyleSet">
             <div class="flex h-full items-center justify-between px-8">
                 <div class="flex items-center gap-2">
                     <vs-image
@@ -16,7 +16,7 @@
             </div>
         </vs-header>
 
-        <vs-container class="flex-1 pb-32 lg:pr-96">
+        <vs-container layout class="flex-1 pb-32 lg:pr-96">
             <vs-page class="w-full" :style-set="{ component: { padding: '0 2rem' } }">
                 <vs-tabs v-model="activeTab" :tabs="tabs" primary class="mb-8" />
 
@@ -35,7 +35,7 @@
             <ColorSchemePanel class="fixed top-20 right-24 hidden lg:block" />
         </vs-container>
 
-        <vs-footer :style-set="basicBarStyleSet">
+        <vs-footer layout :style-set="basicBarStyleSet">
             <div class="flex h-full items-center justify-center text-sm">
                 <span>© 2026 Vlossom</span>
             </div>

--- a/packages/vlossom/src/components/vs-container/README.ko.md
+++ b/packages/vlossom/src/components/vs-container/README.ko.md
@@ -2,13 +2,13 @@
 
 # VsContainer
 
-`VsLayout` 내부에서 사용할 때 위치 지정된 헤더, 푸터, 드로어를 수용하기 위해 패딩을 자동으로 조정하는 레이아웃 컨테이너 컴포넌트입니다.
+`VsLayout` 내부에서 `layout` prop을 통해 opt-in 했을 때, 위치 지정된 헤더/푸터/드로어를 수용하기 위해 패딩을 자동으로 조정하는 레이아웃 컨테이너 컴포넌트입니다.
 
 **Available Version**: 2.0.0+
 
 ## Feature
 
-- 레이아웃 컨텍스트(헤더, 푸터, 드로어 크기)를 기반으로 패딩 자동 계산 및 적용
+- `layout` prop을 통한 `VsLayout` 통합 opt-in — 설정 시 레이아웃 컨텍스트(헤더/푸터/드로어 크기)를 기반으로 패딩 자동 계산 및 적용
 - 드로어 열림/닫힘 상태 변경 시 부드러운 패딩 전환 애니메이션
 - 자식 컴포넌트에서 컨테이너 쿼리를 활성화하는 CSS 컨테이너(`container-type: inline-size`) 역할
 - `tag` prop을 통해 원하는 HTML 요소로 렌더링 가능 (기본값: `div`)
@@ -19,11 +19,11 @@
 ```html
 <template>
     <vs-layout>
-        <vs-header>헤더</vs-header>
-        <vs-container>
+        <vs-header layout>헤더</vs-header>
+        <vs-container layout>
             <p>메인 콘텐츠 영역</p>
         </vs-container>
-        <vs-footer>푸터</vs-footer>
+        <vs-footer layout>푸터</vs-footer>
     </vs-layout>
 </template>
 ```
@@ -33,7 +33,7 @@
 ```html
 <template>
     <vs-layout>
-        <vs-container tag="main">
+        <vs-container layout tag="main">
             <p>시맨틱 메인 콘텐츠</p>
         </vs-container>
     </vs-layout>
@@ -44,6 +44,7 @@
 
 | Prop | Type | Default | Required | Description |
 | ---- | ---- | ------- | -------- | ----------- |
+| `layout` | `boolean` | `false` | | `VsLayout` 통합 opt-in. `VsLayout` 조상이 있어야 동작하며, 없으면 무시됩니다 |
 | `tag` | `string` | `'div'` | | 렌더링할 HTML 태그 |
 
 ## Types
@@ -68,4 +69,4 @@ VsContainer는 StyleSet 인터페이스가 없습니다.
 
 ## Caution
 
-- `VsContainer`는 **`VsLayout`의 직접 자식**일 때만 자동 레이아웃 패딩을 적용합니다. 다른 컨텍스트에서는 일반 컨테이너 요소로 동작합니다.
+- `VsContainer`는 (1) `layout` prop이 설정되어 있고 (2) `VsLayout` 조상이 있을 때만 자동 레이아웃 패딩을 적용합니다. 다른 경우엔 일반 컨테이너 요소로 동작합니다. 다른 컴포넌트로 감싸는 건 지원되지만, 중간에 다른 레이아웃 컴포넌트(`VsHeader`, `VsFooter`, `VsDrawer`, `VsContainer`)가 끼어 있으면 차단되어 동작하지 않습니다.

--- a/packages/vlossom/src/components/vs-container/README.md
+++ b/packages/vlossom/src/components/vs-container/README.md
@@ -2,13 +2,13 @@
 
 # VsContainer
 
-A layout container component that automatically adjusts its padding when used inside `VsLayout` to accommodate positioned headers, footers, and drawers.
+A layout container component that automatically adjusts its padding when opted in with the `layout` prop inside `VsLayout` to accommodate positioned headers, footers, and drawers.
 
 **Available Version**: 2.0.0+
 
 ## Feature
 
-- Automatically calculates and applies padding based on the layout context (header, footer, drawer sizes)
+- Opt-in `VsLayout` integration via the `layout` prop — when set, calculates and applies padding based on the layout context (header, footer, drawer sizes)
 - Smooth padding transition animation when drawer open/close state changes
 - Acts as a CSS container (`container-type: inline-size`) enabling container queries in child components
 - Renders as any HTML element via the `tag` prop (defaults to `div`)
@@ -19,11 +19,11 @@ A layout container component that automatically adjusts its padding when used in
 ```html
 <template>
     <vs-layout>
-        <vs-header>Header</vs-header>
-        <vs-container>
+        <vs-header layout>Header</vs-header>
+        <vs-container layout>
             <p>Main content area</p>
         </vs-container>
-        <vs-footer>Footer</vs-footer>
+        <vs-footer layout>Footer</vs-footer>
     </vs-layout>
 </template>
 ```
@@ -33,7 +33,7 @@ A layout container component that automatically adjusts its padding when used in
 ```html
 <template>
     <vs-layout>
-        <vs-container tag="main">
+        <vs-container layout tag="main">
             <p>Semantic main content</p>
         </vs-container>
     </vs-layout>
@@ -44,6 +44,7 @@ A layout container component that automatically adjusts its padding when used in
 
 | Prop | Type | Default | Required | Description |
 | ---- | ---- | ------- | -------- | ----------- |
+| `layout` | `boolean` | `false` | | Opt in to `VsLayout` integration. Requires a `VsLayout` ancestor; without one this prop has no effect |
 | `tag` | `string` | `'div'` | | HTML tag to render |
 
 ## Types
@@ -68,4 +69,4 @@ VsContainer does not have a StyleSet interface.
 
 ## Caution
 
-- `VsContainer` only applies automatic layout padding when it is a **direct child of `VsLayout`**. In other contexts it behaves as a plain container element.
+- `VsContainer` only applies automatic layout padding when (1) it has the `layout` prop set, and (2) a `VsLayout` ancestor is present. In other contexts it behaves as a plain container element. Wrapping `VsContainer` in another component is supported as long as no intervening layout primitive (`VsHeader`, `VsFooter`, `VsDrawer`, `VsContainer`) sits between it and the `VsLayout`.

--- a/packages/vlossom/src/components/vs-container/VsContainer.vue
+++ b/packages/vlossom/src/components/vs-container/VsContainer.vue
@@ -5,8 +5,10 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, getCurrentInstance, inject } from 'vue';
+import { computed, defineComponent, inject, toRefs } from 'vue';
+import { useLayoutChild } from '@/composables';
 import { LAYOUT_STORE_KEY, VsComponent } from '@/declaration';
+import { getLayoutProps } from '@/props';
 import { LayoutStore } from '@/stores';
 import { objectUtil } from '@/utils';
 
@@ -14,16 +16,18 @@ const componentName = VsComponent.VsContainer;
 export default defineComponent({
     name: componentName,
     props: {
+        ...getLayoutProps(),
         tag: { type: String, default: 'div' },
     },
-    setup() {
-        // only for vs-layout children
-        const isLayoutChild = computed(() => getCurrentInstance()?.parent?.type.name === VsComponent.VsLayout);
+    setup(props) {
+        const { layout } = toRefs(props);
+
+        const { isLayoutChild } = useLayoutChild(layout);
 
         const { header, footer, drawers } = inject(LAYOUT_STORE_KEY, LayoutStore.getDefaultLayoutStore());
 
-        function getDrawerPadding(drawerSize: string, isOpen: boolean, responsive: boolean, barPadding?: string) {
-            if (!responsive || !isOpen || !drawerSize) {
+        function getDrawerPadding(drawerSize: string, isOpen: boolean, pushContainer: boolean, barPadding?: string) {
+            if (!pushContainer || !isOpen || !drawerSize) {
                 return undefined;
             }
             return barPadding ? `calc(${barPadding} + ${drawerSize})` : drawerSize;
@@ -47,12 +51,12 @@ export default defineComponent({
 
             return objectUtil.shake({
                 paddingTop:
-                    getDrawerPadding(top.size, top.isOpen, top.responsive, headerPaddingTop) ?? headerPaddingTop,
+                    getDrawerPadding(top.size, top.isOpen, top.pushContainer, headerPaddingTop) ?? headerPaddingTop,
                 paddingBottom:
-                    getDrawerPadding(bottom.size, bottom.isOpen, bottom.responsive, footerPaddingBottom) ??
+                    getDrawerPadding(bottom.size, bottom.isOpen, bottom.pushContainer, footerPaddingBottom) ??
                     footerPaddingBottom,
-                paddingLeft: getDrawerPadding(left.size, left.isOpen, left.responsive),
-                paddingRight: getDrawerPadding(right.size, right.isOpen, right.responsive),
+                paddingLeft: getDrawerPadding(left.size, left.isOpen, left.pushContainer),
+                paddingRight: getDrawerPadding(right.size, right.isOpen, right.pushContainer),
             });
         });
 

--- a/packages/vlossom/src/components/vs-container/__tests__/vs-container.test.ts
+++ b/packages/vlossom/src/components/vs-container/__tests__/vs-container.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { mount } from '@vue/test-utils';
-import { provide, defineComponent } from 'vue';
+import { provide, defineComponent, h } from 'vue';
 import { LayoutStore } from '@/stores';
-import { LAYOUT_STORE_KEY, VsComponent } from '@/declaration';
+import { LAYOUT_PROVIDED_KEY, LAYOUT_STORE_KEY, VsComponent } from '@/declaration';
 import VsContainer from './../VsContainer.vue';
 
 describe('VsContainer', () => {
@@ -37,10 +37,35 @@ describe('VsContainer', () => {
     describe('vs-layout의 자식이 아닐 때', () => {
         it('vs-layout의 자식이 아니면 추가 스타일이 적용되지 않아야 한다', () => {
             // given, when
-            const wrapper = mount(VsContainer);
+            const wrapper = mount(VsContainer, { props: { layout: true } });
 
             // then
             expect(wrapper.vm.layoutStyles).toEqual({});
+        });
+    });
+
+    describe('vs-layout의 자식이지만 layout prop이 없을 때', () => {
+        const MockVsLayout = defineComponent({
+            name: VsComponent.VsLayout,
+            setup() {
+                provide(LAYOUT_STORE_KEY, layoutStore);
+                provide(LAYOUT_PROVIDED_KEY, true);
+                return {};
+            },
+            template: '<div><slot /></div>',
+        });
+
+        it('layout prop이 없으면 layoutStyles가 적용되지 않아야 한다', () => {
+            // given
+            layoutStore.setHeader({ position: 'fixed', height: '70px' });
+            layoutStore.setFooter({ position: 'fixed', height: '90px' });
+
+            // when
+            const wrapper = mount(MockVsLayout, { slots: { default: () => h(VsContainer) } });
+
+            // then
+            const container = wrapper.findComponent(VsContainer);
+            expect(container.vm.layoutStyles).toEqual({});
         });
     });
 
@@ -49,6 +74,7 @@ describe('VsContainer', () => {
             name: VsComponent.VsLayout,
             setup() {
                 provide(LAYOUT_STORE_KEY, layoutStore);
+                provide(LAYOUT_PROVIDED_KEY, true);
                 return {};
             },
             template: '<div><slot /></div>',
@@ -60,7 +86,7 @@ describe('VsContainer', () => {
             layoutStore.setFooter({ position: 'absolute', height: '90px' });
 
             // when
-            const wrapper = mount(MockVsLayout, { slots: { default: VsContainer } });
+            const wrapper = mount(MockVsLayout, { slots: { default: () => h(VsContainer, { layout: true }) } });
 
             // then
             const container = wrapper.findComponent(VsContainer);
@@ -73,7 +99,7 @@ describe('VsContainer', () => {
             layoutStore.setFooter({ position: 'relative', height: '80px' });
 
             // when
-            const wrapper = mount(MockVsLayout, { slots: { default: VsContainer } });
+            const wrapper = mount(MockVsLayout, { slots: { default: () => h(VsContainer, { layout: true }) } });
 
             // then
             const container = wrapper.findComponent(VsContainer);
@@ -86,7 +112,7 @@ describe('VsContainer', () => {
             layoutStore.setFooter({ position: 'static', height: '80px' });
 
             // when
-            const wrapper = mount(MockVsLayout, { slots: { default: VsContainer } });
+            const wrapper = mount(MockVsLayout, { slots: { default: () => h(VsContainer, { layout: true }) } });
 
             // then
             const container = wrapper.findComponent(VsContainer);
@@ -99,7 +125,7 @@ describe('VsContainer', () => {
             layoutStore.setFooter({ position: 'sticky', height: '80px' });
 
             // when
-            const wrapper = mount(MockVsLayout, { slots: { default: VsContainer } });
+            const wrapper = mount(MockVsLayout, { slots: { default: () => h(VsContainer, { layout: true }) } });
 
             // then
             const container = wrapper.findComponent(VsContainer);
@@ -112,54 +138,55 @@ describe('VsContainer', () => {
             name: VsComponent.VsLayout,
             setup() {
                 provide(LAYOUT_STORE_KEY, layoutStore);
+                provide(LAYOUT_PROVIDED_KEY, true);
                 return {};
             },
             template: '<div><slot /></div>',
         });
 
         describe('각 방향별 drawer 테스트', () => {
-            it('left drawer가 열려있고 responsive이면 왼쪽 패딩이 적용되어야 한다', () => {
+            it('left drawer가 열려있고 pushContainer이면 왼쪽 패딩이 적용되어야 한다', () => {
                 // given
-                layoutStore.setDrawer({ placement: 'left', isOpen: true, size: '200px', responsive: true });
+                layoutStore.setDrawer({ placement: 'left', isOpen: true, size: '200px', pushContainer: true });
 
                 // when
-                const wrapper = mount(MockVsLayout, { slots: { default: VsContainer } });
+                const wrapper = mount(MockVsLayout, { slots: { default: () => h(VsContainer, { layout: true }) } });
 
                 // then
                 const container = wrapper.findComponent(VsContainer);
                 expect(container.vm.layoutStyles).toEqual({ paddingLeft: '200px' });
             });
 
-            it('top drawer가 열려있고 responsive이면 위쪽 패딩이 적용되어야 한다', () => {
+            it('top drawer가 열려있고 pushContainer이면 위쪽 패딩이 적용되어야 한다', () => {
                 // given
-                layoutStore.setDrawer({ placement: 'top', isOpen: true, size: '150px', responsive: true });
+                layoutStore.setDrawer({ placement: 'top', isOpen: true, size: '150px', pushContainer: true });
 
                 // when
-                const wrapper = mount(MockVsLayout, { slots: { default: VsContainer } });
+                const wrapper = mount(MockVsLayout, { slots: { default: () => h(VsContainer, { layout: true }) } });
 
                 // then
                 const container = wrapper.findComponent(VsContainer);
                 expect(container.vm.layoutStyles).toEqual({ paddingTop: '150px' });
             });
 
-            it('right drawer가 열려있고 responsive이면 오른쪽 패딩이 적용되어야 한다', () => {
+            it('right drawer가 열려있고 pushContainer이면 오른쪽 패딩이 적용되어야 한다', () => {
                 // given
-                layoutStore.setDrawer({ placement: 'right', isOpen: true, size: '250px', responsive: true });
+                layoutStore.setDrawer({ placement: 'right', isOpen: true, size: '250px', pushContainer: true });
 
                 // when
-                const wrapper = mount(MockVsLayout, { slots: { default: VsContainer } });
+                const wrapper = mount(MockVsLayout, { slots: { default: () => h(VsContainer, { layout: true }) } });
 
                 // then
                 const container = wrapper.findComponent(VsContainer);
                 expect(container.vm.layoutStyles).toEqual({ paddingRight: '250px' });
             });
 
-            it('bottom drawer가 열려있고 responsive이면 아래쪽 패딩이 적용되어야 한다', () => {
+            it('bottom drawer가 열려있고 pushContainer이면 아래쪽 패딩이 적용되어야 한다', () => {
                 // given
-                layoutStore.setDrawer({ placement: 'bottom', isOpen: true, size: '100px', responsive: true });
+                layoutStore.setDrawer({ placement: 'bottom', isOpen: true, size: '100px', pushContainer: true });
 
                 // when
-                const wrapper = mount(MockVsLayout, { slots: { default: VsContainer } });
+                const wrapper = mount(MockVsLayout, { slots: { default: () => h(VsContainer, { layout: true }) } });
 
                 // then
                 const container = wrapper.findComponent(VsContainer);
@@ -170,22 +197,22 @@ describe('VsContainer', () => {
         describe('drawer 조건 테스트', () => {
             it('drawer가 닫혀있으면 패딩이 적용되지 않아야 한다', () => {
                 // given
-                layoutStore.setDrawer({ placement: 'left', isOpen: false, size: '200px', responsive: true });
+                layoutStore.setDrawer({ placement: 'left', isOpen: false, size: '200px', pushContainer: true });
 
                 // when
-                const wrapper = mount(MockVsLayout, { slots: { default: VsContainer } });
+                const wrapper = mount(MockVsLayout, { slots: { default: () => h(VsContainer, { layout: true }) } });
 
                 // then
                 const container = wrapper.findComponent(VsContainer);
                 expect(container.vm.layoutStyles).toEqual({});
             });
 
-            it('drawer의 responsive가 false이면 패딩이 적용되지 않아야 한다', () => {
+            it('drawer의 pushContainer가 false이면 패딩이 적용되지 않아야 한다', () => {
                 // given
-                layoutStore.setDrawer({ placement: 'left', isOpen: true, size: '200px', responsive: false });
+                layoutStore.setDrawer({ placement: 'left', isOpen: true, size: '200px', pushContainer: false });
 
                 // when
-                const wrapper = mount(MockVsLayout, { slots: { default: VsContainer } });
+                const wrapper = mount(MockVsLayout, { slots: { default: () => h(VsContainer, { layout: true }) } });
 
                 // then
                 const container = wrapper.findComponent(VsContainer);
@@ -194,10 +221,10 @@ describe('VsContainer', () => {
 
             it('drawer의 size가 빈 문자열이면 패딩이 적용되지 않아야 한다', () => {
                 // given
-                layoutStore.setDrawer({ placement: 'left', isOpen: true, size: '', responsive: true });
+                layoutStore.setDrawer({ placement: 'left', isOpen: true, size: '', pushContainer: true });
 
                 // when
-                const wrapper = mount(MockVsLayout, { slots: { default: VsContainer } });
+                const wrapper = mount(MockVsLayout, { slots: { default: () => h(VsContainer, { layout: true }) } });
 
                 // then
                 const container = wrapper.findComponent(VsContainer);
@@ -208,13 +235,13 @@ describe('VsContainer', () => {
         describe('모든 drawer가 활성화된 경우', () => {
             it('모든 방향의 drawer가 활성화되어 있을 때 모든 패딩이 적용되어야 한다', () => {
                 // given
-                layoutStore.setDrawer({ placement: 'left', isOpen: true, size: '200px', responsive: true });
-                layoutStore.setDrawer({ placement: 'top', isOpen: true, size: '150px', responsive: true });
-                layoutStore.setDrawer({ placement: 'right', isOpen: true, size: '250px', responsive: true });
-                layoutStore.setDrawer({ placement: 'bottom', isOpen: true, size: '100px', responsive: true });
+                layoutStore.setDrawer({ placement: 'left', isOpen: true, size: '200px', pushContainer: true });
+                layoutStore.setDrawer({ placement: 'top', isOpen: true, size: '150px', pushContainer: true });
+                layoutStore.setDrawer({ placement: 'right', isOpen: true, size: '250px', pushContainer: true });
+                layoutStore.setDrawer({ placement: 'bottom', isOpen: true, size: '100px', pushContainer: true });
 
                 // when
-                const wrapper = mount(MockVsLayout, { slots: { default: VsContainer } });
+                const wrapper = mount(MockVsLayout, { slots: { default: () => h(VsContainer, { layout: true }) } });
 
                 // then
                 const container = wrapper.findComponent(VsContainer);
@@ -233,6 +260,7 @@ describe('VsContainer', () => {
             name: VsComponent.VsLayout,
             setup() {
                 provide(LAYOUT_STORE_KEY, layoutStore);
+                provide(LAYOUT_PROVIDED_KEY, true);
                 return {};
             },
             template: '<div><slot /></div>',
@@ -242,11 +270,11 @@ describe('VsContainer', () => {
             // given
             layoutStore.setHeader({ position: 'fixed', height: '70px' });
             layoutStore.setFooter({ position: 'absolute', height: '90px' });
-            layoutStore.setDrawer({ placement: 'left', isOpen: true, size: '200px', responsive: true });
-            layoutStore.setDrawer({ placement: 'right', isOpen: true, size: '250px', responsive: true });
+            layoutStore.setDrawer({ placement: 'left', isOpen: true, size: '200px', pushContainer: true });
+            layoutStore.setDrawer({ placement: 'right', isOpen: true, size: '250px', pushContainer: true });
 
             // when
-            const wrapper = mount(MockVsLayout, { slots: { default: VsContainer } });
+            const wrapper = mount(MockVsLayout, { slots: { default: () => h(VsContainer, { layout: true }) } });
 
             // then
             const container = wrapper.findComponent(VsContainer);
@@ -261,11 +289,11 @@ describe('VsContainer', () => {
         it('header가 sticky이고 top drawer가 열려있을 때 paddingTop은 header + drawer 크기의 합이어야 한다', () => {
             // given
             layoutStore.setHeader({ position: 'sticky', height: '60px' });
-            layoutStore.setDrawer({ placement: 'top', isOpen: true, size: '40px', responsive: true });
-            layoutStore.setDrawer({ placement: 'bottom', isOpen: true, size: '50px', responsive: true });
+            layoutStore.setDrawer({ placement: 'top', isOpen: true, size: '40px', pushContainer: true });
+            layoutStore.setDrawer({ placement: 'bottom', isOpen: true, size: '50px', pushContainer: true });
 
             // when
-            const wrapper = mount(MockVsLayout, { slots: { default: VsContainer } });
+            const wrapper = mount(MockVsLayout, { slots: { default: () => h(VsContainer, { layout: true }) } });
 
             // then
             const container = wrapper.findComponent(VsContainer);
@@ -278,10 +306,10 @@ describe('VsContainer', () => {
         it('footer가 fixed이고 bottom drawer가 열려있을 때 paddingBottom은 footer + drawer 크기의 합이어야 한다', () => {
             // given
             layoutStore.setFooter({ position: 'fixed', height: '60px' });
-            layoutStore.setDrawer({ placement: 'bottom', isOpen: true, size: '50px', responsive: true });
+            layoutStore.setDrawer({ placement: 'bottom', isOpen: true, size: '50px', pushContainer: true });
 
             // when
-            const wrapper = mount(MockVsLayout, { slots: { default: VsContainer } });
+            const wrapper = mount(MockVsLayout, { slots: { default: () => h(VsContainer, { layout: true }) } });
 
             // then
             const container = wrapper.findComponent(VsContainer);
@@ -292,11 +320,11 @@ describe('VsContainer', () => {
             // given
             layoutStore.setHeader({ position: 'relative', height: '60px' }); // padding 미적용
             layoutStore.setFooter({ position: 'fixed', height: '80px' }); // padding 적용
-            layoutStore.setDrawer({ placement: 'left', isOpen: false, size: '200px', responsive: true }); // 닫혀있어 미적용
-            layoutStore.setDrawer({ placement: 'right', isOpen: true, size: '250px', responsive: true }); // padding 적용
+            layoutStore.setDrawer({ placement: 'left', isOpen: false, size: '200px', pushContainer: true }); // 닫혀있어 미적용
+            layoutStore.setDrawer({ placement: 'right', isOpen: true, size: '250px', pushContainer: true }); // padding 적용
 
             // when
-            const wrapper = mount(MockVsLayout, { slots: { default: VsContainer } });
+            const wrapper = mount(MockVsLayout, { slots: { default: () => h(VsContainer, { layout: true }) } });
 
             // then
             const container = wrapper.findComponent(VsContainer);

--- a/packages/vlossom/src/components/vs-drawer/README.ko.md
+++ b/packages/vlossom/src/components/vs-drawer/README.ko.md
@@ -11,7 +11,7 @@
 - `left`, `right`, `top`, `bottom` 네 가지 방향 지원
 - 클릭 시 닫기 기능을 포함한 선택적 딤드 배경
 - 접근성 있는 키보드 탐색을 위한 포커스 트래핑
-- `VsLayout`과 통합 시 헤더/푸터 높이 자동 오프셋
+- `layout` prop을 통한 `VsLayout` 통합 opt-in — 설정 시 헤더/푸터 높이를 자동 오프셋하고, 컨테이너 패딩 계산에도 반영
 - 부드러운 슬라이드 인/아웃 트랜지션 애니메이션
 - `v-model` 또는 `openDrawer` / `closeDrawer` 메서드로 제어 가능
 
@@ -59,6 +59,23 @@ const drawerOpen = ref(false);
 </template>
 ```
 
+### VsLayout 내부에서 사용
+
+`layout` prop을 설정하면 드로어가 레이아웃 스토어에 등록됩니다. `pushContainer`와 함께 사용하면 `VsContainer`를 옆으로 밀어 공간을 확보합니다 (overlay 대신). 다른 컴포넌트로 한 번 감싼 경우에도 동작합니다.
+
+```html
+<template>
+    <vs-layout>
+        <vs-drawer v-model="open" layout push-container placement="left" size="240px">
+            <p>사이드바</p>
+        </vs-drawer>
+        <vs-container layout>
+            <p>콘텐츠</p>
+        </vs-container>
+    </vs-layout>
+</template>
+```
+
 ## Props
 
 | Prop | 타입 | 기본값 | 필수 | 설명 |
@@ -74,7 +91,8 @@ const drawerOpen = ref(false);
 | `id` | `string` | `''` | | 드로어의 HTML id 속성 |
 | `fixed` | `boolean` | `false` | | `absolute` 대신 `position: fixed` 사용 |
 | `open` | `boolean` | `false` | | 마운트 시 드로어 열기 |
-| `layoutResponsive` | `boolean` | `false` | | `VsLayout` 내에서 사용 시 레이아웃 조정 |
+| `layout` | `boolean` | `false` | | `VsLayout` 통합 opt-in. `VsLayout` 조상이 있어야 동작하며, 없으면 무시됩니다 |
+| `pushContainer` | `boolean` | `false` | | `layout`과 함께 사용 시 드로어가 `VsContainer`를 옆으로 밀어 공간을 확보 (overlay 대신) |
 | `placement` | `'left' \| 'right' \| 'top' \| 'bottom'` | `'left'` | | 드로어가 슬라이드 인되는 가장자리 방향 |
 | `size` | `string \| number` | | | 드로어 패널의 너비(left/right) 또는 높이(top/bottom). 크기 토큰(`xs`, `sm`, `md`, `lg`, `xl`) 또는 CSS 값 허용 |
 | `modelValue` | `boolean` | `false` | | 열기 상태를 제어하는 v-model 바인딩 |

--- a/packages/vlossom/src/components/vs-drawer/README.md
+++ b/packages/vlossom/src/components/vs-drawer/README.md
@@ -11,7 +11,7 @@ A slide-in panel component that overlays content from any edge of the screen wit
 - Supports four placement directions: `left`, `right`, `top`, `bottom`
 - Optional dimmed backdrop with click-to-close support
 - Focus trapping for accessible keyboard navigation
-- Integrates with `VsLayout` to offset header/footer heights automatically
+- Opt-in `VsLayout` integration via the `layout` prop — when set, offsets header/footer heights automatically and registers itself for container padding
 - Smooth slide-in/out transition animation
 - Controllable via `v-model` or programmatic `openDrawer` / `closeDrawer` methods
 
@@ -59,6 +59,23 @@ const drawerOpen = ref(false);
 </template>
 ```
 
+### Inside VsLayout
+
+Set the `layout` prop to register the drawer with the layout store. Combine with `pushContainer` to push the sibling `VsContainer` aside instead of overlaying it. Wrapping the drawer in another component is supported.
+
+```html
+<template>
+    <vs-layout>
+        <vs-drawer v-model="open" layout push-container placement="left" size="240px">
+            <p>Sidebar</p>
+        </vs-drawer>
+        <vs-container layout>
+            <p>Content</p>
+        </vs-container>
+    </vs-layout>
+</template>
+```
+
 ## Props
 
 | Prop | Type | Default | Required | Description |
@@ -74,7 +91,8 @@ const drawerOpen = ref(false);
 | `id` | `string` | `''` | | HTML id attribute for the drawer |
 | `fixed` | `boolean` | `false` | | Use `position: fixed` instead of `absolute` |
 | `open` | `boolean` | `false` | | Open the drawer on mount |
-| `layoutResponsive` | `boolean` | `false` | | Adjust layout when used inside `VsLayout` |
+| `layout` | `boolean` | `false` | | Opt in to `VsLayout` integration. Requires a `VsLayout` ancestor; without one this prop has no effect |
+| `pushContainer` | `boolean` | `false` | | When used with `layout`, push the sibling `VsContainer` to make room for the drawer instead of overlaying it |
 | `placement` | `'left' \| 'right' \| 'top' \| 'bottom'` | `'left'` | | Edge from which the drawer slides in |
 | `size` | `string \| number` | | | Width (left/right) or height (top/bottom) of the drawer panel. Accepts size tokens (`xs`, `sm`, `md`, `lg`, `xl`) or CSS values |
 | `modelValue` | `boolean` | `false` | | v-model binding to control open state |

--- a/packages/vlossom/src/components/vs-drawer/VsDrawer.vue
+++ b/packages/vlossom/src/components/vs-drawer/VsDrawer.vue
@@ -40,7 +40,6 @@
 import {
     computed,
     defineComponent,
-    getCurrentInstance,
     inject,
     onBeforeMount,
     toRefs,
@@ -63,8 +62,8 @@ import {
     SIZES,
     type Size,
 } from '@/declaration';
-import { useColorScheme, useOverlayCallback, useStyleSet } from '@/composables';
-import { getColorSchemeProps, getStyleSetProps, getOverlayProps } from '@/props';
+import { useColorScheme, useLayoutChild, useOverlayCallback, useStyleSet } from '@/composables';
+import { getColorSchemeProps, getLayoutProps, getStyleSetProps, getOverlayProps } from '@/props';
 import { LayoutStore } from '@/stores';
 import { objectUtil, stringUtil } from '@/utils';
 import type { VsDrawerStyleSet } from './types';
@@ -81,9 +80,10 @@ export default defineComponent({
         ...getColorSchemeProps(),
         ...getStyleSetProps<VsDrawerStyleSet>(),
         ...getOverlayProps(),
+        ...getLayoutProps(),
         fixed: { type: Boolean, default: false },
         open: { type: Boolean, default: false },
-        layoutResponsive: { type: Boolean, default: false },
+        pushContainer: { type: Boolean, default: false },
         placement: {
             type: String as PropType<DrawerPlacement>,
             default: 'left',
@@ -105,7 +105,8 @@ export default defineComponent({
             escClose,
             fixed,
             open: initialOpen,
-            layoutResponsive,
+            layout,
+            pushContainer,
             modelValue,
             placement,
             size,
@@ -195,8 +196,7 @@ export default defineComponent({
             deactivate();
         }
 
-        // only for vs-layout children
-        const isLayoutChild = computed(() => getCurrentInstance()?.parent?.type.name === VsComponent.VsLayout);
+        const { isLayoutChild } = useLayoutChild(layout);
 
         const layoutStore = inject(LAYOUT_STORE_KEY, LayoutStore.getDefaultLayoutStore());
         watchEffect(() => {
@@ -207,7 +207,7 @@ export default defineComponent({
                 isOpen: isOpen.value,
                 placement: placement.value,
                 size: drawerSize.value || DRAWER_SIZE.sm,
-                responsive: layoutResponsive.value,
+                pushContainer: pushContainer.value,
             });
         });
 

--- a/packages/vlossom/src/components/vs-drawer/__tests__/vs-drawer.test.ts
+++ b/packages/vlossom/src/components/vs-drawer/__tests__/vs-drawer.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { provide, defineComponent, h } from 'vue';
 import { LayoutStore } from '@/stores';
-import { LAYOUT_STORE_KEY, VsComponent } from '@/declaration';
+import { LAYOUT_PROVIDED_KEY, LAYOUT_STORE_KEY, VsComponent } from '@/declaration';
 import VsDrawer from './../VsDrawer.vue';
 
 describe('VsDrawer', () => {
@@ -342,6 +342,7 @@ describe('VsDrawer', () => {
             name: VsComponent.VsLayout,
             setup() {
                 provide(LAYOUT_STORE_KEY, layoutStore);
+                provide(LAYOUT_PROVIDED_KEY, true);
                 return {};
             },
             template: '<div><slot /></div>',
@@ -359,7 +360,7 @@ describe('VsDrawer', () => {
             Transition: { template: '<div><slot /></div>' },
         };
 
-        it('vs-layout의 자식일 때 layoutStore.setDrawer가 호출되어야 한다', () => {
+        it('layout prop이 true일 때 layoutStore.setDrawer가 호출되어야 한다', () => {
             // given
             const setDrawerSpy = vi.spyOn(layoutStore, 'setDrawer');
 
@@ -367,7 +368,13 @@ describe('VsDrawer', () => {
             mount(MockVsLayout, {
                 slots: {
                     default: () =>
-                        h(VsDrawer, { modelValue: true, placement: 'left', size: 'md', layoutResponsive: true }),
+                        h(VsDrawer, {
+                            layout: true,
+                            modelValue: true,
+                            placement: 'left',
+                            size: 'md',
+                            pushContainer: true,
+                        }),
                 },
                 global: { stubs: layoutStubs },
             });
@@ -377,8 +384,25 @@ describe('VsDrawer', () => {
                 isOpen: true,
                 placement: 'left',
                 size: '40%',
-                responsive: true,
+                pushContainer: true,
             });
+        });
+
+        it('layout prop이 없으면 setDrawer가 호출되지 않아야 한다', () => {
+            // given
+            const setDrawerSpy = vi.spyOn(layoutStore, 'setDrawer');
+
+            // when
+            mount(MockVsLayout, {
+                slots: {
+                    default: () =>
+                        h(VsDrawer, { modelValue: true, placement: 'left', size: 'md', pushContainer: true }),
+                },
+                global: { stubs: layoutStubs },
+            });
+
+            // then
+            expect(setDrawerSpy).not.toHaveBeenCalled();
         });
     });
 
@@ -387,6 +411,7 @@ describe('VsDrawer', () => {
             name: VsComponent.VsLayout,
             setup() {
                 provide(LAYOUT_STORE_KEY, layoutStore);
+                provide(LAYOUT_PROVIDED_KEY, true);
                 return {};
             },
             template: '<div><slot /></div>',
@@ -411,7 +436,7 @@ describe('VsDrawer', () => {
             // when
             const wrapper = mount(MockVsLayout, {
                 slots: {
-                    default: () => h(VsDrawer, { modelValue: true, placement: 'left' }),
+                    default: () => h(VsDrawer, { layout: true, modelValue: true, placement: 'left' }),
                 },
                 global: { stubs: layoutStubs },
             });
@@ -428,7 +453,7 @@ describe('VsDrawer', () => {
             // when
             const wrapper = mount(MockVsLayout, {
                 slots: {
-                    default: () => h(VsDrawer, { modelValue: true, placement: 'right' }),
+                    default: () => h(VsDrawer, { layout: true, modelValue: true, placement: 'right' }),
                 },
                 global: { stubs: layoutStubs },
             });
@@ -445,7 +470,7 @@ describe('VsDrawer', () => {
             // when
             const wrapper = mount(MockVsLayout, {
                 slots: {
-                    default: () => h(VsDrawer, { modelValue: true, placement: 'top' }),
+                    default: () => h(VsDrawer, { layout: true, modelValue: true, placement: 'top' }),
                 },
                 global: { stubs: layoutStubs },
             });
@@ -462,7 +487,7 @@ describe('VsDrawer', () => {
             // when
             const wrapper = mount(MockVsLayout, {
                 slots: {
-                    default: () => h(VsDrawer, { modelValue: true, placement: 'top' }),
+                    default: () => h(VsDrawer, { layout: true, modelValue: true, placement: 'top' }),
                 },
                 global: { stubs: layoutStubs },
             });
@@ -479,7 +504,7 @@ describe('VsDrawer', () => {
             // when
             const wrapper = mount(MockVsLayout, {
                 slots: {
-                    default: () => h(VsDrawer, { modelValue: true, placement: 'bottom' }),
+                    default: () => h(VsDrawer, { layout: true, modelValue: true, placement: 'bottom' }),
                 },
                 global: { stubs: layoutStubs },
             });
@@ -496,7 +521,7 @@ describe('VsDrawer', () => {
             // when
             const wrapper = mount(MockVsLayout, {
                 slots: {
-                    default: () => h(VsDrawer, { modelValue: true, placement: 'bottom' }),
+                    default: () => h(VsDrawer, { layout: true, modelValue: true, placement: 'bottom' }),
                 },
                 global: { stubs: layoutStubs },
             });
@@ -513,7 +538,7 @@ describe('VsDrawer', () => {
             // when
             const wrapper = mount(MockVsLayout, {
                 slots: {
-                    default: () => h(VsDrawer, { modelValue: true, placement: 'left' }),
+                    default: () => h(VsDrawer, { layout: true, modelValue: true, placement: 'left' }),
                 },
                 global: { stubs: layoutStubs },
             });

--- a/packages/vlossom/src/components/vs-footer/README.ko.md
+++ b/packages/vlossom/src/components/vs-footer/README.ko.md
@@ -12,7 +12,7 @@
 - CSS `position` 값 지원: `static`, `relative`, `absolute`, `fixed`, `sticky`
 - 기본 높이 `3rem` — `height` prop으로 재정의 가능
 - `primary` prop을 통한 기본 색상 스킴 스타일링
-- 드로어 오프셋 계산을 위해 푸터 높이를 보고하는 `VsLayout` 통합
+- `layout` prop을 통한 `VsLayout` 통합 opt-in — 설정 시 드로어 오프셋 계산을 위해 푸터 높이를 보고
 - 완전한 스타일 제어를 위해 `styleSet.component`를 통한 `CSSProperties` 허용
 
 ## 기본 사용법
@@ -45,6 +45,21 @@
 </template>
 ```
 
+### VsLayout 내부에서 사용
+
+`layout` prop을 설정하면 푸터가 레이아웃 스토어에 등록되어 `VsContainer`와 `VsDrawer`가 푸터를 기준으로 오프셋 처리합니다. 다른 컴포넌트로 한 번 감싼 경우에도 동작합니다.
+
+```html
+<template>
+    <vs-layout>
+        <vs-container layout>
+            <p>콘텐츠</p>
+        </vs-container>
+        <vs-footer layout position="fixed" height="3rem">© 2026</vs-footer>
+    </vs-layout>
+</template>
+```
+
 ## Props
 
 | Prop | 타입 | 기본값 | 필수 | 설명 |
@@ -54,6 +69,7 @@
 | `position` | `'static' \| 'relative' \| 'absolute' \| 'fixed' \| 'sticky'` | | | 푸터의 CSS position 값 |
 | `height` | `string` | | | 푸터의 높이. 기본값은 `3rem` |
 | `primary` | `boolean` | `false` | | 기본 색상 스킴 적용 |
+| `layout` | `boolean` | `false` | | `VsLayout` 통합 opt-in. `VsLayout` 조상이 있어야 동작하며, 없으면 무시됩니다 |
 | `tag` | `string` | `'footer'` | | 렌더링할 HTML 태그 |
 
 ## 타입

--- a/packages/vlossom/src/components/vs-footer/README.md
+++ b/packages/vlossom/src/components/vs-footer/README.md
@@ -12,7 +12,7 @@ A page footer bar component that supports fixed, sticky, and absolute positionin
 - Supports CSS `position` values: `static`, `relative`, `absolute`, `fixed`, `sticky`
 - Default height of `3rem` — overridable via the `height` prop
 - Primary color scheme styling via the `primary` prop
-- Integrates with `VsLayout` to report footer height for drawer offset calculations
+- Opt-in `VsLayout` integration via the `layout` prop — when set, reports footer height for drawer offset calculations
 - Accepts `CSSProperties` via `styleSet.component` for full style control
 
 ## Basic Usage
@@ -45,6 +45,21 @@ A page footer bar component that supports fixed, sticky, and absolute positionin
 </template>
 ```
 
+### Inside VsLayout
+
+Set the `layout` prop to register the footer with the layout store so `VsContainer` and `VsDrawer` can offset around it. Wrapping the footer in another component is supported.
+
+```html
+<template>
+    <vs-layout>
+        <vs-container layout>
+            <p>Content</p>
+        </vs-container>
+        <vs-footer layout position="fixed" height="3rem">© 2026</vs-footer>
+    </vs-layout>
+</template>
+```
+
 ## Props
 
 | Prop | Type | Default | Required | Description |
@@ -54,6 +69,7 @@ A page footer bar component that supports fixed, sticky, and absolute positionin
 | `position` | `'static' \| 'relative' \| 'absolute' \| 'fixed' \| 'sticky'` | | | CSS position value for the footer |
 | `height` | `string` | | | Height of the footer. Defaults to `3rem` |
 | `primary` | `boolean` | `false` | | Apply the primary color scheme |
+| `layout` | `boolean` | `false` | | Opt in to `VsLayout` integration. Requires a `VsLayout` ancestor; without one this prop has no effect |
 | `tag` | `string` | `'footer'` | | HTML tag to render as |
 
 ## Types

--- a/packages/vlossom/src/components/vs-footer/VsFooter.vue
+++ b/packages/vlossom/src/components/vs-footer/VsFooter.vue
@@ -5,10 +5,10 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, toRefs, type ComputedRef, getCurrentInstance, inject, watchEffect } from 'vue';
-import { useColorScheme, useStyleSet } from '@/composables';
+import { computed, defineComponent, toRefs, type ComputedRef, inject, watchEffect } from 'vue';
+import { useColorScheme, useLayoutChild, useStyleSet } from '@/composables';
 import { VsComponent, LAYOUT_STORE_KEY, type BarLayout } from '@/declaration';
-import { getColorSchemeProps, getPositionProps, getStyleSetProps } from '@/props';
+import { getColorSchemeProps, getLayoutProps, getPositionProps, getStyleSetProps } from '@/props';
 import { objectUtil } from '@/utils';
 import { LayoutStore } from '@/stores';
 import type { VsFooterStyleSet } from './types';
@@ -23,12 +23,13 @@ export default defineComponent({
         ...getColorSchemeProps(),
         ...getStyleSetProps<VsFooterStyleSet>(),
         ...getPositionProps(),
+        ...getLayoutProps(),
         height: { type: String },
         primary: { type: Boolean, default: false },
         tag: { type: String, default: 'footer' },
     },
     setup(props) {
-        const { colorScheme, styleSet, primary, position, height } = toRefs(props);
+        const { colorScheme, styleSet, primary, position, height, layout } = toRefs(props);
 
         const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
@@ -62,8 +63,7 @@ export default defineComponent({
             'vs-primary': primary.value,
         }));
 
-        // only for vs-layout children
-        const isLayoutChild = computed(() => getCurrentInstance()?.parent?.type.name === VsComponent.VsLayout);
+        const { isLayoutChild } = useLayoutChild(layout);
 
         const layoutStore = inject(LAYOUT_STORE_KEY, LayoutStore.getDefaultLayoutStore());
         watchEffect(() => {

--- a/packages/vlossom/src/components/vs-footer/__stories__/vs-footer.stories.ts
+++ b/packages/vlossom/src/components/vs-footer/__stories__/vs-footer.stories.ts
@@ -55,6 +55,10 @@ const meta: Meta<typeof VsFooter> = {
             options: ['relative', 'absolute', 'fixed', 'sticky'],
             description: '푸터의 위치 지정',
         },
+        layout: {
+            control: 'boolean',
+            description: 'VsLayout 통합 opt-in. VsLayout 조상이 있어야 동작합니다',
+        },
         styleSet: {
             control: 'object',
             description: '커스텀 스타일 객체',

--- a/packages/vlossom/src/components/vs-footer/__tests__/vs-footer.test.ts
+++ b/packages/vlossom/src/components/vs-footer/__tests__/vs-footer.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { provide, defineComponent, h } from 'vue';
 import { LayoutStore } from '@/stores';
-import { LAYOUT_STORE_KEY, VsComponent } from '@/declaration';
+import { LAYOUT_PROVIDED_KEY, LAYOUT_STORE_KEY, VsComponent } from '@/declaration';
 import VsFooter from './../VsFooter.vue';
 
 describe('VsFooter', () => {
@@ -159,31 +159,46 @@ describe('VsFooter', () => {
         });
     });
 
-    describe('vs-layout의 자식일 때', () => {
+    describe('vs-layout의 자식일 때 (layout prop)', () => {
         // vs-layout 컴포넌트 모킹
         const MockVsLayout = defineComponent({
             name: VsComponent.VsLayout,
             setup() {
                 provide(LAYOUT_STORE_KEY, layoutStore);
+                provide(LAYOUT_PROVIDED_KEY, true);
                 return {};
             },
             template: '<div><slot /></div>',
         });
 
-        it('footer 정보가 layoutStore에 설정되어야 한다', () => {
+        it('layout prop이 true이면 footer 정보가 layoutStore에 설정되어야 한다', () => {
             // given
             const setFooterSpy = vi.spyOn(layoutStore, 'setFooter');
 
             // when
             mount(MockVsLayout, {
                 slots: {
-                    default: VsFooter,
+                    default: () => h(VsFooter, { layout: true }),
                 },
             });
 
             // then
-            // setFooter가 호출되었는지 확인
             expect(setFooterSpy).toHaveBeenCalled();
+        });
+
+        it('layout prop이 없으면 layoutStore에 등록되지 않아야 한다', () => {
+            // given
+            const setFooterSpy = vi.spyOn(layoutStore, 'setFooter');
+
+            // when
+            mount(MockVsLayout, {
+                slots: {
+                    default: () => h(VsFooter, { position: 'fixed', height: '4rem' }),
+                },
+            });
+
+            // then
+            expect(setFooterSpy).not.toHaveBeenCalled();
         });
 
         it('position이 absolute일 때 footer 정보가 올바르게 설정되어야 한다', () => {
@@ -193,7 +208,7 @@ describe('VsFooter', () => {
             // when
             mount(MockVsLayout, {
                 slots: {
-                    default: () => h(VsFooter, { position: 'absolute', height: '4rem' }),
+                    default: () => h(VsFooter, { layout: true, position: 'absolute', height: '4rem' }),
                 },
             });
 
@@ -211,7 +226,7 @@ describe('VsFooter', () => {
             // when
             mount(MockVsLayout, {
                 slots: {
-                    default: () => h(VsFooter, { position: 'fixed', height: '5rem' }),
+                    default: () => h(VsFooter, { layout: true, position: 'fixed', height: '5rem' }),
                 },
             });
 
@@ -229,7 +244,7 @@ describe('VsFooter', () => {
             // when
             mount(MockVsLayout, {
                 slots: {
-                    default: () => h(VsFooter, { position: 'sticky', height: '4rem' }),
+                    default: () => h(VsFooter, { layout: true, position: 'sticky', height: '4rem' }),
                 },
             });
 
@@ -247,7 +262,7 @@ describe('VsFooter', () => {
             // when
             mount(MockVsLayout, {
                 slots: {
-                    default: () => h(VsFooter, { position: 'relative', height: '6rem' }),
+                    default: () => h(VsFooter, { layout: true, position: 'relative', height: '6rem' }),
                 },
             });
 
@@ -256,6 +271,19 @@ describe('VsFooter', () => {
                 position: 'relative',
                 height: '6rem',
             });
+        });
+    });
+
+    describe('vs-layout 외부에서는 layout prop이 무시되어야 한다', () => {
+        it('VsLayout 조상이 없으면 layout prop이 true여도 layoutStore에 등록되지 않아야 한다', () => {
+            // given
+            const setFooterSpy = vi.spyOn(layoutStore, 'setFooter');
+
+            // when
+            mount(VsFooter, { props: { layout: true } });
+
+            // then
+            expect(setFooterSpy).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/vlossom/src/components/vs-header/README.ko.md
+++ b/packages/vlossom/src/components/vs-header/README.ko.md
@@ -12,7 +12,7 @@
 - CSS `position` 값 지원: `static`, `relative`, `absolute`, `fixed`, `sticky`
 - 기본 높이 `3rem` — `height` prop으로 재정의 가능
 - `primary` prop을 통한 기본 색상 스킴 스타일링
-- 드로어 오프셋 계산을 위해 헤더 높이를 보고하는 `VsLayout` 통합
+- `layout` prop을 통한 `VsLayout` 통합 opt-in — 설정 시 드로어 오프셋 계산을 위해 헤더 높이를 보고
 - 완전한 스타일 제어를 위해 `styleSet.component`를 통한 `CSSProperties` 허용
 
 ## 기본 사용법
@@ -45,6 +45,21 @@
 </template>
 ```
 
+### VsLayout 내부에서 사용
+
+`layout` prop을 설정하면 헤더가 레이아웃 스토어에 등록되어 `VsContainer`와 `VsDrawer`가 헤더를 기준으로 오프셋 처리합니다. 다른 컴포넌트로 한 번 감싼 경우에도 동작합니다.
+
+```html
+<template>
+    <vs-layout>
+        <vs-header layout position="fixed" height="3rem">앱 헤더</vs-header>
+        <vs-container layout>
+            <p>콘텐츠</p>
+        </vs-container>
+    </vs-layout>
+</template>
+```
+
 ## Props
 
 | Prop | 타입 | 기본값 | 필수 | 설명 |
@@ -54,6 +69,7 @@
 | `position` | `'static' \| 'relative' \| 'absolute' \| 'fixed' \| 'sticky'` | | | 헤더의 CSS position 값 |
 | `height` | `string` | | | 헤더의 높이. 기본값은 `3rem` |
 | `primary` | `boolean` | `false` | | 기본 색상 스킴 적용 |
+| `layout` | `boolean` | `false` | | `VsLayout` 통합 opt-in. `VsLayout` 조상이 있어야 동작하며, 없으면 무시됩니다 |
 | `tag` | `string` | `'header'` | | 렌더링할 HTML 태그 |
 
 ## 타입

--- a/packages/vlossom/src/components/vs-header/README.md
+++ b/packages/vlossom/src/components/vs-header/README.md
@@ -12,7 +12,7 @@ A page header bar component that supports fixed, sticky, and absolute positionin
 - Supports CSS `position` values: `static`, `relative`, `absolute`, `fixed`, `sticky`
 - Default height of `3rem` — overridable via the `height` prop
 - Primary color scheme styling via the `primary` prop
-- Integrates with `VsLayout` to report header height for drawer offset calculations
+- Opt-in `VsLayout` integration via the `layout` prop — when set, reports header height for drawer offset calculations
 - Accepts `CSSProperties` via `styleSet.component` for full style control
 
 ## Basic Usage
@@ -45,6 +45,21 @@ A page header bar component that supports fixed, sticky, and absolute positionin
 </template>
 ```
 
+### Inside VsLayout
+
+Set the `layout` prop to register the header with the layout store so `VsContainer` and `VsDrawer` can offset around it. Wrapping the header in another component is supported.
+
+```html
+<template>
+    <vs-layout>
+        <vs-header layout position="fixed" height="3rem">My App</vs-header>
+        <vs-container layout>
+            <p>Content</p>
+        </vs-container>
+    </vs-layout>
+</template>
+```
+
 ## Props
 
 | Prop | Type | Default | Required | Description |
@@ -54,6 +69,7 @@ A page header bar component that supports fixed, sticky, and absolute positionin
 | `position` | `'static' \| 'relative' \| 'absolute' \| 'fixed' \| 'sticky'` | | | CSS position value for the header |
 | `height` | `string` | | | Height of the header. Defaults to `3rem` |
 | `primary` | `boolean` | `false` | | Apply the primary color scheme |
+| `layout` | `boolean` | `false` | | Opt in to `VsLayout` integration. Requires a `VsLayout` ancestor; without one this prop has no effect |
 | `tag` | `string` | `'header'` | | HTML tag to render as |
 
 ## Types

--- a/packages/vlossom/src/components/vs-header/VsHeader.vue
+++ b/packages/vlossom/src/components/vs-header/VsHeader.vue
@@ -5,10 +5,10 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, toRefs, type ComputedRef, getCurrentInstance, inject, watchEffect } from 'vue';
-import { useColorScheme, useStyleSet } from '@/composables';
+import { computed, defineComponent, toRefs, type ComputedRef, inject, watchEffect } from 'vue';
+import { useColorScheme, useLayoutChild, useStyleSet } from '@/composables';
 import { VsComponent, LAYOUT_STORE_KEY, type BarLayout } from '@/declaration';
-import { getColorSchemeProps, getPositionProps, getStyleSetProps } from '@/props';
+import { getColorSchemeProps, getLayoutProps, getPositionProps, getStyleSetProps } from '@/props';
 import { objectUtil } from '@/utils';
 import { LayoutStore } from '@/stores';
 import type { VsHeaderStyleSet } from './types';
@@ -23,12 +23,13 @@ export default defineComponent({
         ...getColorSchemeProps(),
         ...getStyleSetProps<VsHeaderStyleSet>(),
         ...getPositionProps(),
+        ...getLayoutProps(),
         height: { type: String },
         primary: { type: Boolean, default: false },
         tag: { type: String, default: 'header' },
     },
     setup(props) {
-        const { colorScheme, styleSet, primary, position, height } = toRefs(props);
+        const { colorScheme, styleSet, primary, position, height, layout } = toRefs(props);
 
         const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
@@ -62,8 +63,7 @@ export default defineComponent({
             'vs-primary': primary.value,
         }));
 
-        // only for vs-layout children
-        const isLayoutChild = computed(() => getCurrentInstance()?.parent?.type.name === VsComponent.VsLayout);
+        const { isLayoutChild } = useLayoutChild(layout);
 
         const layoutStore = inject(LAYOUT_STORE_KEY, LayoutStore.getDefaultLayoutStore());
         watchEffect(() => {

--- a/packages/vlossom/src/components/vs-header/__stories__/vs-header.stories.ts
+++ b/packages/vlossom/src/components/vs-header/__stories__/vs-header.stories.ts
@@ -55,6 +55,10 @@ const meta: Meta<typeof VsHeader> = {
             options: ['relative', 'absolute', 'fixed', 'sticky'],
             description: '헤더의 위치 지정',
         },
+        layout: {
+            control: 'boolean',
+            description: 'VsLayout 통합 opt-in. VsLayout 조상이 있어야 동작합니다',
+        },
         styleSet: {
             control: 'object',
             description: '커스텀 스타일 객체',

--- a/packages/vlossom/src/components/vs-header/__tests__/vs-header.test.ts
+++ b/packages/vlossom/src/components/vs-header/__tests__/vs-header.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { provide, defineComponent, h } from 'vue';
 import { LayoutStore } from '@/stores';
-import { LAYOUT_STORE_KEY, VsComponent } from '@/declaration';
+import { LAYOUT_PROVIDED_KEY, LAYOUT_STORE_KEY, VsComponent } from '@/declaration';
 import VsHeader from './../VsHeader.vue';
 
 describe('VsHeader', () => {
@@ -159,31 +159,46 @@ describe('VsHeader', () => {
         });
     });
 
-    describe('vs-layout의 자식일 때', () => {
+    describe('vs-layout의 자식일 때 (layout prop)', () => {
         // vs-layout 컴포넌트 모킹
         const MockVsLayout = defineComponent({
             name: VsComponent.VsLayout,
             setup() {
                 provide(LAYOUT_STORE_KEY, layoutStore);
+                provide(LAYOUT_PROVIDED_KEY, true);
                 return {};
             },
             template: '<div><slot /></div>',
         });
 
-        it('header 정보가 layoutStore에 설정되어야 한다', () => {
+        it('layout prop이 true이면 header 정보가 layoutStore에 설정되어야 한다', () => {
             // given
             const setHeaderSpy = vi.spyOn(layoutStore, 'setHeader');
 
             // when
             mount(MockVsLayout, {
                 slots: {
-                    default: VsHeader,
+                    default: () => h(VsHeader, { layout: true }),
                 },
             });
 
             // then
-            // setHeader가 호출되었는지 확인
             expect(setHeaderSpy).toHaveBeenCalled();
+        });
+
+        it('layout prop이 없으면 layoutStore에 등록되지 않아야 한다', () => {
+            // given
+            const setHeaderSpy = vi.spyOn(layoutStore, 'setHeader');
+
+            // when
+            mount(MockVsLayout, {
+                slots: {
+                    default: () => h(VsHeader, { position: 'fixed', height: '4rem' }),
+                },
+            });
+
+            // then
+            expect(setHeaderSpy).not.toHaveBeenCalled();
         });
 
         it('position이 absolute일 때 header 정보가 올바르게 설정되어야 한다', () => {
@@ -193,7 +208,7 @@ describe('VsHeader', () => {
             // when
             mount(MockVsLayout, {
                 slots: {
-                    default: () => h(VsHeader, { position: 'absolute', height: '4rem' }),
+                    default: () => h(VsHeader, { layout: true, position: 'absolute', height: '4rem' }),
                 },
             });
 
@@ -211,7 +226,7 @@ describe('VsHeader', () => {
             // when
             mount(MockVsLayout, {
                 slots: {
-                    default: () => h(VsHeader, { position: 'fixed', height: '5rem' }),
+                    default: () => h(VsHeader, { layout: true, position: 'fixed', height: '5rem' }),
                 },
             });
 
@@ -229,7 +244,7 @@ describe('VsHeader', () => {
             // when
             mount(MockVsLayout, {
                 slots: {
-                    default: () => h(VsHeader, { position: 'sticky', height: '4rem' }),
+                    default: () => h(VsHeader, { layout: true, position: 'sticky', height: '4rem' }),
                 },
             });
 
@@ -247,7 +262,7 @@ describe('VsHeader', () => {
             // when
             mount(MockVsLayout, {
                 slots: {
-                    default: () => h(VsHeader, { position: 'relative', height: '6rem' }),
+                    default: () => h(VsHeader, { layout: true, position: 'relative', height: '6rem' }),
                 },
             });
 
@@ -256,6 +271,19 @@ describe('VsHeader', () => {
                 position: 'relative',
                 height: '6rem', // height prop이 적용됨
             });
+        });
+    });
+
+    describe('vs-layout 외부에서는 layout prop이 무시되어야 한다', () => {
+        it('VsLayout 조상이 없으면 layout prop이 true여도 layoutStore에 등록되지 않아야 한다', () => {
+            // given
+            const setHeaderSpy = vi.spyOn(layoutStore, 'setHeader');
+
+            // when
+            mount(VsHeader, { props: { layout: true } });
+
+            // then
+            expect(setHeaderSpy).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/vlossom/src/components/vs-layout/README.ko.md
+++ b/packages/vlossom/src/components/vs-layout/README.ko.md
@@ -8,21 +8,23 @@
 
 ## Feature
 
-- `provide`를 통해 하위 레이아웃 컴포넌트에 레이아웃 스토어를 제공합니다.
-- `VsHeader` 및 `VsFooter` 위치 추적을 가능하게 하는 최상위 컨테이너 역할을 합니다.
+- `provide`를 통해 하위 레이아웃 컴포넌트에 레이아웃 스토어와 레이아웃 컨텍스트 마커를 제공합니다.
+- `layout` prop을 명시적으로 켠 하위 컴포넌트(`VsHeader`, `VsFooter`, `VsDrawer`, `VsContainer`)의 위치 추적을 가능하게 합니다.
 - 부모 요소의 전체 너비와 높이를 차지합니다.
 - 추가 props나 스타일링이 없는 단순한 래퍼입니다.
 
 ## Basic Usage
 
+레이아웃 스토어 연동에 참여하려면 하위 컴포넌트에 `layout` prop을 명시적으로 설정해야 합니다. 중간에 일반 wrapper 컴포넌트가 몇 단계 끼어 있어도 동작하지만, 다른 레이아웃 컴포넌트가 중간에 끼면 그 안쪽으로는 차단되어 의도치 않은 연동이 발생하지 않습니다.
+
 ```html
 <template>
     <vs-layout>
-        <vs-header>앱 헤더</vs-header>
-        <main>
+        <vs-header layout>앱 헤더</vs-header>
+        <vs-container layout>
             <slot />
-        </main>
-        <vs-footer>푸터</vs-footer>
+        </vs-container>
+        <vs-footer layout>푸터</vs-footer>
     </vs-layout>
 </template>
 ```
@@ -56,4 +58,4 @@
 
 ## Caution
 
-`VsLayout`은 `VsHeader` 또는 `VsFooter`를 사용하는 모든 페이지나 섹션을 감싸야 합니다. 이것이 없으면 해당 컴포넌트들이 레이아웃 스토어에 등록되지 않아 정상적으로 동작하지 않습니다.
+`VsHeader`, `VsFooter`, `VsDrawer`, `VsContainer`에 `layout` prop을 사용하는 모든 페이지/섹션은 `VsLayout`으로 감싸야 합니다. `VsLayout` 조상이 없으면 `layout` prop은 무시되고, 해당 컴포넌트들은 일반 컴포넌트처럼 동작합니다.

--- a/packages/vlossom/src/components/vs-layout/README.md
+++ b/packages/vlossom/src/components/vs-layout/README.md
@@ -8,21 +8,23 @@ A root layout container that provides the layout store context required by `VsHe
 
 ## Feature
 
-- Provides the layout store via `provide` for descendant layout components.
-- Acts as the top-level container that enables `VsHeader` and `VsFooter` position tracking.
+- Provides the layout store and a layout context marker via `provide` for descendant layout components.
+- Enables position tracking for descendants that opt in with the `layout` prop (`VsHeader`, `VsFooter`, `VsDrawer`, `VsContainer`).
 - Takes up the full width and height of its parent element.
 - Simple wrapper with no additional props or styling.
 
 ## Basic Usage
 
+Descendants must explicitly opt in with the `layout` prop to participate in layout-store coordination. The opt-in works through any number of intermediate wrapper components, but does **not** propagate through another layout primitive (the inner one is barriered to prevent unintended coupling).
+
 ```html
 <template>
     <vs-layout>
-        <vs-header>My App Header</vs-header>
-        <main>
+        <vs-header layout>My App Header</vs-header>
+        <vs-container layout>
             <slot />
-        </main>
-        <vs-footer>Footer</vs-footer>
+        </vs-container>
+        <vs-footer layout>Footer</vs-footer>
     </vs-layout>
 </template>
 ```
@@ -56,4 +58,4 @@ A root layout container that provides the layout store context required by `VsHe
 
 ## Caution
 
-`VsLayout` must wrap any page or section that uses `VsHeader` or `VsFooter`. Without it, those components cannot register themselves in the layout store and will not function correctly.
+`VsLayout` must wrap any page or section that uses the `layout` prop on `VsHeader`, `VsFooter`, `VsDrawer`, or `VsContainer`. Without a `VsLayout` ancestor, the `layout` prop has no effect and those components fall back to standalone behavior.

--- a/packages/vlossom/src/components/vs-layout/VsLayout.vue
+++ b/packages/vlossom/src/components/vs-layout/VsLayout.vue
@@ -7,7 +7,7 @@
 <script lang="ts">
 import { defineComponent, provide } from 'vue';
 import { LayoutStore } from '@/stores';
-import { LAYOUT_STORE_KEY, VsComponent } from '@/declaration';
+import { LAYOUT_PROVIDED_KEY, LAYOUT_STORE_KEY, VsComponent } from '@/declaration';
 
 const componentName = VsComponent.VsLayout;
 export default defineComponent({
@@ -16,6 +16,7 @@ export default defineComponent({
         const layoutStore = LayoutStore.getDefaultLayoutStore();
 
         provide(LAYOUT_STORE_KEY, layoutStore);
+        provide(LAYOUT_PROVIDED_KEY, true);
 
         return {};
     },

--- a/packages/vlossom/src/components/vs-layout/__tests__/vs-layout.test.ts
+++ b/packages/vlossom/src/components/vs-layout/__tests__/vs-layout.test.ts
@@ -3,7 +3,7 @@ import { mount } from '@vue/test-utils';
 import { defineComponent, inject } from 'vue';
 import VsLayout from './../VsLayout.vue';
 import { LayoutStore } from '@/stores';
-import { LAYOUT_STORE_KEY } from '@/declaration';
+import { LAYOUT_PROVIDED_KEY, LAYOUT_STORE_KEY } from '@/declaration';
 
 describe('VsLayout', () => {
     let layoutStore: LayoutStore;
@@ -39,6 +39,32 @@ describe('VsLayout', () => {
             expect(childWrapper.vm.injectedLayoutStore).toBeDefined();
             expect(childWrapper.vm.injectedLayoutStore).toBe(layoutStore);
             expect(childWrapper.vm.injectedLayoutStore).toBeInstanceOf(LayoutStore);
+        });
+    });
+
+    describe('LAYOUT_PROVIDED 마커 제공', () => {
+        it('LAYOUT_PROVIDED_KEY로 true를 provide해야 한다', () => {
+            // given
+            const ChildComponent = defineComponent({
+                name: 'TestChild',
+                setup() {
+                    const injectedFlag = inject<boolean>(LAYOUT_PROVIDED_KEY, false);
+                    return { injectedFlag };
+                },
+                template: '<div>test</div>',
+            });
+
+            // when
+            const wrapper = mount(VsLayout, {
+                slots: {
+                    default: ChildComponent,
+                },
+            });
+
+            const childWrapper = wrapper.findComponent(ChildComponent);
+
+            // then
+            expect(childWrapper.vm.injectedFlag).toBe(true);
         });
     });
 });

--- a/packages/vlossom/src/composables/index.ts
+++ b/packages/vlossom/src/composables/index.ts
@@ -6,6 +6,7 @@ export * from './input-form/input-form-composable';
 export * from './input-messages/input-messages-composable';
 export * from './input-option/input-option-composable';
 export * from './input-rules/input-rules-composable';
+export * from './layout-child/layout-child-composable';
 export * from './list-index-selector/list-index-selector-composable';
 export * from './option-label-value/option-label-value-composable';
 export * from './option-list/option-list-composable';

--- a/packages/vlossom/src/composables/layout-child/layout-child-composable.ts
+++ b/packages/vlossom/src/composables/layout-child/layout-child-composable.ts
@@ -1,0 +1,13 @@
+import { computed, inject, provide, type Ref } from 'vue';
+import { LAYOUT_PROVIDED_KEY } from '@/declaration';
+
+export function useLayoutChild(layoutProp: Ref<boolean>) {
+    const hasLayoutAncestor = inject<boolean>(LAYOUT_PROVIDED_KEY, false);
+
+    // barrier: prevent layout context from leaking to descendants
+    provide(LAYOUT_PROVIDED_KEY, false);
+
+    const isLayoutChild = computed(() => layoutProp.value && hasLayoutAncestor);
+
+    return { isLayoutChild };
+}

--- a/packages/vlossom/src/declaration/constants.ts
+++ b/packages/vlossom/src/declaration/constants.ts
@@ -1,5 +1,6 @@
 export const THEME_KEY = 'vlossom:theme-mode';
 export const LAYOUT_STORE_KEY = 'vlossom:layout-store';
+export const LAYOUT_PROVIDED_KEY = 'vlossom:layout-provided';
 export const FORM_STORE_KEY = 'vlossom:form-store';
 
 export const OVERLAY_OPEN = 'vlossom:overlay-open';

--- a/packages/vlossom/src/declaration/types.ts
+++ b/packages/vlossom/src/declaration/types.ts
@@ -46,7 +46,7 @@ export type OverlayCallbacks<T = void> = { [eventName: string]: (...args: any[])
 
 export interface DrawerLayout {
     isOpen: boolean;
-    responsive: boolean;
+    pushContainer: boolean;
     placement: DrawerPlacement;
     size: string;
 }

--- a/packages/vlossom/src/props/index.ts
+++ b/packages/vlossom/src/props/index.ts
@@ -1,6 +1,7 @@
 export * from './button-props';
 export * from './floating-props';
 export * from './input-props';
+export * from './layout-props';
 export * from './min-max-props';
 export * from './options-props';
 export * from './overlay-props';

--- a/packages/vlossom/src/props/layout-props.ts
+++ b/packages/vlossom/src/props/layout-props.ts
@@ -1,0 +1,5 @@
+export function getLayoutProps() {
+    return {
+        layout: { type: Boolean, default: false },
+    };
+}

--- a/packages/vlossom/src/stores/layout-store.ts
+++ b/packages/vlossom/src/stores/layout-store.ts
@@ -6,10 +6,10 @@ export class LayoutStore {
     private _header: Ref<BarLayout> = ref({ position: 'relative', height: '' });
     private _footer: Ref<BarLayout> = ref({ position: 'relative', height: '' });
     private _drawers: Ref<DrawerLayouts> = ref({
-        left: { isOpen: false, responsive: false, placement: 'left', size: '' },
-        top: { isOpen: false, responsive: false, placement: 'top', size: '' },
-        right: { isOpen: false, responsive: false, placement: 'right', size: '' },
-        bottom: { isOpen: false, responsive: false, placement: 'bottom', size: '' },
+        left: { isOpen: false, pushContainer: false, placement: 'left', size: '' },
+        top: { isOpen: false, pushContainer: false, placement: 'top', size: '' },
+        right: { isOpen: false, pushContainer: false, placement: 'right', size: '' },
+        bottom: { isOpen: false, pushContainer: false, placement: 'bottom', size: '' },
     });
 
     public static getDefaultLayoutStore(): LayoutStore {


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat))

## Summary
vs-layout에 반응하는 자식 컴포넌트들이 vs-layout 부모라는 것을 확인하는 로직을 변경

## Description
- 기존 구현은 layout children을 component로 감쌀 경우에 제대로 동작하지 않는 이슈가 있었음
- 단순히 provide/inject 만 사용하면 깊이가 아주 깊어지는 nested children의 경우에 예기치 못한 side-effect 발생함
- 그래서 사용자가 명시적으로 `layout` 이라는 prop을 남겨서 layout 요소임을 표시하도록 강제함
- layout임을 확인한 이후에는 provide가 더 전파되지 않도록 false 처리
- 기존에 vs-drawer에 있던 layout-responsive가 layout과 이름이 헷갈려서 push-container로 이름 변경
- 관련된 문서와 테스트 수정

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
