### PR TITLE
fix: replace deprecated small prop with size on VsButton/VsChip usages

### DIFF
--- a/packages/vlossom/src/components/vs-pagination/VsPagination.vue
+++ b/packages/vlossom/src/components/vs-pagination/VsPagination.vue
@@ -12,7 +12,7 @@
             :ghost
             :outline
             aria-label="go to first page"
-            small
+            size="sm"
             @click.prevent.stop="goFirst()"
         >
             <slot name="first">
@@ -27,7 +27,7 @@
             :ghost
             :outline
             aria-label="go to previous page"
-            small
+            size="sm"
             @click.prevent.stop="goPrev()"
         >
             <slot name="prev">
@@ -46,7 +46,7 @@
                 :ghost
                 :outline
                 :aria-label="`go to page ${page}`"
-                small
+                size="sm"
                 @click.prevent.stop="selectIndex(page - 1)"
             >
                 <slot name="page" :page="page">
@@ -62,7 +62,7 @@
             :ghost
             :outline
             aria-label="go to next page"
-            small
+            size="sm"
             @click.prevent.stop="goNext()"
         >
             <slot name="next">
@@ -78,7 +78,7 @@
             :ghost
             :outline
             aria-label="go to last page"
-            small
+            size="sm"
             @click.prevent.stop="goLast()"
         >
             <slot name="last">

--- a/packages/vlossom/src/components/vs-select/VsSelectTrigger.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelectTrigger.vue
@@ -19,7 +19,7 @@
                         :closable="closableChips"
                         :style-set="styleSet?.chip"
                         primary
-                        small
+                        size="xs"
                         @close="$emit('deselect', selectedOptions[0].id)"
                     >
                         {{ selectedOptions[0].label }}
@@ -34,7 +34,7 @@
                         :closable="closableChips"
                         :style-set="styleSet?.chip"
                         primary
-                        small
+                        size="xs"
                         @close="$emit('deselect', option.id)"
                     >
                         {{ option.label }}

--- a/packages/vlossom/src/components/vs-select/__stories__/vs-select.chromatic.stories.ts
+++ b/packages/vlossom/src/components/vs-select/__stories__/vs-select.chromatic.stories.ts
@@ -47,7 +47,7 @@ const meta: Meta<typeof VsSelect> = {
                 <div>
                     <h3 style="margin: 0 0 1rem 0; font-size: 1.2rem; font-weight: 600;">크기</h3>
                     <div style="display: flex; flex-direction: column; gap: 1rem;">
-                        <vs-select :options="basicOptions" label="Small" placeholder="Small select" model-value="Apple" small />
+                        <vs-select :options="basicOptions" label="Small" placeholder="Small select" model-value="Apple" />
                     </div>
                 </div>
 

--- a/packages/vlossom/src/components/vs-table/VsTableExpandCell.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableExpandCell.vue
@@ -16,7 +16,7 @@
                     },
                 }"
                 @click.prevent.stop="expandRow(cells, $event)"
-                small
+                size="sm"
             >
                 <vs-render
                     class="transition-transform"

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.vue
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.vue
@@ -7,7 +7,7 @@
             :disabled="isFirstEdge"
             :style-set="componentStyleSet.scrollButton"
             tabindex="-1"
-            small
+            size="sm"
             @click.prevent.stop="goPrev"
         >
             <vs-render :content="vsTabsIcons.goPrev" class="vs-tab-scroll-icon" />
@@ -48,7 +48,7 @@
             :disabled="isLastEdge"
             :style-set="componentStyleSet.scrollButton"
             tabindex="-1"
-            small
+            size="sm"
             @click.prevent.stop="goNext"
         >
             <vs-render :content="vsTabsIcons.goNext" class="vs-tab-scroll-icon" />

--- a/packages/vlossom/src/storybook/args.ts
+++ b/packages/vlossom/src/storybook/args.ts
@@ -13,7 +13,6 @@ export const inputPropsArgTypes = {
     noLabel: { control: 'boolean' as any, table: { category: 'Input Wrapper Props' } },
     noMessages: { control: 'boolean' as any, table: { category: 'Input Wrapper Props' } },
     required: { control: 'boolean' as any, table: { category: 'Input Wrapper Props' } },
-    small: { control: 'boolean' as any, table: { category: 'Input Wrapper Props' } },
     messages: { control: 'object' as any, table: { category: 'Input Props' } },
     name: { control: 'text' as any, table: { category: 'Input Props' } },
     noDefaultRules: { control: 'boolean' as any, table: { category: 'Input Props' } },


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
VsButton and VsChip props changed from boolean small to size enum. Update internal usages in VsPagination, VsTabs, VsSelectTrigger, VsTableExpandCell.

## Description
- 나중에 만들어진 component에 적용하는게 누락된듯
- vs-select는 sm보다 더 작아야 예뻐저 xs 적용함

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
