### PR TITLE
feat(VsTable): add click-row event and transform typing

### DIFF
--- a/packages/vlossom/src/components/vs-table/README.ko.md
+++ b/packages/vlossom/src/components/vs-table/README.ko.md
@@ -192,6 +192,7 @@ interface VsTablePaginationOptions {
 | 이벤트                 | 페이로드                                      | 설명                             |
 | ---------------------- | --------------------------------------------- | -------------------------------- |
 | `click-cell`           | `(cell: VsTableBodyCell, event: MouseEvent)`  | 셀 클릭 시 발생                  |
+| `click-row`            | `(item: VsTableItem, index: number, event: MouseEvent)` | 바디 행 클릭 시 발생             |
 | `select-row`           | `(row: VsTableBodyCell[], event: MouseEvent)` | 행 선택 시 발생                  |
 | `expand-row`           | `(row: VsTableBodyCell[], event: MouseEvent)` | 행 확장 시 발생                  |
 | `drag`                 | `SortableEvent`                               | 드래그 앤 드롭 재정렬 후 발생    |

--- a/packages/vlossom/src/components/vs-table/README.ko.md
+++ b/packages/vlossom/src/components/vs-table/README.ko.md
@@ -156,7 +156,7 @@ interface VsTableColumnDef<I = VsTableItem> {
     sortable?: boolean;
     sortBy?: VsTableColumnKey<I>;
     skipSearch?: boolean;
-    transform?: (value: unknown, item: I) => unknown;
+    transform?: (value: any, item: I) => unknown;
 }
 
 interface VsTablePaginationOptions {

--- a/packages/vlossom/src/components/vs-table/README.md
+++ b/packages/vlossom/src/components/vs-table/README.md
@@ -156,7 +156,7 @@ interface VsTableColumnDef<I = VsTableItem> {
     sortable?: boolean;
     sortBy?: VsTableColumnKey<I>;
     skipSearch?: boolean;
-    transform?: (value: unknown, item: I) => unknown;
+    transform?: (value: any, item: I) => unknown;
 }
 
 interface VsTablePaginationOptions {

--- a/packages/vlossom/src/components/vs-table/README.md
+++ b/packages/vlossom/src/components/vs-table/README.md
@@ -192,6 +192,7 @@ interface VsTablePaginationOptions {
 | Event                  | Payload                                       | Description                           |
 | ---------------------- | --------------------------------------------- | ------------------------------------- |
 | `click-cell`           | `(cell: VsTableBodyCell, event: MouseEvent)`  | Emitted when a cell is clicked        |
+| `click-row`            | `(item: VsTableItem, index: number, event: MouseEvent)` | Emitted when a body row is clicked    |
 | `select-row`           | `(row: VsTableBodyCell[], event: MouseEvent)` | Emitted when a row is selected        |
 | `expand-row`           | `(row: VsTableBodyCell[], event: MouseEvent)` | Emitted when a row is expanded        |
 | `drag`                 | `SortableEvent`                               | Emitted after a drag-and-drop reorder |

--- a/packages/vlossom/src/components/vs-table/VsTable.vue
+++ b/packages/vlossom/src/components/vs-table/VsTable.vue
@@ -57,6 +57,7 @@
                     </vs-table-header>
                     <vs-table-body
                         @click-cell="clickCell"
+                        @click-row="clickRow"
                         @select-row="selectRow"
                         @expand-row="expandRow"
                         @drag="dragRow"
@@ -277,6 +278,7 @@ export default defineComponent({
     },
     emits: [
         'click-cell',
+        'click-row',
         'select-row',
         'expand-row',
         'drag',
@@ -356,6 +358,9 @@ export default defineComponent({
         function clickCell(cell: VsTableBodyCell, event: MouseEvent): void {
             emit('click-cell', cell, event);
         }
+        function clickRow(item: VsTableItem, index: number, event: MouseEvent): void {
+            emit('click-row', item, index, event);
+        }
         function selectRow(row: VsTableBodyCell[], event: MouseEvent): void {
             emit('select-row', row, event);
         }
@@ -424,6 +429,7 @@ export default defineComponent({
             table,
             totalPages: table.totalPages,
             clickCell,
+            clickRow,
             selectRow,
             expandRow,
             searchRows,

--- a/packages/vlossom/src/components/vs-table/VsTableBody.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableBody.vue
@@ -13,6 +13,7 @@
                 :cells="element"
                 :rowIdx="index"
                 @click-cell="clickCell"
+                @click-row="clickRow"
                 @select-row="selectRow"
                 @expand-row="expandRow"
             >
@@ -65,7 +66,7 @@ export default defineComponent({
         VsTableBodyRow,
         draggable,
     },
-    emits: ['click-cell', 'select-row', 'expand-row', 'drag'],
+    emits: ['click-cell', 'click-row', 'select-row', 'expand-row', 'drag'],
     setup(props, { slots, emit }) {
         const { bodyCells, loading } = inject<TableComposable>(TABLE_COMPOSABLE_TOKEN)!;
         const colorScheme = inject<ComputedRef<ColorScheme | undefined>>(TABLE_COLOR_SCHEME_TOKEN);
@@ -98,6 +99,10 @@ export default defineComponent({
             emit('click-cell', { ...cell }, event);
         }
 
+        function clickRow(item: VsTableBodyCell['item'], index: number, event: MouseEvent): void {
+            emit('click-row', item, index, event);
+        }
+
         function selectRow(row: VsTableBodyCell[], event: MouseEvent): void {
             emit('select-row', row, event);
             emit('click-cell', { ...row[0] }, event);
@@ -128,6 +133,7 @@ export default defineComponent({
             loading,
             tableIcons,
             clickCell,
+            clickRow,
             getRowItem: getRowItem,
             getRowId,
             selectRow,

--- a/packages/vlossom/src/components/vs-table/VsTableBodyRow.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableBodyRow.vue
@@ -81,7 +81,7 @@ export default defineComponent({
             required: true,
         },
     },
-    emits: ['click-cell', 'select-row', 'expand-row'],
+    emits: ['click-cell', 'click-row', 'select-row', 'expand-row'],
     setup(props, { emit, slots }) {
         const { cells, rowIdx: rowIndex } = toRefs(props);
         const {
@@ -216,6 +216,7 @@ export default defineComponent({
 
         function clickCell(cell: VsTableBodyCell, event: MouseEvent): void {
             emit('click-cell', { ...cell }, event);
+            emit('click-row', cell.item, rowIndex.value, event);
         }
 
         function getHeaderLabel(colIdx: number, fallback: string): string {

--- a/packages/vlossom/src/components/vs-table/__tests__/table-cell-builder.test.ts
+++ b/packages/vlossom/src/components/vs-table/__tests__/table-cell-builder.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, expectTypeOf, beforeEach, afterEach, vi } from 'vitest';
 import { stringUtil } from '@/utils';
 import { TableCellBuilder } from './../models/table-cell-builder';
 import type { VsTableColumnDef } from './../types';
@@ -71,5 +71,29 @@ describe('TableCellBuilder', () => {
 
         expect(nextHeader.map((h) => h.colKey)).toEqual(['title']);
         expect(nextBody[0][0]).toMatchObject({ value: 'Hello', colKey: 'title', rowIdx: 0, colIdx: 0 });
+    });
+
+    it('transform value 타입은 any이고 item 타입은 유지한다', () => {
+        type User = {
+            id: string;
+            profile: {
+                name: string;
+                age: number;
+            };
+        };
+
+        const columns: VsTableColumnDef<User>[] = [
+            {
+                key: 'profile.age',
+                label: '나이',
+                transform: (value, item) => {
+                    expectTypeOf(value).toBeAny();
+                    expectTypeOf(item).toEqualTypeOf<User>();
+                    return value.toLocaleString();
+                },
+            },
+        ];
+
+        expect(columns).toHaveLength(1);
     });
 });

--- a/packages/vlossom/src/components/vs-table/__tests__/vs-table.test.ts
+++ b/packages/vlossom/src/components/vs-table/__tests__/vs-table.test.ts
@@ -458,6 +458,24 @@ describe('VsTable', () => {
             expect(cell.item).toStrictEqual(tableItems[0]);
         });
 
+        it('셀 클릭 시 click-row 이벤트를 item과 index와 함께 발생시킨다', async () => {
+            const wrapper = mountTable();
+
+            await nextTick();
+            const firstCell = wrapper.get('tbody td');
+
+            await firstCell.trigger('click');
+
+            const emitted = wrapper.emitted('click-row');
+            expect(emitted).toHaveLength(1);
+
+            const [item, index, event] = emitted![0] as [VsTableItem, number, Event];
+            expect(item).toStrictEqual(tableItems[0]);
+            expect(index).toBe(0);
+            expect(event).toBeInstanceOf(Event);
+            expect((event as Event).type).toBe('click');
+        });
+
         it('선택 셀 클릭 시 select-row 이벤트를 발생시킨다', async () => {
             const wrapper = mountTable({
                 props: { selectable: true },

--- a/packages/vlossom/src/components/vs-table/types.ts
+++ b/packages/vlossom/src/components/vs-table/types.ts
@@ -72,7 +72,7 @@ export interface VsTableColumnDef<I = VsTableItem> {
     sortable?: boolean;
     sortBy?: VsTableColumnKey<I>;
     skipSearch?: boolean;
-    transform?: (value: unknown, item: I) => unknown;
+    transform?: (value: any, item: I) => unknown;
 }
 
 export interface VsTableCell<I = VsTableItem> {


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)
-   [x] Fix Bug (fix)

## Summary

- `VsTable`에 `click-row` event 추가 (data -> item, index, and MouseEvent payload)
- `VsTable` column transform function 느슨하게 수정 

Closes #445
Closes #444