### PR TITLE
fix(VsTable): hide pagination block entirely when there are no items

### DIFF
--- a/packages/vlossom/src/components/vs-table/VsTable.vue
+++ b/packages/vlossom/src/components/vs-table/VsTable.vue
@@ -69,7 +69,7 @@
             </vs-visible-render>
         </div>
 
-        <vs-table-pagination v-if="pagination" @paginate="paginate" />
+        <vs-table-pagination v-if="pagination && totalPages" @paginate="paginate" />
     </div>
 </template>
 
@@ -422,6 +422,7 @@ export default defineComponent({
             stickyHeaderTop,
             searchOptions,
             table,
+            totalPages: table.totalPages,
             clickCell,
             selectRow,
             expandRow,

--- a/packages/vlossom/src/components/vs-table/VsTablePagination.vue
+++ b/packages/vlossom/src/components/vs-table/VsTablePagination.vue
@@ -19,7 +19,6 @@
         </div>
 
         <vs-pagination
-            v-if="totalPages"
             v-model="page"
             :color-scheme
             :disabled="loading"


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
no items 상황일 때 pagination 영역을 숨김
