### PR TITLE
feat(VsModal): add beforeClose hook to abort modal close

### DIFF
--- a/packages/vlossom/src/components/vs-modal/README.ko.md
+++ b/packages/vlossom/src/components/vs-modal/README.ko.md
@@ -82,6 +82,7 @@ const isOpen = ref(false);
 | `colorScheme` | `string`                                                    | -         | -        | 모달의 색상 스킴.                                                                 |
 | `styleSet`    | `string \| VsModalNodeStyleSet`                             | -         | -        | 모달 노드의 커스텀 스타일 셋.                                                     |
 | `modelValue`  | `boolean`                                                   | `false`   | -        | 모달의 표시 여부를 제어합니다 (v-model).                                          |
+| `beforeClose` | `() => Promise<boolean> \| boolean`                         | -         | -        | 모달이 닫히기 전에 호출되는 훅. `false`를 반환하면 닫기를 취소합니다.             |
 | `container`   | `string`                                                    | `'body'`  | -        | 모달을 텔레포트할 요소의 CSS 선택자.                                              |
 | `escClose`    | `boolean`                                                   | `true`    | -        | ESC 키를 누르면 모달을 닫습니다.                                                  |
 | `size`        | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| string \| number \| { width?: SizeProp; height?: SizeProp }` | - | - | 사전 정의된 키워드 또는 커스텀 width/height로 모달 크기를 설정합니다. |

--- a/packages/vlossom/src/components/vs-modal/README.ko.md
+++ b/packages/vlossom/src/components/vs-modal/README.ko.md
@@ -75,6 +75,25 @@ const isOpen = ref(false);
 </template>
 ```
 
+### Before Close Hook
+
+```html
+<template>
+    <vs-modal v-model="isOpen" :before-close="confirmClose">
+        <div>닫기를 시도해보세요.</div>
+    </vs-modal>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+const isOpen = ref(false);
+
+async function confirmClose() {
+    return window.confirm('정말 닫으시겠습니까?');
+}
+</script>
+```
+
 ## Props
 
 | Prop          | Type                                                        | Default   | Required | Description                                                                       |

--- a/packages/vlossom/src/components/vs-modal/README.ko.md
+++ b/packages/vlossom/src/components/vs-modal/README.ko.md
@@ -96,21 +96,21 @@ async function confirmClose() {
 
 ## Props
 
-| Prop          | Type                                                        | Default   | Required | Description                                                                       |
-| ------------- | ----------------------------------------------------------- | --------- | -------- | --------------------------------------------------------------------------------- |
-| `colorScheme` | `string`                                                    | -         | -        | 모달의 색상 스킴.                                                                 |
-| `styleSet`    | `string \| VsModalNodeStyleSet`                             | -         | -        | 모달 노드의 커스텀 스타일 셋.                                                     |
-| `modelValue`  | `boolean`                                                   | `false`   | -        | 모달의 표시 여부를 제어합니다 (v-model).                                          |
-| `beforeClose` | `() => Promise<boolean> \| boolean`                         | -         | -        | 모달이 닫히기 전에 호출되는 훅. `false`를 반환하면 닫기를 취소합니다.             |
-| `container`   | `string`                                                    | `'body'`  | -        | 모달을 텔레포트할 요소의 CSS 선택자.                                              |
-| `escClose`    | `boolean`                                                   | `true`    | -        | ESC 키를 누르면 모달을 닫습니다.                                                  |
-| `size`        | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| string \| number \| { width?: SizeProp; height?: SizeProp }` | - | - | 사전 정의된 키워드 또는 커스텀 width/height로 모달 크기를 설정합니다. |
-| `callbacks`   | `OverlayCallbacks`                                          | `{}`      | -        | 오버레이 콜백 핸들러.                                                             |
-| `dimClose`    | `boolean`                                                   | `false`   | -        | 딤드 영역 클릭 시 모달을 닫습니다.                                                |
-| `dimmed`      | `boolean`                                                   | `false`   | -        | 모달 뒤에 딤드 오버레이를 표시합니다.                                             |
-| `focusLock`   | `boolean`                                                   | `false`   | -        | 모달이 열려 있는 동안 포커스를 내부에 고정합니다.                                 |
-| `hideScroll`  | `boolean`                                                   | `false`   | -        | 모달이 열려 있을 때 컨테이너의 스크롤을 숨깁니다.                                 |
-| `id`          | `string`                                                    | `''`      | -        | 모달 오버레이 인스턴스의 커스텀 ID.                                               |
+| Prop          | Type                                                                                                  | Default  | Required | Description                                                                                                       |
+| ------------- | ----------------------------------------------------------------------------------------------------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------------- |
+| `colorScheme` | `string`                                                                                              | -        | -        | 모달의 색상 스킴.                                                                                                 |
+| `styleSet`    | `string \| VsModalNodeStyleSet`                                                                       | -        | -        | 모달 노드의 커스텀 스타일 셋.                                                                                     |
+| `modelValue`  | `boolean`                                                                                             | `false`  | -        | 모달의 표시 여부를 제어합니다 (v-model).                                                                          |
+| `beforeClose` | `() => Promise<boolean> \| boolean`                                                                   | -        | -        | 모달이 닫히기 전에 호출되는 훅. `false`를 반환하면 닫기를 취소합니다. `$vs.modal.clear()` 호출 시에는 무시됩니다. |
+| `container`   | `string`                                                                                              | `'body'` | -        | 모달을 텔레포트할 요소의 CSS 선택자.                                                                              |
+| `escClose`    | `boolean`                                                                                             | `true`   | -        | ESC 키를 누르면 모달을 닫습니다.                                                                                  |
+| `size`        | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| string \| number \| { width?: SizeProp; height?: SizeProp }` | -        | -        | 사전 정의된 키워드 또는 커스텀 width/height로 모달 크기를 설정합니다.                                             |
+| `callbacks`   | `OverlayCallbacks`                                                                                    | `{}`     | -        | 오버레이 콜백 핸들러.                                                                                             |
+| `dimClose`    | `boolean`                                                                                             | `false`  | -        | 딤드 영역 클릭 시 모달을 닫습니다.                                                                                |
+| `dimmed`      | `boolean`                                                                                             | `false`  | -        | 모달 뒤에 딤드 오버레이를 표시합니다.                                                                             |
+| `focusLock`   | `boolean`                                                                                             | `false`  | -        | 모달이 열려 있는 동안 포커스를 내부에 고정합니다.                                                                 |
+| `hideScroll`  | `boolean`                                                                                             | `false`  | -        | 모달이 열려 있을 때 컨테이너의 스크롤을 숨깁니다.                                                                 |
+| `id`          | `string`                                                                                              | `''`     | -        | 모달 오버레이 인스턴스의 커스텀 ID.                                                                               |
 
 ## Types
 
@@ -150,17 +150,17 @@ interface VsModalNodeStyleSet {
 
 ## Events
 
-| 이벤트              | 페이로드  | 설명                                    |
-| ------------------- | --------- | --------------------------------------- |
-| `update:modelValue` | `boolean` | 모달 열림 상태가 변경될 때 발생합니다.  |
-| `open`              | -         | 모달이 열릴 때 발생합니다.              |
-| `close`             | -         | 모달이 닫힐 때 발생합니다.              |
+| 이벤트              | 페이로드  | 설명                                   |
+| ------------------- | --------- | -------------------------------------- |
+| `update:modelValue` | `boolean` | 모달 열림 상태가 변경될 때 발생합니다. |
+| `open`              | -         | 모달이 열릴 때 발생합니다.             |
+| `close`             | -         | 모달이 닫힐 때 발생합니다.             |
 
 ## Slots
 
-| 슬롯      | 설명                                       |
-| --------- | ------------------------------------------ |
-| `default` | 모달 다이얼로그 내부에 렌더링할 콘텐츠.    |
+| 슬롯      | 설명                                    |
+| --------- | --------------------------------------- |
+| `default` | 모달 다이얼로그 내부에 렌더링할 콘텐츠. |
 
 ## Methods
 

--- a/packages/vlossom/src/components/vs-modal/README.md
+++ b/packages/vlossom/src/components/vs-modal/README.md
@@ -82,6 +82,7 @@ const isOpen = ref(false);
 | `colorScheme` | `string`                                                    | -         | -        | Color scheme for the modal.                                                    |
 | `styleSet`    | `string \| VsModalNodeStyleSet`                             | -         | -        | Custom style set for the modal node.                                           |
 | `modelValue`  | `boolean`                                                   | `false`   | -        | Controls the visibility of the modal (v-model).                                |
+| `beforeClose` | `() => Promise<boolean> \| boolean`                         | -         | -        | Hook invoked before the modal closes. Resolve `false` to abort the close.       |
 | `container`   | `string`                                                    | `'body'`  | -        | CSS selector of the element to teleport the modal into.                        |
 | `escClose`    | `boolean`                                                   | `true`    | -        | Closes the modal when the ESC key is pressed.                                  |
 | `size`        | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| string \| number \| { width?: SizeProp; height?: SizeProp }` | - | - | Modal size as a predefined keyword or custom width/height. |
@@ -91,6 +92,25 @@ const isOpen = ref(false);
 | `focusLock`   | `boolean`                                                   | `false`   | -        | Traps focus within the modal while it is open.                                 |
 | `hideScroll`  | `boolean`                                                   | `false`   | -        | Hides the scroll on the container when the modal is open.                      |
 | `id`          | `string`                                                    | `''`      | -        | Custom ID for the modal overlay instance.                                      |
+
+### Before Close Hook
+
+```html
+<template>
+    <vs-modal v-model="isOpen" :before-close="confirmClose">
+        <div>Try to close me.</div>
+    </vs-modal>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+const isOpen = ref(false);
+
+async function confirmClose() {
+    return window.confirm('Are you sure you want to close?');
+}
+</script>
+```
 
 ## Types
 

--- a/packages/vlossom/src/components/vs-modal/README.md
+++ b/packages/vlossom/src/components/vs-modal/README.md
@@ -96,21 +96,21 @@ async function confirmClose() {
 
 ## Props
 
-| Prop          | Type                                                                                                  | Default  | Required | Description                                                               |
-| ------------- | ----------------------------------------------------------------------------------------------------- | -------- | -------- | ------------------------------------------------------------------------- |
-| `colorScheme` | `string`                                                                                              | -        | -        | Color scheme for the modal.                                               |
-| `styleSet`    | `string \| VsModalNodeStyleSet`                                                                       | -        | -        | Custom style set for the modal node.                                      |
-| `modelValue`  | `boolean`                                                                                             | `false`  | -        | Controls the visibility of the modal (v-model).                           |
-| `beforeClose` | `() => Promise<boolean> \| boolean`                                                                   | -        | -        | Hook invoked before the modal closes. Resolve `false` to abort the close. |
-| `container`   | `string`                                                                                              | `'body'` | -        | CSS selector of the element to teleport the modal into.                   |
-| `escClose`    | `boolean`                                                                                             | `true`   | -        | Closes the modal when the ESC key is pressed.                             |
-| `size`        | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| string \| number \| { width?: SizeProp; height?: SizeProp }` | -        | -        | Modal size as a predefined keyword or custom width/height.                |
-| `callbacks`   | `OverlayCallbacks`                                                                                    | `{}`     | -        | Overlay callback handlers.                                                |
-| `dimClose`    | `boolean`                                                                                             | `false`  | -        | Closes the modal when clicking the dimmed area.                           |
-| `dimmed`      | `boolean`                                                                                             | `false`  | -        | Shows a dimmed overlay behind the modal.                                  |
-| `focusLock`   | `boolean`                                                                                             | `false`  | -        | Traps focus within the modal while it is open.                            |
-| `hideScroll`  | `boolean`                                                                                             | `false`  | -        | Hides the scroll on the container when the modal is open.                 |
-| `id`          | `string`                                                                                              | `''`     | -        | Custom ID for the modal overlay instance.                                 |
+| Prop          | Type                                                                                                  | Default  | Required | Description                                                                                                |
+| ------------- | ----------------------------------------------------------------------------------------------------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------- |
+| `colorScheme` | `string`                                                                                              | -        | -        | Color scheme for the modal.                                                                                |
+| `styleSet`    | `string \| VsModalNodeStyleSet`                                                                       | -        | -        | Custom style set for the modal node.                                                                       |
+| `modelValue`  | `boolean`                                                                                             | `false`  | -        | Controls the visibility of the modal (v-model).                                                            |
+| `beforeClose` | `() => Promise<boolean> \| boolean`                                                                   | -        | -        | Hook invoked before the modal closes. Resolve `false` to abort the close. Bypassed by `$vs.modal.clear()`. |
+| `container`   | `string`                                                                                              | `'body'` | -        | CSS selector of the element to teleport the modal into.                                                    |
+| `escClose`    | `boolean`                                                                                             | `true`   | -        | Closes the modal when the ESC key is pressed.                                                              |
+| `size`        | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| string \| number \| { width?: SizeProp; height?: SizeProp }` | -        | -        | Modal size as a predefined keyword or custom width/height.                                                 |
+| `callbacks`   | `OverlayCallbacks`                                                                                    | `{}`     | -        | Overlay callback handlers.                                                                                 |
+| `dimClose`    | `boolean`                                                                                             | `false`  | -        | Closes the modal when clicking the dimmed area.                                                            |
+| `dimmed`      | `boolean`                                                                                             | `false`  | -        | Shows a dimmed overlay behind the modal.                                                                   |
+| `focusLock`   | `boolean`                                                                                             | `false`  | -        | Traps focus within the modal while it is open.                                                             |
+| `hideScroll`  | `boolean`                                                                                             | `false`  | -        | Hides the scroll on the container when the modal is open.                                                  |
+| `id`          | `string`                                                                                              | `''`     | -        | Custom ID for the modal overlay instance.                                                                  |
 
 ## Types
 

--- a/packages/vlossom/src/components/vs-modal/README.md
+++ b/packages/vlossom/src/components/vs-modal/README.md
@@ -75,24 +75,6 @@ const isOpen = ref(false);
 </template>
 ```
 
-## Props
-
-| Prop          | Type                                                        | Default   | Required | Description                                                                    |
-| ------------- | ----------------------------------------------------------- | --------- | -------- | ------------------------------------------------------------------------------ |
-| `colorScheme` | `string`                                                    | -         | -        | Color scheme for the modal.                                                    |
-| `styleSet`    | `string \| VsModalNodeStyleSet`                             | -         | -        | Custom style set for the modal node.                                           |
-| `modelValue`  | `boolean`                                                   | `false`   | -        | Controls the visibility of the modal (v-model).                                |
-| `beforeClose` | `() => Promise<boolean> \| boolean`                         | -         | -        | Hook invoked before the modal closes. Resolve `false` to abort the close.       |
-| `container`   | `string`                                                    | `'body'`  | -        | CSS selector of the element to teleport the modal into.                        |
-| `escClose`    | `boolean`                                                   | `true`    | -        | Closes the modal when the ESC key is pressed.                                  |
-| `size`        | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| string \| number \| { width?: SizeProp; height?: SizeProp }` | - | - | Modal size as a predefined keyword or custom width/height. |
-| `callbacks`   | `OverlayCallbacks`                                          | `{}`      | -        | Overlay callback handlers.                                                     |
-| `dimClose`    | `boolean`                                                   | `false`   | -        | Closes the modal when clicking the dimmed area.                                |
-| `dimmed`      | `boolean`                                                   | `false`   | -        | Shows a dimmed overlay behind the modal.                                       |
-| `focusLock`   | `boolean`                                                   | `false`   | -        | Traps focus within the modal while it is open.                                 |
-| `hideScroll`  | `boolean`                                                   | `false`   | -        | Hides the scroll on the container when the modal is open.                      |
-| `id`          | `string`                                                    | `''`      | -        | Custom ID for the modal overlay instance.                                      |
-
 ### Before Close Hook
 
 ```html
@@ -111,6 +93,24 @@ async function confirmClose() {
 }
 </script>
 ```
+
+## Props
+
+| Prop          | Type                                                                                                  | Default  | Required | Description                                                               |
+| ------------- | ----------------------------------------------------------------------------------------------------- | -------- | -------- | ------------------------------------------------------------------------- |
+| `colorScheme` | `string`                                                                                              | -        | -        | Color scheme for the modal.                                               |
+| `styleSet`    | `string \| VsModalNodeStyleSet`                                                                       | -        | -        | Custom style set for the modal node.                                      |
+| `modelValue`  | `boolean`                                                                                             | `false`  | -        | Controls the visibility of the modal (v-model).                           |
+| `beforeClose` | `() => Promise<boolean> \| boolean`                                                                   | -        | -        | Hook invoked before the modal closes. Resolve `false` to abort the close. |
+| `container`   | `string`                                                                                              | `'body'` | -        | CSS selector of the element to teleport the modal into.                   |
+| `escClose`    | `boolean`                                                                                             | `true`   | -        | Closes the modal when the ESC key is pressed.                             |
+| `size`        | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| string \| number \| { width?: SizeProp; height?: SizeProp }` | -        | -        | Modal size as a predefined keyword or custom width/height.                |
+| `callbacks`   | `OverlayCallbacks`                                                                                    | `{}`     | -        | Overlay callback handlers.                                                |
+| `dimClose`    | `boolean`                                                                                             | `false`  | -        | Closes the modal when clicking the dimmed area.                           |
+| `dimmed`      | `boolean`                                                                                             | `false`  | -        | Shows a dimmed overlay behind the modal.                                  |
+| `focusLock`   | `boolean`                                                                                             | `false`  | -        | Traps focus within the modal while it is open.                            |
+| `hideScroll`  | `boolean`                                                                                             | `false`  | -        | Hides the scroll on the container when the modal is open.                 |
+| `id`          | `string`                                                                                              | `''`     | -        | Custom ID for the modal overlay instance.                                 |
 
 ## Types
 
@@ -150,17 +150,17 @@ interface VsModalNodeStyleSet {
 
 ## Events
 
-| Event               | Payload   | Description                              |
-| ------------------- | --------- | ---------------------------------------- |
+| Event               | Payload   | Description                                |
+| ------------------- | --------- | ------------------------------------------ |
 | `update:modelValue` | `boolean` | Emitted when the modal open state changes. |
-| `open`              | -         | Emitted when the modal opens.            |
-| `close`             | -         | Emitted when the modal closes.           |
+| `open`              | -         | Emitted when the modal opens.              |
+| `close`             | -         | Emitted when the modal closes.             |
 
 ## Slots
 
-| Slot      | Description                                         |
-| --------- | --------------------------------------------------- |
-| `default` | The content rendered inside the modal dialog.       |
+| Slot      | Description                                   |
+| --------- | --------------------------------------------- |
+| `default` | The content rendered inside the modal dialog. |
 
 ## Methods
 

--- a/packages/vlossom/src/components/vs-modal/VsModal.vue
+++ b/packages/vlossom/src/components/vs-modal/VsModal.vue
@@ -13,6 +13,10 @@ export default defineComponent({
         ...getColorSchemeProps(),
         ...getStyleSetProps<VsModalNodeStyleSet>(),
         ...getOverlayProps(),
+        beforeClose: {
+            type: Function as PropType<() => Promise<boolean> | boolean>,
+            default: undefined,
+        },
         container: { type: String, default: 'body' },
         escClose: { type: Boolean, default: true },
         size: {
@@ -31,10 +35,6 @@ export default defineComponent({
         const isOpen = ref(modelValue.value);
         const modalId = ref('');
 
-        watch(modelValue, (o) => {
-            isOpen.value = o;
-        });
-
         const modalOptions = computed(() => {
             return {
                 ...props,
@@ -47,6 +47,20 @@ export default defineComponent({
             };
         });
 
+        watch(modelValue, async (o) => {
+            if (o === isOpen.value) {
+                return;
+            }
+            if (!o) {
+                const closed = await $vs.modal.closeWithId(container.value, modalId.value);
+                if (!closed) {
+                    emit('update:modelValue', true);
+                }
+                return;
+            }
+            isOpen.value = true;
+        });
+
         watch(isOpen, (o) => {
             emit('update:modelValue', o);
             emit(o ? 'open' : 'close');
@@ -55,8 +69,6 @@ export default defineComponent({
                 const vnode = slots.default?.();
                 const modalComponent: Component = vnode ? () => vnode : ((() => null) as Component);
                 modalId.value = $vs.modal.open(modalComponent, modalOptions.value);
-            } else {
-                $vs.modal.closeWithId(container.value, modalId.value);
             }
         });
 

--- a/packages/vlossom/src/components/vs-modal/VsModalNode.vue
+++ b/packages/vlossom/src/components/vs-modal/VsModalNode.vue
@@ -40,6 +40,10 @@ export default defineComponent({
         ...getColorSchemeProps(),
         ...getStyleSetProps<VsModalNodeStyleSet>(),
         ...getOverlayProps(),
+        beforeClose: {
+            type: Function as PropType<() => Promise<boolean> | boolean>,
+            default: undefined,
+        },
         container: { type: String, default: 'body' },
         escClose: { type: Boolean, default: true },
         dimClose: { type: Boolean, default: true },
@@ -49,7 +53,8 @@ export default defineComponent({
     },
     emits: ['close', 'click-dimmed'],
     setup(props, { emit }) {
-        const { colorScheme, styleSet, dimClose, size, id, escClose, callbacks, focusLock } = toRefs(props);
+        const { beforeClose, colorScheme, styleSet, dimClose, size, id, escClose, callbacks, focusLock } =
+            toRefs(props);
 
         const innerId = stringUtil.createID();
         const computedId = computed(() => id.value || innerId);
@@ -119,6 +124,21 @@ export default defineComponent({
             deactivate();
         }
 
+        async function runBeforeClose(): Promise<boolean> {
+            const fn = beforeClose.value;
+            if (!fn) {
+                return true;
+            }
+            const result = await fn();
+            return result !== false;
+        }
+
+        async function tryCloseModalNode() {
+            if (await runBeforeClose()) {
+                closeModalNode();
+            }
+        }
+
         const computedCallbacks = computed(() => {
             return {
                 ...callbacks.value,
@@ -128,14 +148,14 @@ export default defineComponent({
 
                     closeModalNode();
                 },
-                ['key-Escape']: (event: KeyboardEvent) => {
+                ['key-Escape']: async (event: KeyboardEvent) => {
                     event.preventDefault();
                     event.stopPropagation();
 
                     callbacks.value?.['key-Escape']?.(event);
 
                     if (escClose.value) {
-                        closeModalNode();
+                        await tryCloseModalNode();
                     }
                 },
             };
@@ -143,11 +163,11 @@ export default defineComponent({
 
         const { activate, deactivate } = useOverlayCallback(computedId, computedCallbacks);
 
-        function onClickDimmed() {
+        async function onClickDimmed() {
             emit('click-dimmed');
 
             if (dimClose.value) {
-                closeModalNode();
+                await tryCloseModalNode();
             }
         }
 

--- a/packages/vlossom/src/components/vs-modal/VsModalView.vue
+++ b/packages/vlossom/src/components/vs-modal/VsModalView.vue
@@ -4,6 +4,7 @@
             <vs-modal-node
                 v-for="modal in modals"
                 :key="modal.id"
+                :before-close="modal.beforeClose"
                 :color-scheme="modal.colorScheme"
                 :style-set="modal.styleSet"
                 :callbacks="modal.callbacks"

--- a/packages/vlossom/src/components/vs-modal/__tests__/vs-modal-node.test.ts
+++ b/packages/vlossom/src/components/vs-modal/__tests__/vs-modal-node.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import VsModalNode from './../VsModalNode.vue';
 
@@ -73,6 +73,52 @@ describe('VsModalNode', () => {
                 width: '45%',
                 height: '400px',
             });
+        });
+    });
+
+    describe('beforeClose hook', () => {
+        it('beforeClose가 false를 반환하면 dimmed 클릭 시 close 이벤트가 발생하지 않아야 한다', async () => {
+            // given
+            const beforeClose = vi.fn(async () => false);
+            const wrapper = mount(VsModalNode, {
+                props: {
+                    dimmed: true,
+                    dimClose: true,
+                    beforeClose,
+                },
+            });
+
+            await wrapper.vm.$nextTick();
+
+            // when
+            await wrapper.vm.onClickDimmed();
+            await wrapper.vm.$nextTick();
+
+            // then
+            expect(beforeClose).toHaveBeenCalled();
+            expect(wrapper.emitted('close')).toBeFalsy();
+        });
+
+        it('beforeClose가 true를 반환하면 dimmed 클릭 시 close 이벤트가 발생해야 한다', async () => {
+            // given
+            const beforeClose = vi.fn(async () => true);
+            const wrapper = mount(VsModalNode, {
+                props: {
+                    dimmed: true,
+                    dimClose: true,
+                    beforeClose,
+                },
+            });
+
+            await wrapper.vm.$nextTick();
+
+            // when
+            await wrapper.vm.onClickDimmed();
+            await wrapper.vm.$nextTick();
+
+            // then
+            expect(beforeClose).toHaveBeenCalled();
+            expect(wrapper.emitted('close')).toBeTruthy();
         });
     });
 

--- a/packages/vlossom/src/plugins/alert-plugin/__tests__/alert-plugin.test.ts
+++ b/packages/vlossom/src/plugins/alert-plugin/__tests__/alert-plugin.test.ts
@@ -5,12 +5,12 @@ import type { ModalPlugin } from '@/plugins/modal-plugin';
 
 describe('alert-plugin', () => {
     let registeredCallbacks: Record<string, (...args: any[]) => void>;
-    let closeWithId: ReturnType<typeof vi.fn<(container: string, id: string) => void>>;
+    let closeWithId: ReturnType<typeof vi.fn<(container: string, id: string) => Promise<boolean>>>;
     let modalPlugin: ModalPlugin;
 
     beforeEach(() => {
         registeredCallbacks = {};
-        closeWithId = vi.fn<(container: string, id: string) => void>();
+        closeWithId = vi.fn<(container: string, id: string) => Promise<boolean>>(async () => true);
         modalPlugin = {
             open: vi.fn((_content: any, options) => {
                 registeredCallbacks = options?.callbacks ?? {};

--- a/packages/vlossom/src/plugins/alert-plugin/types.ts
+++ b/packages/vlossom/src/plugins/alert-plugin/types.ts
@@ -8,7 +8,7 @@ export interface VsAlertStyleSet extends VsModalNodeStyleSet {
     button?: Omit<VsButtonStyleSet, 'loading'>;
 }
 
-export interface AlertModalOptions extends ModalOptions {
+export interface AlertModalOptions extends Omit<ModalOptions, 'beforeClose'> {
     styleSet?: VsAlertStyleSet;
     colorScheme?: ColorScheme;
     okText?: string;

--- a/packages/vlossom/src/plugins/confirm-plugin/types.ts
+++ b/packages/vlossom/src/plugins/confirm-plugin/types.ts
@@ -10,7 +10,7 @@ export interface VsConfirmStyleSet extends VsModalNodeStyleSet {
     cancelButton?: Omit<VsButtonStyleSet, 'loading'>;
 }
 
-export interface ConfirmModalOptions extends ModalOptions {
+export interface ConfirmModalOptions extends Omit<ModalOptions, 'beforeClose'> {
     styleSet?: VsConfirmStyleSet;
     colorScheme?: ColorScheme;
     okText?: string;

--- a/packages/vlossom/src/plugins/modal-plugin/README.ko.md
+++ b/packages/vlossom/src/plugins/modal-plugin/README.ko.md
@@ -91,14 +91,15 @@ function closeModal() {
 | `open`          | `content: string \| Component, options?: ModalOptions`      | 주어진 콘텐츠와 옵션으로 모달을 엽니다. 모달의 고유 문자열 ID를 반환합니다.                             |
 | `emit`          | `eventName: string, ...args: any[]`                                        | 가장 최근에 열린 모달의 콜백 스토어에 이름이 있는 이벤트를 emit합니다.                                  |
 | `emitWithId`    | `id: string, eventName: string, ...args: any[]`                            | ID로 특정 모달에 이름이 있는 이벤트를 emit합니다.                                                       |
-| `close`         | `container?: string`                                                       | 주어진 컨테이너(기본값: `'body'`)에서 가장 최근에 열린 모달을 닫습니다.                                 |
-| `closeWithId`   | `container: string, id: string`                                            | 컨테이너와 ID로 특정 모달을 닫습니다.                                                                   |
-| `clear`         | `container?: string`                                                       | 주어진 컨테이너(기본값: `'body'`)의 모든 모달을 닫습니다.                                               |
+| `close`         | `container?: string`                                                       | 주어진 컨테이너(기본값: `'body'`)에서 가장 최근에 열린 모달을 닫습니다. 실제로 닫혔는지를 `Promise<boolean>`으로 반환합니다 (`beforeClose`가 `false`를 반환하면 닫기를 취소). |
+| `closeWithId`   | `container: string, id: string`                                            | 컨테이너와 ID로 특정 모달을 닫습니다. 실제로 닫혔는지를 `Promise<boolean>`으로 반환합니다.              |
+| `clear`         | `container?: string`                                                       | 주어진 컨테이너(기본값: `'body'`)의 모든 모달을 닫습니다. `beforeClose`를 무시합니다.                  |
 
 ## 타입
 
 ```typescript
 interface ModalOptions {
+    beforeClose?: () => Promise<boolean> | boolean;
     container?: string;
     colorScheme?: ColorScheme;
     styleSet?: string | VsModalNodeStyleSet;
@@ -116,10 +117,30 @@ interface ModalPlugin {
     open(content: string | Component, options?: ModalOptions): string;
     emit(eventName: string, ...args: any[]): void | Promise<void>;
     emitWithId(id: string, eventName: string, ...args: any[]): void | Promise<void>;
-    close(container?: string): void;
-    closeWithId(container: string, id: string): void;
+    close(container?: string): Promise<boolean>;
+    closeWithId(container: string, id: string): Promise<boolean>;
     clear(container?: string): void;
 }
+```
+
+### `beforeClose`로 닫기 중단
+
+`ModalOptions`에 `beforeClose` 훅을 전달하면 ESC, 딤 클릭, `close`/`closeWithId` 호출 시 닫기를 가로챌 수 있습니다. `false`를 resolve하면 모달이 유지됩니다.
+
+```html
+<script setup>
+import { inject } from 'vue';
+
+const $vsModal = inject('$vsModal');
+
+function openModal() {
+    $vsModal.open('저장하지 않은 변경 사항이 있어요. 닫으시겠습니까?', {
+        dimClose: true,
+        escClose: true,
+        beforeClose: async () => window.confirm('변경 사항을 버리시겠어요?'),
+    });
+}
+</script>
 ```
 
 > [!NOTE]

--- a/packages/vlossom/src/plugins/modal-plugin/README.md
+++ b/packages/vlossom/src/plugins/modal-plugin/README.md
@@ -91,14 +91,15 @@ function closeModal() {
 | `open`          | `content: string \| Component, options?: ModalOptions`      | Opens a modal with the given content and options. Returns the modal's unique string ID.                       |
 | `emit`          | `eventName: string, ...args: any[]`                                        | Emits a named event on the most recently opened modal's callback store.                                       |
 | `emitWithId`    | `id: string, eventName: string, ...args: any[]`                            | Emits a named event on a specific modal by its ID.                                                            |
-| `close`         | `container?: string`                                                       | Closes the most recently opened modal in the given container (defaults to `'body'`).                          |
-| `closeWithId`   | `container: string, id: string`                                            | Closes a specific modal by its container and ID.                                                              |
-| `clear`         | `container?: string`                                                       | Closes all modals in the given container (defaults to `'body'`).                                              |
+| `close`         | `container?: string`                                                       | Closes the most recently opened modal in the given container (defaults to `'body'`). Returns `Promise<boolean>` indicating whether the modal actually closed (a `beforeClose` hook can abort by resolving `false`). |
+| `closeWithId`   | `container: string, id: string`                                            | Closes a specific modal by its container and ID. Returns `Promise<boolean>` indicating whether the modal actually closed. |
+| `clear`         | `container?: string`                                                       | Closes all modals in the given container (defaults to `'body'`). Bypasses `beforeClose`.                       |
 
 ## Types
 
 ```typescript
 interface ModalOptions {
+    beforeClose?: () => Promise<boolean> | boolean;
     container?: string;
     colorScheme?: ColorScheme;
     styleSet?: string | VsModalNodeStyleSet;
@@ -116,10 +117,30 @@ interface ModalPlugin {
     open(content: string | Component, options?: ModalOptions): string;
     emit(eventName: string, ...args: any[]): void | Promise<void>;
     emitWithId(id: string, eventName: string, ...args: any[]): void | Promise<void>;
-    close(container?: string): void;
-    closeWithId(container: string, id: string): void;
+    close(container?: string): Promise<boolean>;
+    closeWithId(container: string, id: string): Promise<boolean>;
     clear(container?: string): void;
 }
+```
+
+### Aborting close with `beforeClose`
+
+Pass a `beforeClose` hook in `ModalOptions` to gate ESC, dim-click, and `close`/`closeWithId` calls. Resolve `false` to keep the modal open.
+
+```html
+<script setup>
+import { inject } from 'vue';
+
+const $vsModal = inject('$vsModal');
+
+function openModal() {
+    $vsModal.open('Unsaved changes — close anyway?', {
+        dimClose: true,
+        escClose: true,
+        beforeClose: async () => window.confirm('Discard changes?'),
+    });
+}
+</script>
 ```
 
 > [!NOTE]

--- a/packages/vlossom/src/plugins/modal-plugin/modal-plugin.ts
+++ b/packages/vlossom/src/plugins/modal-plugin/modal-plugin.ts
@@ -1,13 +1,22 @@
 import { type Component } from 'vue';
 import { useOverlayContainerStore, useModalContainerStore, useOverlayCallbackStore } from '@/stores';
 import { logUtil } from '@/utils';
-import type { ModalOptions, ModalPlugin } from './types';
+import type { ModalInfo, ModalOptions, ModalPlugin } from './types';
 import { createModalInfo } from './modal-model';
 
 export function createModalPlugin(): ModalPlugin {
     const overlayContainerStore = useOverlayContainerStore();
     const modalStore = useModalContainerStore();
     const overlayCallbackStore = useOverlayCallbackStore();
+
+    async function runBeforeClose(modal: ModalInfo): Promise<boolean> {
+        const fn = modal.beforeClose;
+        if (!fn) {
+            return true;
+        }
+        const result = await fn();
+        return result !== false;
+    }
 
     return {
         open(content: string | Component, options: ModalOptions = {}): string {
@@ -40,17 +49,36 @@ export function createModalPlugin(): ModalPlugin {
             return overlayCallbackStore.run(id, eventName, ...args);
         },
 
-        close(container = 'body') {
+        async close(container = 'body'): Promise<boolean> {
+            const modals = modalStore.get(container);
+            if (modals.length === 0) {
+                return false;
+            }
+            const last = modals[modals.length - 1];
+            if (!(await runBeforeClose(last))) {
+                return false;
+            }
+
             modalStore.pop(container);
 
             const lastOverlayId = overlayCallbackStore.getLastOverlayId();
             overlayCallbackStore.remove(lastOverlayId);
+            return true;
         },
 
-        closeWithId(container: string, id: string) {
+        async closeWithId(container: string, id: string): Promise<boolean> {
+            const target = modalStore.get(container).find((modal) => modal.id === id);
+            if (!target) {
+                return false;
+            }
+            if (!(await runBeforeClose(target))) {
+                return false;
+            }
+
             modalStore.remove(container, id);
 
             overlayCallbackStore.remove(id);
+            return true;
         },
 
         clear(container = 'body') {

--- a/packages/vlossom/src/plugins/modal-plugin/types.ts
+++ b/packages/vlossom/src/plugins/modal-plugin/types.ts
@@ -3,6 +3,7 @@ import type { ColorScheme, OverlayCallbacks, SizeProp } from '@/declaration';
 import type { VsModalNodeStyleSet } from '@/components/vs-modal/types';
 
 export interface ModalOptions {
+    beforeClose?: () => Promise<boolean> | boolean;
     container?: string;
     colorScheme?: ColorScheme;
     styleSet?: string | VsModalNodeStyleSet;
@@ -26,7 +27,7 @@ export interface ModalPlugin {
     open(content: string | Component, options?: ModalOptions): string;
     emit(eventName: string, ...args: any[]): void | Promise<void>;
     emitWithId(id: string, eventName: string, ...args: any[]): void | Promise<void>;
-    close(container?: string): void;
-    closeWithId(container: string, id: string): void;
+    close(container?: string): Promise<boolean>;
+    closeWithId(container: string, id: string): Promise<boolean>;
     clear(container?: string): void;
 }

--- a/packages/vlossom/src/plugins/prompt-plugin/types.ts
+++ b/packages/vlossom/src/plugins/prompt-plugin/types.ts
@@ -11,7 +11,7 @@ export interface VsPromptStyleSet extends VsModalNodeStyleSet {
     cancelButton?: Omit<VsButtonStyleSet, 'loading'>;
 }
 
-export interface PromptModalOptions extends ModalOptions {
+export interface PromptModalOptions extends Omit<ModalOptions, 'beforeClose'> {
     styleSet?: VsPromptStyleSet;
     colorScheme?: ColorScheme;
     input?: PropsOf<VsComponent.VsInput> & { initialValue?: VsInputValueType };


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary
modal beforeClose hook 추가

## Description
Adds a beforeClose hook on VsModalNode, VsModal, and modal-plugin that can resolve false to keep the modal open. ESC, dim click, v-model, and $vs.modal.close()/closeWithId() all gate on it; close methods now return Promise<boolean> so callers can detect aborted closes (VsModal uses this to revert update:modelValue and stay in sync with the parent).

- beforeChange hook 추가
- plugin close/closeWithId가 닫는 결과를 return 해서 닫기 처리를 명확하게 함
- alert / prompt / confirm은 beforeChange를 제공하지 않도록 막음

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
