### PR TITLE
feat(style-set): flatten $component CSSProperties

### DIFF
--- a/.claude/skills/style-set-create/SKILL.md
+++ b/.claude/skills/style-set-create/SKILL.md
@@ -13,11 +13,31 @@ description: 새로운 컴포넌트의 StyleSet을 철학에 맞게 생성
 - StyleSet 설계 방향이 불확실할 때
 - 철학에 맞는 구현을 처음부터 하고 싶을 때
 
+## Style-Set 컨벤션 (v2.0.0+)
+
+`VsXxxStyleSet`은 `CSSProperties`를 상속(extends)하며, 키는 `$` prefix 유무로 구분됩니다.
+
+| 키 형태 | 의미 | 처리 |
+|---------|------|------|
+| `width`, `padding`, ... (non-`$`) | 표준 CSS — 컴포넌트 루트에 inline style로 적용 | `componentInlineStyle`로 자동 수집 |
+| `$X` (string/number) | CSS 변수로 노출 | `--vs-{kebab-component}-X`로 emit (`styleSetVariables`) |
+| `$X` (object) | 슬롯/요소 스타일 또는 하위 StyleSet | `componentStyleSet.$X`로 직접 접근 |
+
+```typescript
+import type { CSSProperties } from 'vue';
+
+export interface VsButtonStyleSet extends CSSProperties {
+    $padding?: string;            // CSS 변수: --vs-button-padding
+    $content?: CSSProperties;     // 슬롯
+    $loading?: VsLoadingStyleSet; // 하위 컴포넌트
+}
+```
+
+> 💡 root에 `CSSProperties`가 있고 `$` prefix로 슬롯/변수가 분리되므로 키 충돌이 발생하지 않습니다.
+
 ## 생성 프로세스
 
 ### 1단계: 요구사항 분석
-
-다음 질문에 답하세요:
 
 #### 컴포넌트 분석
 1. **컴포넌트 이름**: `Vs[ComponentName]`
@@ -31,44 +51,28 @@ description: 새로운 컴포넌트의 StyleSet을 철학에 맞게 생성
 3. **상태별 스타일**: hover, focus, disabled 등 상태가 있는가?
 4. **테마 변형**: primary, outline 같은 변형이 필요한가?
 
-### 2단계: Variables 설계
+### 2단계: 키 분류
 
-#### 결정 기준 (4가지 모두 Yes여야 함)
+각 스타일 속성에 대해 결정 트리를 적용:
 
-각 속성에 대해 체크:
+```
+이 속성을 외부에서 자주 커스터마이징하나?
+├── No → CSS에 직접 하드코딩 (디자인 토큰: var(--vs-comp-bg) 등)
+└── Yes → 어떻게 노출할지 결정
+    ├── 임의의 CSS로 자유롭게 변경 가능 → root CSSProperties (extends로 노출됨)
+    ├── CSS 변수로 .css 안에서 fallback과 함께 사용 → $X primitive
+    ├── 특정 슬롯/요소만 스타일링 → $X: CSSProperties
+    └── 하위 컴포넌트 전체 스타일 전파 → $X: VsXxxStyleSet
+```
+
+#### `$X` (CSS 변수) 사용 기준 (4가지 모두 Yes여야 함)
 
 - [ ] **빈도**: 사용자가 자주 커스터마이징하는가?
-- [ ] **런타임**: CSS 변수로 런타임에 변경할 필요가 있는가?
+- [ ] **CSS 활용**: `.css`에서 `calc()` 등으로 다른 속성과 연동되는가?
 - [ ] **재사용**: 여러 곳에서 재사용되는 값인가?
 - [ ] **명확성**: 명확한 의미와 용도가 있는가?
 
-#### Variables 구조 결정
-
-**단순 변수** (1단계)
-```typescript
-variables?: {
-    width?: string;
-    padding?: string;
-}
-```
-- 독립적이고 단순한 속성
-- 다른 속성과 논리적 관계 없음
-
-**그룹화 변수** (2단계 중첩)
-```typescript
-variables?: {
-    focused?: {
-        border?: string;
-        backgroundColor?: string;
-    };
-    disabled?: {
-        opacity?: string;
-        cursor?: string;
-    };
-}
-```
-- 상태별, 영역별로 논리적 그룹
-- 2단계 이상 중첩 금지
+> 위 4가지를 만족하지 않는다면 root CSSProperties로 자유롭게 두는 편이 낫습니다 (예: `width`, `height`, `padding`은 root에서 직접 받는 게 일반적).
 
 ### 3단계: 타입 정의 작성
 
@@ -89,39 +93,19 @@ export type { Vs[ComponentName] };
 
 export interface Vs[ComponentName]Ref extends ComponentPublicInstance<typeof Vs[ComponentName]> {}
 
-export interface Vs[ComponentName]StyleSet {
-    /**
-     * CSS 변수로 노출될 커스터마이징 포인트
-     * 자주 변경되는 속성만 포함
-     */
-    variables?: {
-        // 단순 변수들
-        propertyName?: string;
+export interface Vs[ComponentName]StyleSet extends CSSProperties {
+    /** CSS 변수: --vs-[component]-arrowSize */
+    $arrowSize?: string;
 
-        // 그룹화된 변수들 (선택적)
-        groupName?: {
-            property1?: string;
-            property2?: string;
-        };
-    };
+    /** 슬롯/요소 스타일 */
+    $element?: CSSProperties;
 
-    /**
-     * 컴포넌트 루트 요소의 직접 스타일
-     * 모든 CSSProperties 사용 가능
-     */
-    component?: CSSProperties;
-
-    /**
-     * 특정 요소의 스타일 (선택적)
-     */
-    elementName?: CSSProperties;
-
-    /**
-     * 하위 컴포넌트 스타일 전파 (선택적)
-     */
-    childComponent?: VsChildStyleSet;
+    /** 하위 컴포넌트 StyleSet */
+    $childComponent?: VsChildStyleSet;
 }
 ```
+
+> `extends CSSProperties`로 root에 표준 CSS가 자동으로 노출되므로, 별도의 `component?: CSSProperties` 키는 필요 없습니다.
 
 ### 4단계: 컴포넌트 구현
 
@@ -149,33 +133,32 @@ export default defineComponent({
 
         const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        // ✅ 기본값이 있는 경우: 반응성이 필요하면 computed, 아니면 ref 사용
+        // 하위 컴포넌트 기본값 (고정값이면 ref 권장, 반응성 필요시 computed)
         const baseStyleSet: Ref<Vs[ComponentName]StyleSet> = ref({
-            childComponent: {
-                component: { width: '100%' },
+            $childComponent: {
+                width: '100%',  // 자식의 root CSSProperties
             },
         });
 
-        // ✅ props에서 동적 값이 오는 경우: additionalStyleSet (4번째 인자)
-        // objectUtil.shake는 undefined 값의 키를 제거하여 불필요한 오버라이드 방지
+        // props에서 동적 값이 오면 root에 직접 (CSSProperties extends 덕분에 평탄)
         const additionalStyleSet = computed<Vs[ComponentName]StyleSet>(() => {
             return objectUtil.shake({
-                component: objectUtil.shake({
-                    height: props.height || undefined,
-                }),
+                height: props.height || undefined,
             });
         });
 
-        const { componentStyleSet, styleSetVariables } = useStyleSet<Vs[ComponentName]StyleSet>(
-            componentName,
-            styleSet,
-            baseStyleSet,          // 3번째: 기본값 (가장 낮은 우선순위)
-            additionalStyleSet,    // 4번째: props 동적 값 (가장 높은 우선순위)
-        );
+        const { componentStyleSet, styleSetVariables, componentInlineStyle } =
+            useStyleSet<Vs[ComponentName]StyleSet>(
+                componentName,
+                styleSet,
+                baseStyleSet,       // 3번째: 기본값 (가장 낮은 우선순위)
+                additionalStyleSet, // 4번째: props 동적 값 (가장 높은 우선순위)
+            );
 
         return {
             colorSchemeClass,
             styleSetVariables,
+            componentInlineStyle,
             componentStyleSet,
         };
     },
@@ -184,11 +167,10 @@ export default defineComponent({
 
 #### useStyleSet 인자 규칙
 
-| 인자 | 용도 | 반응성 |
-|------|------|--------|
-| `baseStyleSet` (3번째) | 하위 컴포넌트 기본값, 고정 스타일 | `ref({})` 권장 (고정값), `computed` 허용 (반응성 필요시) |
-| `additionalStyleSet` (4번째) | props에서 오는 동적 값 (최우선) | `computed` (항상 반응성 필요) |
-
+| 인자                       | 용도                              | 반응성                                                   |
+| -------------------------- | --------------------------------- | -------------------------------------------------------- |
+| `baseStyleSet` (3번째)     | 하위 컴포넌트 기본값, 고정 스타일 | `ref({})` 권장 (고정값), `computed` 허용 (반응성 필요시) |
+| `additionalStyleSet` (4번째) | props에서 오는 동적 값 (최우선)  | `computed` (항상 반응성 필요)                            |
 
 > **성능 팁**: 고정값은 `ref({...})`가 `computed(() => ({...}))`보다 효율적이지만, 둘 다 허용됩니다.
 
@@ -198,19 +180,19 @@ export default defineComponent({
 <template>
     <div
         :class="['vs-[component-name]', colorSchemeClass, classObj]"
-        :style="{ ...styleSetVariables, ...componentStyleSet.component }"
+        :style="{ ...styleSetVariables, ...componentInlineStyle }"
     >
-        <!-- 특정 요소 -->
+        <!-- 슬롯/요소 -->
         <div
             class="vs-[component-name]-element"
-            :style="componentStyleSet.elementName"
+            :style="componentStyleSet.$element"
         >
             <slot name="element" />
         </div>
 
         <!-- 하위 컴포넌트 -->
         <vs-child-component
-            :style-set="componentStyleSet.childComponent"
+            :style-set="componentStyleSet.$childComponent"
         />
 
         <slot />
@@ -218,23 +200,24 @@ export default defineComponent({
 </template>
 ```
 
+핵심 포인트:
+1. **루트 요소**: `{ ...styleSetVariables, ...componentInlineStyle }` 두 가지를 spread
+2. **슬롯/요소**: `componentStyleSet.$X` (CSSProperties)
+3. **하위 컴포넌트**: `componentStyleSet.$X` (StyleSet)
+
 ### 5단계: CSS 작성
 
 ```css
 .vs-[component-name] {
-    /* CSS 변수 선언 (variables에 정의된 것만) */
-    --vs-[component-name]-propertyName: initial;
-
-    /* 중첩된 경우 */
-    --vs-[component-name]-groupName-property1: initial;
-    --vs-[component-name]-groupName-property2: initial;
+    /* CSS 변수 선언 ($X primitive로 정의된 것만) */
+    --vs-[component-name]-arrowSize: initial;
 
     /* 레이아웃과 기본 스타일 (직접 값) */
     display: flex;
     flex-direction: column;
 
     /* CSS 변수 사용 (적절한 fallback 포함) */
-    padding: var(--vs-[component-name]-padding, 1rem);
+    padding-right: var(--vs-[component-name]-arrowSize, 1rem);
 
     /* 디자인 토큰 사용 */
     background-color: var(--vs-comp-bg);
@@ -258,12 +241,6 @@ export default defineComponent({
     opacity: 0.5;
     cursor: not-allowed;
 }
-
-/* 그룹화된 변수 사용 */
-.vs-[component-name]:focus-within {
-    border: var(--vs-[component-name]-focused-border, 2px solid var(--vs-primary));
-    background-color: var(--vs-[component-name]-focused-backgroundColor, transparent);
-}
 ```
 
 ### 6단계: 검증 체크리스트
@@ -272,24 +249,25 @@ export default defineComponent({
 
 #### 타입 정의
 - [ ] 인터페이스명이 `Vs[ComponentName]StyleSet`인가?
-- [ ] `variables`에 자주 변경되는 속성만 있는가?
-- [ ] 중첩이 2단계를 넘지 않는가?
-- [ ] `component?: CSSProperties` 포함되었는가? (루트 스타일링 필요시)
+- [ ] `extends CSSProperties`로 선언되어 있는가?
+- [ ] `$component?: CSSProperties` 같은 root 래퍼 키가 없는가? (`extends CSSProperties`로 대체됨)
+- [ ] `$X` primitive는 정말 CSS 변수로 노출이 필요한 속성만 있는가?
+- [ ] `$X` object 키 이름이 명확한가?
 - [ ] 하위 컴포넌트 StyleSet이 올바르게 참조되는가?
-- [ ] `wrapper?: VsInputWrapperStyleSet` 포함되었는가? (form 컴포넌트에서 VsInputWrapper 사용시)
+- [ ] `$wrapper?: VsInputWrapperStyleSet` 포함되었는가? (form 컴포넌트에서 VsInputWrapper 사용 시)
 - [ ] 타입 안전한 CSS 속성 타입을 사용했는가? (`CSSProperties['objectFit'] & {}` 등)
 
 #### 네이밍
-- [ ] 상태 수식어가 prefix 패턴인가? (`activeStep` ✅, `stepActive` ❌)
-- [ ] 속성명이 내용을 반영하는가? (`content` ✅, `expand` ❌ — 동작이 아닌 내용 기반)
+- [ ] 상태 수식어가 prefix 패턴인가? (`$activeStep` ✅, `$stepActive` ❌)
+- [ ] 속성명이 내용을 반영하는가? (`$content` ✅, `$expand` ❌ — 동작이 아닌 내용 기반)
 - [ ] import가 같은 모듈에서 통합되었는가?
 
 #### 컴포넌트
+- [ ] `useStyleSet`에서 `componentInlineStyle`을 destructure했는가?
+- [ ] root `:style`에 `{ ...styleSetVariables, ...componentInlineStyle }`을 spread했는가?
 - [ ] `baseStyleSet`이 고정값이면 `ref` 사용을 검토했는가? (`computed`도 허용, `ref` 권장)
-- [ ] Template에서 스타일 병합 순서가 올바른가?
-- [ ] 하위 컴포넌트에 `:style-set` prop 전달하는가?
-- [ ] undefined spread 안전한가? (`styleSetVariables`와 `componentStyleSet`은 useStyleSet이 보장)
-- [ ] README.md의 Types 섹션이 새 StyleSet 구조를 반영하는가?
+- [ ] 하위 컴포넌트에 `:style-set="componentStyleSet.$X"`로 전달하는가?
+- [ ] README.md의 Types 섹션이 새 StyleSet 구조(extends CSSProperties)를 반영하는가?
 
 #### CSS
 - [ ] 변수명이 `--vs-[component]-[property]` 규칙을 따르는가?
@@ -311,19 +289,17 @@ export default defineComponent({
 - 하위 컴포넌트: 없음
 
 **스타일 분석**:
-- 자주 변경: width, padding, shadow
-- 고정: border-radius 비율, 기본 배경색
-- 상태: hover 시 elevation 증가
-- 변형: primary, outlined
+- 자주 변경: width, padding, shadow → root CSSProperties로 충분
+- 고정: border-radius 비율, 기본 배경색 → CSS 직접
+- 상태: hover 시 elevation 증가 → CSS만으로 처리
+- 변형: primary, outlined → ColorScheme
 
-#### 2단계: Variables 설계
+#### 2단계: 키 분류
 
-체크 결과:
-- `width`: ✅✅✅✅ → variables
-- `padding`: ✅✅✅✅ → variables
-- `shadow`: ✅✅✅✅ → variables
-- `backgroundColor`: ❌ (ColorScheme으로 제어) → component
-- `borderRadius`: ❌ (디자인 시스템 일관성) → 직접 값
+- `width`, `height`, `padding`, `boxShadow` → root CSSProperties (extends 덕분에 자동)
+- `backgroundColor` → ColorScheme이 처리 (별도 노출 X)
+- `borderRadius` → 디자인 시스템 일관성을 위해 CSS 하드코딩
+- header/body/footer → 슬롯이므로 `$header`, `$body`, `$footer`
 
 #### 3단계: 타입 정의
 
@@ -341,91 +317,84 @@ export type { VsCard };
 
 export interface VsCardRef extends ComponentPublicInstance<typeof VsCard> {}
 
-export interface VsCardStyleSet {
-    /**
-     * CSS 변수로 노출될 커스터마이징 포인트
-     */
-    variables?: {
-        /** 카드 너비 */
-        width?: string;
-        /** 카드 내부 여백 */
-        padding?: string;
-        /** 카드 그림자 */
-        shadow?: string;
-    };
-
-    /** 카드 루트 요소 스타일 */
-    component?: CSSProperties;
-
+export interface VsCardStyleSet extends CSSProperties {
     /** 헤더 영역 스타일 */
-    header?: CSSProperties;
+    $header?: CSSProperties;
 
     /** 바디 영역 스타일 */
-    body?: CSSProperties;
+    $body?: CSSProperties;
 
     /** 푸터 영역 스타일 */
-    footer?: CSSProperties;
+    $footer?: CSSProperties;
 }
 ```
 
-#### 4-5단계: 구현 (생략, 위 패턴 참고)
+#### 사용 예시
 
-#### 6단계: 검증
-
-✅ 모든 체크리스트 통과
+```vue
+<vs-card
+    :style-set="{
+        width: '320px',
+        padding: '1rem',
+        boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+        $header: { fontWeight: 600 },
+        $footer: { borderTop: '1px solid #eee' },
+    }"
+/>
+```
 
 ## 주의사항
 
 ### 🚫 하지 말아야 할 것
 
-1. **모든 CSS 속성을 variables로**
-   - 필요한 것만 노출
+1. **`$component?: CSSProperties` 같은 래퍼 키 추가**
+   - `extends CSSProperties`로 root에 자동 노출됨
 
-2. **3단계 이상 중첩**
-   - 최대 2단계까지
+2. **모든 속성을 `$X` (CSS 변수)로**
+   - `.css`에서 변수가 정말 필요한 경우(`calc()` 연동 등)에만 노출
+   - 단순 자유 스타일링은 root CSSProperties로 충분
 
-3. **의미 없는 그룹명**
-   - `styles`, `config` 같은 모호한 이름
+3. **3단계 이상 중첩**
+   - `$X: { $Y: { ... } }`는 자식 StyleSet 자체일 때만 허용
 
-4. **BoxStyleSet 같은 공통 인터페이스 extends**
-   - 명시적 정의 선호
+4. **의미 없는 그룹명**
+   - `$styles`, `$config` 같은 모호한 이름
 
 ### ✅ 해야 할 것
 
-1. **사용자 관점에서 생각**
-   - 어떤 속성을 자주 조정할까?
-
-2. **명확한 네이밍**
-   - 변수명만 봐도 용도를 알 수 있게
-
-3. **적절한 fallback**
-   - CSS 변수는 항상 fallback 제공
-
-4. **문서화**
-   - JSDoc으로 각 속성의 용도 설명
+1. **사용자 관점에서 생각** — 어떤 속성을 자주 조정할까?
+2. **명확한 네이밍** — 변수명만 봐도 용도를 알 수 있게
+3. **적절한 fallback** — CSS 변수는 항상 fallback 제공
+4. **문서화** — JSDoc으로 각 속성의 용도 설명
 
 ## 도움말
 
-### Variables vs Component 결정이 어려울 때
+### root CSSProperties vs `$X` 결정이 어려울 때
 
-**Variables로 만들기**:
-- padding, spacing, gap
-- width, height (컨테이너 크기)
-- color 계열 (단, ColorScheme이 우선)
+**root CSSProperties로 (extends에서 자동)**:
+- width, height, padding, margin
+- 임의의 CSS로 자유롭게 변경되어도 무방한 속성
+- 컨테이너 크기·여백 등 일반 스타일
+
+**`$X` primitive (CSS 변수)로**:
+- 다른 CSS 속성과 `calc()` 등으로 연동되어야 함
 - 특정 요소의 크기 (arrow-size 등)
+- 자식 의사 요소(`::after`)에서 참조 필요
 
-**Component로 만들기**:
-- border, border-radius (디자인 시스템)
-- background-color (ColorScheme)
-- font-size, font-weight (Typography)
-- 복잡한 속성 조합
+**`$X` object (CSSProperties)로**:
+- 컴포넌트 내부의 특정 요소/슬롯 스타일
+- 사용자가 자유롭게 CSS를 적용할 슬롯
+
+**`$X` (자식 StyleSet)로**:
+- 하위 Vlossom 컴포넌트의 스타일을 일괄 제어
+- 예: Button의 $loading, Select의 $chip
 
 ### 하위 컴포넌트 스타일 전파 여부
 
 **전파하는 경우**:
 - 상위 컴포넌트가 하위의 스타일을 제어해야 함
 - 일관된 디자인을 위해 일괄 적용 필요
-- 예: Button의 Loading, Select의 Chip
+- 예: `$loading` (Button), `$chip` (Select)
 
 **전파하지 않는 경우**:
 - 하위 컴포넌트가 독립적으로 동작
@@ -439,28 +408,26 @@ export interface VsCardStyleSet {
 **상태 수식어는 prefix 패턴 사용:**
 
 ```typescript
-// ✅ CORRECT: prefix 패턴 (코드베이스 표준)
-step?: CSSProperties;
-activeStep?: CSSProperties;
-label?: CSSProperties;
-activeLabel?: CSSProperties;
-progress?: CSSProperties;
-activeProgress?: CSSProperties;
+// ✅ CORRECT: prefix 패턴
+$step?: CSSProperties;
+$activeStep?: CSSProperties;
+$label?: CSSProperties;
+$activeLabel?: CSSProperties;
 
 // ❌ WRONG: suffix 패턴
-stepActive?: CSSProperties;
-labelActive?: CSSProperties;
+$stepActive?: CSSProperties;
+$labelActive?: CSSProperties;
 ```
 
 **속성명은 내용 기반 (동작이 아닌):**
 
 ```typescript
 // ✅ CORRECT: 내용을 반영
-content?: CSSProperties;   // 무엇이 들어있는지
-title?: CSSProperties;
+$content?: CSSProperties; // 무엇이 들어있는지
+$title?: CSSProperties;
 
 // ❌ WRONG: 동작을 반영
-expand?: CSSProperties;    // 무엇을 하는지
+$expand?: CSSProperties; // 무엇을 하는지
 ```
 
 ### 타입 안전성
@@ -469,49 +436,27 @@ expand?: CSSProperties;    // 무엇을 하는지
 
 ```typescript
 // ✅ CORRECT: 타입 안전 (& {}는 자동완성 지원 트릭)
-variables?: {
-    objectFit?: CSSProperties['objectFit'] & {};
-};
+$objectFit?: CSSProperties['objectFit'] & {};
 
 // ❌ WRONG: 범용 string
-variables?: {
-    objectFit?: string;  // 아무 값이나 가능
-};
+$objectFit?: string; // 아무 값이나 가능
 ```
-
-### Partial<T> 사용 가이드
-
-```typescript
-// ✅ PREFERRED (baseStyleSet 고정값): Partial 없이 ref 사용
-const baseStyleSet: Ref<VsButtonStyleSet> = ref({...})
-
-// ✅ OK (additionalStyleSet): computed 필요, Partial 허용
-const additionalStyleSet: ComputedRef<Partial<VsButtonStyleSet>> = computed(...)
-// 또는 Partial 없이도 가능 (모든 속성이 이미 optional)
-const additionalStyleSet = computed<VsButtonStyleSet>(() => ({...}))
-```
-
-> **참고**: `Partial<T>`는 모든 속성이 이미 optional이면 기술적으로 불필요하지만, 기존 코드베이스에서 `additionalStyleSet`에 광범위하게 사용 중이므로 허용됩니다.
 
 ### 성능: computed vs ref
 
 ```typescript
 // ✅ PREFERRED: 고정값은 ref 사용 (반응성 오버헤드 없음)
 const baseStyleSet: Ref<VsButtonStyleSet> = ref({
-    loading: { component: { width: '30%' } },
+    $loading: { width: '30%' },
 });
 
 // ✅ OK: computed도 허용 (기존 코드에서 광범위 사용)
 const baseStyleSet = computed<VsButtonStyleSet>(() => ({
-    loading: { component: { width: '30%' } },
+    $loading: { width: '30%' },
 }));
 
 // ✅ BEST: baseStyleSet/additionalStyleSet 모두 불필요하면 생략
-const { componentStyleSet } = useStyleSet(componentName, styleSet);
-
-// ✅ OK: additionalStyleSet만 필요할 때 빈 baseStyleSet은 ref 사용
-const baseStyleSet: Ref<VsButtonStyleSet> = ref({});
-const { componentStyleSet } = useStyleSet(componentName, styleSet, baseStyleSet, additionalStyleSet);
+const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet(componentName, styleSet);
 ```
 
 ### CSS 단위 규칙
@@ -528,34 +473,20 @@ font-size: 14px;
 width: 32px;
 ```
 
-### ColorScheme과 variables의 관계
+### ColorScheme과 styleSet의 관계
+
+기본 테마 색상(`--vs-comp-bg`, `--vs-comp-font`)은 별도 노출하지 않음 → ColorScheme이 자동 적용.
 
 ```typescript
-// 기본 테마 색상(--vs-comp-bg, --vs-comp-font)은 variables에 넣지 않음
-// → ColorScheme이 자동 적용
+// ✅ CORRECT: 컴포넌트 고유 속성만 $X로 노출
+$arrowSize?: string;
 
-// ✅ CORRECT: 컴포넌트 고유 속성만
-variables?: {
-    padding?: string;
-    arrowSize?: string;
-};
-
-// ❌ WRONG: 기본 테마 색상을 variables에 노출
-variables?: {
-    backgroundColor?: string;  // var(--vs-comp-bg)로 자동 적용됨
-    fontColor?: string;        // var(--vs-comp-font)으로 자동 적용됨
-};
-
-// ✅ OK: 상태별/영역별 색상은 variables에 포함 가능
-variables?: {
-    selected?: {
-        backgroundColor?: string;  // 선택 상태의 특수 색상
-    };
-    focused?: {
-        backgroundColor?: string;  // 포커스 상태의 특수 색상
-    };
-};
+// ❌ WRONG: 기본 테마 색상을 $X로 노출
+$backgroundColor?: string; // ColorScheme이 처리해야 함
+$fontColor?: string;
 ```
+
+> 사용자가 임시로 배경색을 바꾸고 싶으면 root CSSProperties(`backgroundColor`)로 직접 넣을 수 있으므로, `$backgroundColor`로 별도 노출할 필요 없습니다.
 
 ### 에러 처리: spread 안전성
 
@@ -563,20 +494,28 @@ variables?: {
 
 ```vue
 <!-- ✅ SAFE: useStyleSet이 반환한 값은 항상 객체 -->
-<div :style="{ ...styleSetVariables, ...componentStyleSet.component }">
+<div :style="{ ...styleSetVariables, ...componentInlineStyle }">
 ```
 
-단, 자식 컴포넌트의 StyleSet을 전달할 때는 optional chaining 불필요 (undefined는 :style-set prop에서 무시됨):
+자식 컴포넌트의 StyleSet을 전달할 때는 optional chaining 불필요 (undefined는 `:style-set` prop에서 무시됨):
 
 ```vue
 <!-- ✅ CORRECT: undefined면 자식 컴포넌트가 기본 동작 -->
-<vs-loading :style-set="componentStyleSet.loading" />
+<vs-loading :style-set="componentStyleSet.$loading" />
+```
+
+### 머지된 styleSet을 자식에 전달하는 패턴
+
+`VsSelect`처럼 부모가 머지한 `componentStyleSet`을 자식(`VsSelectTrigger`)에 그대로 넘기고, 자식에서 inline style만 추출하고 싶을 때는 자식에서 다시 `useStyleSet`을 호출합니다:
+
+```typescript
+// VsSelectTrigger.vue
+const { componentInlineStyle } = useStyleSet<VsSelectStyleSet>(VsComponent.VsSelect, styleSet);
 ```
 
 ## 참고 문서
 
-- [STYLE_SET_GUIDELINES.md](../../../packages/vlossom/STYLE_SET_GUIDELINES.md)
-- [useStyleSet Composable](../../../packages/vlossom/src/composables/style-set-composable.ts)
+- [useStyleSet Composable](../../../packages/vlossom/src/composables/style-set/README.md)
 - [기존 컴포넌트 예제](../../../packages/vlossom/src/components/)
 - [프로젝트 규칙](../../rules/) — architecture, naming, type-safety 등
 

--- a/.claude/skills/style-set-create/SKILL.md
+++ b/.claude/skills/style-set-create/SKILL.md
@@ -258,7 +258,7 @@ export default defineComponent({
 - [ ] 타입 안전한 CSS 속성 타입을 사용했는가? (`CSSProperties['objectFit'] & {}` 등)
 
 #### 네이밍
-- [ ] 상태 수식어가 prefix 패턴인가? (`$activeStep` ✅, `$stepActive` ❌)
+- [ ] 상태 수식어가 nested-state 패턴인가? (`$step.$active` ✅, `$activeStep` ❌)
 - [ ] 속성명이 내용을 반영하는가? (`$content` ✅, `$expand` ❌ — 동작이 아닌 내용 기반)
 - [ ] import가 같은 모듈에서 통합되었는가?
 
@@ -405,10 +405,21 @@ export interface VsCardStyleSet extends CSSProperties {
 
 ### 네이밍 규칙
 
-**상태 수식어는 prefix 패턴 사용:**
+**상태 수식어는 nested-state 패턴 사용:**
+
+상태(`$active`, `$selected`, `$focused` 등)는 별도의 top-level 키로 분리하지 말고, 해당 요소의 styleset 안에 중첩한다.
+컴포넌트의 .vue 파일에서 상태에 따라 `computed`로 base 스타일과 상태 스타일을 머지해 적용한다.
 
 ```typescript
-// ✅ CORRECT: prefix 패턴
+// ✅ CORRECT: nested-state 패턴
+$step?: CSSProperties & {
+    $active?: CSSProperties;
+};
+$label?: CSSProperties & {
+    $active?: CSSProperties;
+};
+
+// ❌ WRONG: prefix 패턴 (별도 top-level 키)
 $step?: CSSProperties;
 $activeStep?: CSSProperties;
 $label?: CSSProperties;

--- a/packages/vlossom/eslint.config.ts
+++ b/packages/vlossom/eslint.config.ts
@@ -86,7 +86,7 @@ export default defineConfigWithVueTs(
             'no-shadow': 'off',
             'no-prototype-builtins': 'off',
             'no-unused-vars': 'off',
-            '@typescript-eslint/no-unused-vars': 'error',
+            '@typescript-eslint/no-unused-vars': ['error', { ignoreRestSiblings: true }],
             '@typescript-eslint/no-shadow': 'error',
             '@typescript-eslint/no-explicit-any': 'off',
             '@typescript-eslint/explicit-module-boundary-types': 'off',

--- a/packages/vlossom/playground/App.vue
+++ b/packages/vlossom/playground/App.vue
@@ -17,7 +17,7 @@
         </vs-header>
 
         <vs-container layout class="flex-1 pb-32 lg:pr-96">
-            <vs-page class="w-full" :style-set="{ $component: { padding: '0 2rem' } }">
+            <vs-page class="w-full" :style-set="{ padding: '0 2rem' }">
                 <vs-tabs v-model="activeTab" :tabs="tabs" primary class="mb-8" />
 
                 <vs-index-view v-model="activeTab" keep-alive>
@@ -85,13 +85,11 @@ export default defineComponent({
         const activeTab = ref(0);
 
         const basicBarStyleSet: VsBarStyleSet = {
-            $component: {
-                backgroundColor: 'black',
-                color: 'white',
-                border: 'none',
-                height: '60px',
-                borderBottom: '1px solid gray',
-            },
+            backgroundColor: 'black',
+            color: 'white',
+            border: 'none',
+            height: '60px',
+            borderBottom: '1px solid gray',
         };
 
         return {

--- a/packages/vlossom/playground/Sandbox.vue
+++ b/packages/vlossom/playground/Sandbox.vue
@@ -1,18 +1,121 @@
 <template>
-    <vs-page class="mb-8" :style-set="{ $component: { padding: '0' } }">
-        <div class="sandbox">
+    <vs-page class="mb-8" :style-set="{ padding: '0' }">
+        <div class="sandbox flex flex-col gap-8 p-8">
             <h1>Sandbox</h1>
+
+            <section class="flex flex-col gap-3">
+                <h2 class="text-lg font-semibold">1. 기본 inline style (CSSProperties extends)</h2>
+                <p class="text-sm text-gray-500">
+                    StyleSet 루트의 CSS 속성이 컴포넌트 루트 요소에 inline style로 적용됩니다.
+                </p>
+                <vs-select
+                    v-model="value1"
+                    :options="fruits"
+                    :style-set="{
+                        width: '300px',
+                        backgroundColor: '#fff7ed',
+                        borderRadius: '12px',
+                    }"
+                />
+            </section>
+
+            <section class="flex flex-col gap-3">
+                <h2 class="text-lg font-semibold">2. CSS 변수($height) 사용</h2>
+                <p class="text-sm text-gray-500">
+                    `$`-prefix가 붙은 primitive 값은 CSS 변수(--vs-select-height)로 emit됩니다.
+                </p>
+                <vs-select v-model="value2" :options="fruits" :style-set="{ $height: '3.5rem', width: '300px' }" />
+            </section>
+
+            <section class="flex flex-col gap-3">
+                <h2 class="text-lg font-semibold">3. $focused / $option / $selectedOption 슬롯 스타일</h2>
+                <p class="text-sm text-gray-500">
+                    상태/요소별로 슬롯을 구분해서 스타일링할 수 있습니다.
+                </p>
+                <vs-select
+                    v-model="value3"
+                    :options="fruits"
+                    :style-set="{
+                        width: '300px',
+                        $focused: {
+                            border: '2px solid #2563eb',
+                            backgroundColor: '#eff6ff',
+                        },
+                        $option: {
+                            padding: '0.75rem 1rem',
+                        },
+                        $selectedOption: {
+                            backgroundColor: '#dbeafe',
+                            fontWeight: 600,
+                        },
+                    }"
+                />
+            </section>
+
+            <section class="flex flex-col gap-3">
+                <h2 class="text-lg font-semibold">4. multiple + $chip 하위 컴포넌트 스타일</h2>
+                <p class="text-sm text-gray-500">
+                    선택된 항목의 chip에 별도 StyleSet을 전달합니다.
+                </p>
+                <vs-select
+                    v-model="value4"
+                    multiple
+                    :options="fruits"
+                    :style-set="{
+                        width: '400px',
+                        $chip: {
+                            $height: '1.6rem',
+                            backgroundColor: '#fef3c7',
+                            color: '#92400e',
+                        },
+                    }"
+                />
+            </section>
+
+            <section class="flex flex-col gap-3">
+                <h2 class="text-lg font-semibold">5. $wrapper(VsInputWrapper)에 라벨/메시지 스타일</h2>
+                <p class="text-sm text-gray-500">
+                    $wrapper로 라벨/메시지 영역까지 함께 스타일링합니다.
+                </p>
+                <vs-select
+                    v-model="value5"
+                    label="과일 선택"
+                    :options="fruits"
+                    :messages="[{ state: 'info', text: '하나를 골라주세요.' }]"
+                    :style-set="{
+                        width: '320px',
+                        $wrapper: {
+                            $label: {
+                                color: '#0f766e',
+                                fontWeight: 600,
+                            },
+                            $messages: {
+                                marginTop: '0.5rem',
+                            },
+                        },
+                    }"
+                />
+            </section>
         </div>
     </vs-page>
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { defineComponent, ref } from 'vue';
 
 export default defineComponent({
     name: 'Sandbox',
     setup() {
-        return {};
+        const fruits = ['apple', 'banana', 'cherry', 'durian', 'elderberry'];
+
+        return {
+            fruits,
+            value1: ref('apple'),
+            value2: ref('banana'),
+            value3: ref('cherry'),
+            value4: ref(['apple', 'banana']),
+            value5: ref(null),
+        };
     },
 });
 </script>

--- a/packages/vlossom/playground/Sandbox.vue
+++ b/packages/vlossom/playground/Sandbox.vue
@@ -1,121 +1,18 @@
 <template>
     <vs-page class="mb-8" :style-set="{ padding: '0' }">
-        <div class="sandbox flex flex-col gap-8 p-8">
+        <div class="sandbox">
             <h1>Sandbox</h1>
-
-            <section class="flex flex-col gap-3">
-                <h2 class="text-lg font-semibold">1. 기본 inline style (CSSProperties extends)</h2>
-                <p class="text-sm text-gray-500">
-                    StyleSet 루트의 CSS 속성이 컴포넌트 루트 요소에 inline style로 적용됩니다.
-                </p>
-                <vs-select
-                    v-model="value1"
-                    :options="fruits"
-                    :style-set="{
-                        width: '300px',
-                        backgroundColor: '#fff7ed',
-                        borderRadius: '12px',
-                    }"
-                />
-            </section>
-
-            <section class="flex flex-col gap-3">
-                <h2 class="text-lg font-semibold">2. CSS 변수($height) 사용</h2>
-                <p class="text-sm text-gray-500">
-                    `$`-prefix가 붙은 primitive 값은 CSS 변수(--vs-select-height)로 emit됩니다.
-                </p>
-                <vs-select v-model="value2" :options="fruits" :style-set="{ $height: '3.5rem', width: '300px' }" />
-            </section>
-
-            <section class="flex flex-col gap-3">
-                <h2 class="text-lg font-semibold">3. $focused / $option / $selectedOption 슬롯 스타일</h2>
-                <p class="text-sm text-gray-500">
-                    상태/요소별로 슬롯을 구분해서 스타일링할 수 있습니다.
-                </p>
-                <vs-select
-                    v-model="value3"
-                    :options="fruits"
-                    :style-set="{
-                        width: '300px',
-                        $focused: {
-                            border: '2px solid #2563eb',
-                            backgroundColor: '#eff6ff',
-                        },
-                        $option: {
-                            padding: '0.75rem 1rem',
-                        },
-                        $selectedOption: {
-                            backgroundColor: '#dbeafe',
-                            fontWeight: 600,
-                        },
-                    }"
-                />
-            </section>
-
-            <section class="flex flex-col gap-3">
-                <h2 class="text-lg font-semibold">4. multiple + $chip 하위 컴포넌트 스타일</h2>
-                <p class="text-sm text-gray-500">
-                    선택된 항목의 chip에 별도 StyleSet을 전달합니다.
-                </p>
-                <vs-select
-                    v-model="value4"
-                    multiple
-                    :options="fruits"
-                    :style-set="{
-                        width: '400px',
-                        $chip: {
-                            $height: '1.6rem',
-                            backgroundColor: '#fef3c7',
-                            color: '#92400e',
-                        },
-                    }"
-                />
-            </section>
-
-            <section class="flex flex-col gap-3">
-                <h2 class="text-lg font-semibold">5. $wrapper(VsInputWrapper)에 라벨/메시지 스타일</h2>
-                <p class="text-sm text-gray-500">
-                    $wrapper로 라벨/메시지 영역까지 함께 스타일링합니다.
-                </p>
-                <vs-select
-                    v-model="value5"
-                    label="과일 선택"
-                    :options="fruits"
-                    :messages="[{ state: 'info', text: '하나를 골라주세요.' }]"
-                    :style-set="{
-                        width: '320px',
-                        $wrapper: {
-                            $label: {
-                                color: '#0f766e',
-                                fontWeight: 600,
-                            },
-                            $messages: {
-                                marginTop: '0.5rem',
-                            },
-                        },
-                    }"
-                />
-            </section>
         </div>
     </vs-page>
 </template>
 
 <script lang="ts">
-import { defineComponent, ref } from 'vue';
+import { defineComponent } from 'vue';
 
 export default defineComponent({
     name: 'Sandbox',
     setup() {
-        const fruits = ['apple', 'banana', 'cherry', 'durian', 'elderberry'];
-
-        return {
-            fruits,
-            value1: ref('apple'),
-            value2: ref('banana'),
-            value3: ref('cherry'),
-            value4: ref(['apple', 'banana']),
-            value5: ref(null),
-        };
+        return {};
     },
 });
 </script>

--- a/packages/vlossom/playground/components/ColorSchemePanel.vue
+++ b/packages/vlossom/playground/components/ColorSchemePanel.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="z-99">
-        <vs-accordion :style-set="{ $component: { width: '15rem' } }" open>
+        <vs-accordion :style-set="{ width: '15rem' }" open>
             <template #title><p class="font-bold">Color Scheme Panel</p></template>
             <vs-focus-trap>
                 <vs-grid :grid-size="5" column-gap="0.8rem" row-gap="0.8rem">

--- a/packages/vlossom/playground/components/ColorSchemePanelButton.vue
+++ b/packages/vlossom/playground/components/ColorSchemePanelButton.vue
@@ -15,9 +15,7 @@ import ColorSchemePanel from './ColorSchemePanel.vue';
 import type { VsButtonStyleSet } from '@/components/vs-button/types';
 
 const buttonStyleSet: VsButtonStyleSet = {
-    $component: {
-        backgroundColor: 'transparent',
-    },
+    backgroundColor: 'transparent',
 };
 
 export default defineComponent({

--- a/packages/vlossom/playground/views/Basic.vue
+++ b/packages/vlossom/playground/views/Basic.vue
@@ -38,9 +38,9 @@
         <h3 class="mb-4 font-semibold">VsBar</h3>
         <div class="flex flex-col gap-4">
             <h4 class="text-sm text-gray-500 dark:text-gray-400">Default</h4>
-            <vs-bar :style-set="{ $component: { padding: '1rem' } }">Default Bar</vs-bar>
+            <vs-bar :style-set="{ padding: '1rem' }">Default Bar</vs-bar>
             <h4 class="text-sm text-gray-500 dark:text-gray-400">Primary</h4>
-            <vs-bar primary :style-set="{ $component: { padding: '1rem' } }">Primary Bar</vs-bar>
+            <vs-bar primary :style-set="{ padding: '1rem' }">Primary Bar</vs-bar>
         </div>
         <vs-divider style-set="playground" />
 
@@ -166,10 +166,10 @@
 
         <h3 class="mb-4 font-semibold">VsSkeleton</h3>
         <div class="flex flex-wrap items-center gap-4">
-            <vs-skeleton :style-set="{ $component: { width: '50px', height: '50px', borderRadius: '50%' } }" />
+            <vs-skeleton :style-set="{ width: '50px', height: '50px', borderRadius: '50%' }" />
             <div class="flex flex-col gap-2">
-                <vs-skeleton :style-set="{ $component: { width: '150px', height: '20px' } }" />
-                <vs-skeleton :style-set="{ $component: { width: '100px', height: '20px' } }" />
+                <vs-skeleton :style-set="{ width: '150px', height: '20px' }" />
+                <vs-skeleton :style-set="{ width: '100px', height: '20px' }" />
             </div>
         </div>
         <vs-divider style-set="playground" />
@@ -223,7 +223,7 @@
                     class="flex w-40 flex-col items-center justify-center gap-2 rounded border border-dashed
                         border-gray-300 p-3 dark:border-gray-600"
                 >
-                    <vs-chip :primary="toggleValue" :style-set="{ $component: { width: '120px' } }">{{
+                    <vs-chip :primary="toggleValue" :style-set="{ width: '120px' }">{{
                         toggleValue
                     }}</vs-chip>
                 </div>

--- a/packages/vlossom/playground/views/ColorPalette.vue
+++ b/packages/vlossom/playground/views/ColorPalette.vue
@@ -1,33 +1,31 @@
 <template>
-    <vs-page class="color-palette" :style-set="{ $component: { padding: '0' } }">
+    <vs-page class="color-palette" :style-set="{ padding: '0' }">
         <template #title>
             <h1 class="text-2xl font-bold">Color Palette</h1>
         </template>
         <div class="flex flex-col gap-3">
             <div class="flex gap-3">
-                <vs-avatar :style-set="{ $component: { border: 'none', width: '4rem', height: '1rem' } }"></vs-avatar>
+                <vs-avatar :style-set="{ border: 'none', width: '4rem', height: '1rem' }"></vs-avatar>
                 <vs-avatar
                     v-for="step in steps"
                     :key="step"
-                    :style-set="{ $component: { border: 'none', width: '3rem', height: '1rem' } }"
+                    :style-set="{ border: 'none', width: '3rem', height: '1rem' }"
                 >
                     <span class="text-xs">{{ step }}</span>
                 </vs-avatar>
             </div>
             <div v-for="color in COLORS" :key="color" class="flex flex-nowrap gap-3">
-                <vs-avatar :style-set="{ $component: { border: 'none', width: '4rem', height: '3rem' } }">
+                <vs-avatar :style-set="{ border: 'none', width: '4rem', height: '3rem' }">
                     <span class="text-sm font-bold" :style="{ color: `var(--vs-${color}-500)` }">{{ color }}</span>
                 </vs-avatar>
                 <vs-avatar
                     v-for="step in steps"
                     :key="`${color}-${step}`"
                     :style-set="{
-                        $component: {
-                            backgroundColor: `var(--vs-${color}-${step})`,
-                            border: 'none',
-                            width: '3rem',
-                            height: '3rem',
-                        },
+                        backgroundColor: `var(--vs-${color}-${step})`,
+                        border: 'none',
+                        width: '3rem',
+                        height: '3rem',
                     }"
                 />
             </div>

--- a/packages/vlossom/playground/views/ColorScheme.vue
+++ b/packages/vlossom/playground/views/ColorScheme.vue
@@ -1,5 +1,5 @@
 <template>
-    <vs-page :style-set="{ $component: { padding: '0' } }">
+    <vs-page :style-set="{ padding: '0' }">
         <template #title>
             <h1 class="text-2xl font-bold">Color Scheme</h1>
         </template>

--- a/packages/vlossom/playground/views/DataDisplay.vue
+++ b/packages/vlossom/playground/views/DataDisplay.vue
@@ -11,7 +11,7 @@
                 :options="tablePropsOptions"
                 option-label="label"
                 option-value="value"
-                :style-set="{ $wrapper: { $component: { width: '100%' } } }"
+                :style-set="{ $wrapper: { width: '100%' } }"
             />
         </div>
         <div :class="tablePropsSelected.includes('stickyHeader') ? 'max-h-100 overflow-y-auto' : ''">
@@ -181,12 +181,12 @@
                     class="flex w-40 flex-col items-center justify-center gap-2 rounded border border-dashed
                         border-gray-300 p-3 dark:border-gray-600"
                 >
-                    <vs-chip :style-set="{ $component: { width: '80px' } }">{{ progressValue }}%</vs-chip>
+                    <vs-chip :style-set="{ width: '80px' }">{{ progressValue }}%</vs-chip>
                     <div class="flex gap-2">
-                        <vs-button size="sm" :style-set="{ $component: { width: '2.5rem' } }" @click="decreaseProgress"
+                        <vs-button size="sm" :style-set="{ width: '2.5rem' }" @click="decreaseProgress"
                             >-</vs-button
                         >
-                        <vs-button size="sm" :style-set="{ $component: { width: '2.5rem' } }" @click="increaseProgress"
+                        <vs-button size="sm" :style-set="{ width: '2.5rem' }" @click="increaseProgress"
                             >+</vs-button
                         >
                     </div>

--- a/packages/vlossom/src/components/vs-accordion/README.ko.md
+++ b/packages/vlossom/src/components/vs-accordion/README.ko.md
@@ -79,12 +79,11 @@ const isOpen = ref(false);
 ## Types
 
 ```typescript
-interface VsAccordionStyleSet {
+interface VsAccordionStyleSet extends CSSProperties {
     $arrowColor?: string;
     $arrowSize?: string;
     $arrowSpacing?: string;
     $border?: string;
-    $component?: CSSProperties;
     $title?: CSSProperties;
     $content?: VsExpandableStyleSet;
 }
@@ -103,7 +102,7 @@ interface VsAccordionStyleSet {
             $arrowSize: '0.5rem',
             $arrowSpacing: '4%',
             $border: '2px solid #6200ea',
-            $component: { borderRadius: '0.75rem' },
+            borderRadius: '0.75rem',
             $title: { fontWeight: 'bold', padding: '1rem' },
         }"
     >

--- a/packages/vlossom/src/components/vs-accordion/README.md
+++ b/packages/vlossom/src/components/vs-accordion/README.md
@@ -79,12 +79,11 @@ const isOpen = ref(false);
 ## Types
 
 ```typescript
-interface VsAccordionStyleSet {
+interface VsAccordionStyleSet extends CSSProperties {
     $arrowColor?: string;
     $arrowSize?: string;
     $arrowSpacing?: string;
     $border?: string;
-    $component?: CSSProperties;
     $title?: CSSProperties;
     $content?: VsExpandableStyleSet;
 }
@@ -103,7 +102,7 @@ interface VsAccordionStyleSet {
             $arrowSize: '0.5rem',
             $arrowSpacing: '4%',
             $border: '2px solid #6200ea',
-            $component: { borderRadius: '0.75rem' },
+            borderRadius: '0.75rem',
             $title: { fontWeight: 'bold', padding: '1rem' },
         }"
     >

--- a/packages/vlossom/src/components/vs-accordion/VsAccordion.vue
+++ b/packages/vlossom/src/components/vs-accordion/VsAccordion.vue
@@ -3,7 +3,7 @@
         :class="['vs-accordion', colorSchemeClass, classObj, { 'vs-accordion-open': isOpen }]"
         :width
         :grid
-        :style="[styleSetVariables, componentInlineStyle]"
+        :style="{ ...styleSetVariables, ...componentInlineStyle }"
         :tabindex="disabled ? -1 : 0"
         @keydown.enter.prevent.stop="toggle"
         @keydown.space.prevent.stop="toggle"

--- a/packages/vlossom/src/components/vs-accordion/VsAccordion.vue
+++ b/packages/vlossom/src/components/vs-accordion/VsAccordion.vue
@@ -3,7 +3,7 @@
         :class="['vs-accordion', colorSchemeClass, classObj, { 'vs-accordion-open': isOpen }]"
         :width
         :grid
-        :style="[styleSetVariables, componentStyleSet.$component]"
+        :style="[styleSetVariables, componentInlineStyle]"
         :tabindex="disabled ? -1 : 0"
         @keydown.enter.prevent.stop="toggle"
         @keydown.space.prevent.stop="toggle"
@@ -49,7 +49,10 @@ export default defineComponent({
 
         const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { componentStyleSet, styleSetVariables } = useStyleSet<VsAccordionStyleSet>(componentName, styleSet);
+        const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet<VsAccordionStyleSet>(
+            componentName,
+            styleSet,
+        );
 
         const isOpen = ref(open.value || modelValue.value);
 
@@ -79,6 +82,7 @@ export default defineComponent({
             colorSchemeClass,
             styleSetVariables,
             componentStyleSet,
+            componentInlineStyle,
             isOpen,
             classObj,
             toggle,

--- a/packages/vlossom/src/components/vs-accordion/types.ts
+++ b/packages/vlossom/src/components/vs-accordion/types.ts
@@ -14,13 +14,12 @@ export interface VsAccordionRef extends ComponentPublicInstance<typeof VsAccordi
     toggle: () => void;
 }
 
-export interface VsAccordionStyleSet {
+export interface VsAccordionStyleSet extends CSSProperties {
     $accordionBorder?: string;
     $arrowColor?: string;
     $arrowSize?: string;
     $arrowSpacing?: string;
 
-    $component?: CSSProperties;
     $title?: CSSProperties;
     $content?: VsExpandableStyleSet;
 }

--- a/packages/vlossom/src/components/vs-avatar/README.ko.md
+++ b/packages/vlossom/src/components/vs-avatar/README.ko.md
@@ -9,7 +9,6 @@
 ## Feature
 
 - 기본 슬롯을 통해 이미지, 텍스트 이니셜, 아이콘 콘텐츠 수용
-- `objectFit` CSS 변수를 통한 이미지 object-fit 커스터마이징 지원
 - 배경 및 테두리 스타일링을 위한 색상 테마 지원
 - 기본 크기(3.6rem × 3.6rem) 고정이며 `component` CSSProperties로 완전 재정의 가능
 
@@ -43,16 +42,16 @@
 
 ## Props
 
-| Prop | Type | Default | Required | Description |
-| ---- | ---- | ------- | -------- | ----------- |
-| `colorScheme` | `ColorScheme` | | | 컴포넌트 색상 테마 |
-| `styleSet` | `string \| VsAvatarStyleSet` | | | 커스텀 스타일 세트 |
+| Prop          | Type                         | Default | Required | Description        |
+| ------------- | ---------------------------- | ------- | -------- | ------------------ |
+| `colorScheme` | `ColorScheme`                |         |          | 컴포넌트 색상 테마 |
+| `styleSet`    | `string \| VsAvatarStyleSet` |         |          | 커스텀 스타일 세트 |
 
 ## Types
 
 ```typescript
 interface VsAvatarStyleSet extends CSSProperties {
-    $objectFit?: CSSProperties['objectFit'] & {};
+    $imageObjectFit?: CSSProperties['objectFit'] & {};
 }
 ```
 
@@ -62,7 +61,7 @@ interface VsAvatarStyleSet extends CSSProperties {
 <template>
     <vs-avatar
         :style-set="{
-            $objectFit: 'cover',
+            $imageObjectFit: 'cover',
             width: '5rem',
             height: '5rem',
             borderRadius: '50%',
@@ -80,8 +79,8 @@ interface VsAvatarStyleSet extends CSSProperties {
 
 ## Slots
 
-| Slot | Description |
-| ---- | ----------- |
+| Slot      | Description                            |
+| --------- | -------------------------------------- |
 | `default` | 아바타 콘텐츠 — 이미지, 이니셜, 아이콘 |
 
 ## Methods

--- a/packages/vlossom/src/components/vs-avatar/README.ko.md
+++ b/packages/vlossom/src/components/vs-avatar/README.ko.md
@@ -51,9 +51,8 @@
 ## Types
 
 ```typescript
-interface VsAvatarStyleSet {
+interface VsAvatarStyleSet extends CSSProperties {
     $objectFit?: CSSProperties['objectFit'] & {};
-    $component?: CSSProperties;
 }
 ```
 
@@ -64,11 +63,9 @@ interface VsAvatarStyleSet {
     <vs-avatar
         :style-set="{
             $objectFit: 'cover',
-            $component: {
-                width: '5rem',
-                height: '5rem',
-                borderRadius: '50%',
-            },
+            width: '5rem',
+            height: '5rem',
+            borderRadius: '50%',
         }"
     >
         <img src="/profile.png" alt="사용자" />

--- a/packages/vlossom/src/components/vs-avatar/README.md
+++ b/packages/vlossom/src/components/vs-avatar/README.md
@@ -9,7 +9,6 @@ A circular or rounded display element for showing user profile images, initials,
 ## Feature
 
 - Accepts image elements, text initials, or icon content via the default slot
-- Supports `object-fit` customization for images via the `objectFit` CSS variable
 - Color scheme support for background and border styling
 - Fixed default size (3.6rem × 3.6rem) with full override via `component` CSSProperties
 
@@ -43,16 +42,16 @@ A circular or rounded display element for showing user profile images, initials,
 
 ## Props
 
-| Prop | Type | Default | Required | Description |
-| ---- | ---- | ------- | -------- | ----------- |
-| `colorScheme` | `ColorScheme` | | | Color scheme for the component |
-| `styleSet` | `string \| VsAvatarStyleSet` | | | Custom style set |
+| Prop          | Type                         | Default | Required | Description                    |
+| ------------- | ---------------------------- | ------- | -------- | ------------------------------ |
+| `colorScheme` | `ColorScheme`                |         |          | Color scheme for the component |
+| `styleSet`    | `string \| VsAvatarStyleSet` |         |          | Custom style set               |
 
 ## Types
 
 ```typescript
 interface VsAvatarStyleSet extends CSSProperties {
-    $objectFit?: CSSProperties['objectFit'] & {};
+    $imageObjectFit?: CSSProperties['objectFit'] & {};
 }
 ```
 
@@ -62,7 +61,7 @@ interface VsAvatarStyleSet extends CSSProperties {
 <template>
     <vs-avatar
         :style-set="{
-            $objectFit: 'cover',
+            $imageObjectFit: 'cover',
             width: '5rem',
             height: '5rem',
             borderRadius: '50%',
@@ -80,8 +79,8 @@ interface VsAvatarStyleSet extends CSSProperties {
 
 ## Slots
 
-| Slot | Description |
-| ---- | ----------- |
+| Slot      | Description                               |
+| --------- | ----------------------------------------- |
 | `default` | Avatar content — image, initials, or icon |
 
 ## Methods

--- a/packages/vlossom/src/components/vs-avatar/README.md
+++ b/packages/vlossom/src/components/vs-avatar/README.md
@@ -51,9 +51,8 @@ A circular or rounded display element for showing user profile images, initials,
 ## Types
 
 ```typescript
-interface VsAvatarStyleSet {
+interface VsAvatarStyleSet extends CSSProperties {
     $objectFit?: CSSProperties['objectFit'] & {};
-    $component?: CSSProperties;
 }
 ```
 
@@ -64,11 +63,9 @@ interface VsAvatarStyleSet {
     <vs-avatar
         :style-set="{
             $objectFit: 'cover',
-            $component: {
-                width: '5rem',
-                height: '5rem',
-                borderRadius: '50%',
-            },
+            width: '5rem',
+            height: '5rem',
+            borderRadius: '50%',
         }"
     >
         <img src="/profile.png" alt="User" />

--- a/packages/vlossom/src/components/vs-avatar/VsAvatar.vue
+++ b/packages/vlossom/src/components/vs-avatar/VsAvatar.vue
@@ -23,14 +23,10 @@ export default defineComponent({
 
         const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet<VsAvatarStyleSet>(
-            componentName,
-            styleSet,
-        );
+        const { styleSetVariables, componentInlineStyle } = useStyleSet<VsAvatarStyleSet>(componentName, styleSet);
 
         return {
             colorSchemeClass,
-            componentStyleSet,
             styleSetVariables,
             componentInlineStyle,
         };

--- a/packages/vlossom/src/components/vs-avatar/VsAvatar.vue
+++ b/packages/vlossom/src/components/vs-avatar/VsAvatar.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="['vs-avatar', colorSchemeClass]" :style="{ ...styleSetVariables, ...componentStyleSet.$component }">
+    <div :class="['vs-avatar', colorSchemeClass]" :style="{ ...styleSetVariables, ...componentInlineStyle }">
         <slot />
     </div>
 </template>
@@ -23,12 +23,16 @@ export default defineComponent({
 
         const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { componentStyleSet, styleSetVariables } = useStyleSet<VsAvatarStyleSet>(componentName, styleSet);
+        const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet<VsAvatarStyleSet>(
+            componentName,
+            styleSet,
+        );
 
         return {
             colorSchemeClass,
             componentStyleSet,
             styleSetVariables,
+            componentInlineStyle,
         };
     },
 });

--- a/packages/vlossom/src/components/vs-avatar/__stories__/vs-avatar.stories.ts
+++ b/packages/vlossom/src/components/vs-avatar/__stories__/vs-avatar.stories.ts
@@ -19,13 +19,11 @@ const meta: Meta<typeof VsAvatar> = {
         components: { VsAvatar },
         setup() {
             const preDefinedStyleSet: VsAvatarStyleSet = {
-                $component: {
-                    backgroundColor: '#1e88e5',
-                    borderRadius: '50%',
-                    color: '#fff',
-                    width: '5rem',
-                    height: '5rem',
-                },
+                backgroundColor: '#1e88e5',
+                borderRadius: '50%',
+                color: '#fff',
+                width: '5rem',
+                height: '5rem',
             } as const;
 
             useVlossom().styleSet = {
@@ -116,13 +114,11 @@ export const StyleSet: Story = {
     }),
     args: {
         styleSet: {
-            $component: {
-                borderRadius: '0.6rem',
-                backgroundColor: '#e188e5',
-                color: '#fff',
-                height: '5rem',
-                width: '5rem',
-            },
+            borderRadius: '0.6rem',
+            backgroundColor: '#e188e5',
+            color: '#fff',
+            height: '5rem',
+            width: '5rem',
         },
     },
 };

--- a/packages/vlossom/src/components/vs-avatar/types.ts
+++ b/packages/vlossom/src/components/vs-avatar/types.ts
@@ -11,7 +11,6 @@ export type { VsAvatar };
 
 export interface VsAvatarRef extends ComponentPublicInstance<typeof VsAvatar> {}
 
-export interface VsAvatarStyleSet {
+export interface VsAvatarStyleSet extends CSSProperties {
     $imageObjectFit?: CSSProperties['objectFit'] & {};
-    $component?: CSSProperties;
 }

--- a/packages/vlossom/src/components/vs-bar/README.ko.md
+++ b/packages/vlossom/src/components/vs-bar/README.ko.md
@@ -11,7 +11,7 @@
 - `tag` prop을 통해 원하는 HTML 요소로 렌더링 가능 (기본값: `div`)
 - `position` prop을 통해 `absolute`, `fixed`, `sticky` 등 CSS position 값 지원
 - 두드러진 툴바/헤더 스타일링을 위한 Primary 변형
-- `$component` CSSProperties를 통한 완전한 스타일 재정의
+- `CSSProperties`를 통한 완전한 스타일 재정의
 
 ## Basic Usage
 
@@ -56,9 +56,7 @@
 ## Types
 
 ```typescript
-interface VsBarStyleSet {
-    $component?: CSSProperties;
-}
+interface VsBarStyleSet extends CSSProperties {}
 ```
 
 ### StyleSet 사용 예시
@@ -67,12 +65,10 @@ interface VsBarStyleSet {
 <template>
     <vs-bar
         :style-set="{
-            $component: {
-                backgroundColor: '#1a1a2e',
-                color: '#ffffff',
-                padding: '0 1.5rem',
-                height: '4rem',
-            },
+            backgroundColor: '#1a1a2e',
+            color: '#ffffff',
+            padding: '0 1.5rem',
+            height: '4rem',
         }"
     >
         <span>커스텀 스타일 바</span>

--- a/packages/vlossom/src/components/vs-bar/README.md
+++ b/packages/vlossom/src/components/vs-bar/README.md
@@ -11,7 +11,7 @@ A full-width horizontal bar component typically used as a header, footer, or too
 - Renders as any HTML element via the `tag` prop (defaults to `div`)
 - Supports `position` prop for `absolute`, `fixed`, `sticky`, and other CSS position values
 - Primary variant for prominent toolbar/header styling
-- Full style override via `$component` CSSProperties
+- Full style override via `CSSProperties`
 
 ## Basic Usage
 
@@ -56,9 +56,7 @@ A full-width horizontal bar component typically used as a header, footer, or too
 ## Types
 
 ```typescript
-interface VsBarStyleSet {
-    $component?: CSSProperties;
-}
+interface VsBarStyleSet extends CSSProperties {}
 ```
 
 ### StyleSet Example
@@ -67,12 +65,10 @@ interface VsBarStyleSet {
 <template>
     <vs-bar
         :style-set="{
-            $component: {
-                backgroundColor: '#1a1a2e',
-                color: '#ffffff',
-                padding: '0 1.5rem',
-                height: '4rem',
-            },
+            backgroundColor: '#1a1a2e',
+            color: '#ffffff',
+            padding: '0 1.5rem',
+            height: '4rem',
         }"
     >
         <span>Custom Styled Bar</span>

--- a/packages/vlossom/src/components/vs-bar/VsBar.vue
+++ b/packages/vlossom/src/components/vs-bar/VsBar.vue
@@ -1,9 +1,5 @@
 <template>
-    <component
-        :is="tag"
-        :class="['vs-bar', colorSchemeClass, classObj]"
-        :style="componentInlineStyle"
-    >
+    <component :is="tag" :class="['vs-bar', colorSchemeClass, classObj]" :style="componentInlineStyle">
         <slot />
     </component>
 </template>
@@ -36,7 +32,7 @@ export default defineComponent({
                 position: position.value || undefined,
             });
         });
-        const { componentStyleSet, componentInlineStyle } = useStyleSet<VsBarStyleSet>(
+        const { componentInlineStyle } = useStyleSet<VsBarStyleSet>(
             componentName,
             styleSet,
             baseStyleSet,
@@ -47,7 +43,7 @@ export default defineComponent({
             'vs-primary': primary.value,
         }));
 
-        return { colorSchemeClass, componentStyleSet, componentInlineStyle, classObj };
+        return { colorSchemeClass, componentInlineStyle, classObj };
     },
 });
 </script>

--- a/packages/vlossom/src/components/vs-bar/VsBar.vue
+++ b/packages/vlossom/src/components/vs-bar/VsBar.vue
@@ -2,7 +2,7 @@
     <component
         :is="tag"
         :class="['vs-bar', colorSchemeClass, classObj]"
-        :style="componentStyleSet.$component"
+        :style="componentInlineStyle"
     >
         <slot />
     </component>
@@ -33,12 +33,10 @@ export default defineComponent({
         const baseStyleSet: ComputedRef<VsBarStyleSet> = computed(() => ({}));
         const additionalStyleSet: ComputedRef<Partial<VsBarStyleSet>> = computed(() => {
             return objectUtil.shake({
-                $component: objectUtil.shake({
-                    position: position.value || undefined,
-                }),
+                position: position.value || undefined,
             });
         });
-        const { componentStyleSet } = useStyleSet<VsBarStyleSet>(
+        const { componentStyleSet, componentInlineStyle } = useStyleSet<VsBarStyleSet>(
             componentName,
             styleSet,
             baseStyleSet,
@@ -49,7 +47,7 @@ export default defineComponent({
             'vs-primary': primary.value,
         }));
 
-        return { colorSchemeClass, componentStyleSet, classObj };
+        return { colorSchemeClass, componentStyleSet, componentInlineStyle, classObj };
     },
 });
 </script>

--- a/packages/vlossom/src/components/vs-bar/__stories__/vs-bar.chromatic.stories.ts
+++ b/packages/vlossom/src/components/vs-bar/__stories__/vs-bar.chromatic.stories.ts
@@ -29,38 +29,34 @@ export const AllVariations: Story = {
         template: `
             <div class="chromatic-wrapper">
                 <div class="chromatic-section">
-                    <vs-bar :style-set='{ $component: { padding: "1rem", margin: "0.5rem 0" } }'>
+                    <vs-bar :style-set='{ padding: "1rem", margin: "0.5rem 0" }'>
                         기본 바
                     </vs-bar>
                 </div>
 
                 <div class="chromatic-section">
-                    <vs-bar primary :style-set='{ $component: { padding: "1rem", margin: "0.5rem 0" } }'>
+                    <vs-bar primary :style-set='{ padding: "1rem", margin: "0.5rem 0" }'>
                         Primary 바
                     </vs-bar>
                 </div>
 
                 <div class="chromatic-section">
                     <vs-bar :style-set='{
-                        $component: {
-                            backgroundColor: "#e3f2fd",
-                            border: "2px solid #2196f3",
-                            borderRadius: "8px",
-                            padding: "1rem",
-                            margin: "0.5rem 0"
-                        }
+                        backgroundColor: "#e3f2fd",
+                        border: "2px solid #2196f3",
+                        borderRadius: "8px",
+                        padding: "1rem",
+                        margin: "0.5rem 0"
                     }'>
                         커스텀 스타일 바
                     </vs-bar>
 
                     <vs-bar :style-set='{
-                        $component: {
-                            backgroundColor: "#f3e5f5",
-                            color: "#7b1fa2",
-                            fontWeight: "600",
-                            padding: "1rem",
-                            margin: "0.5rem 0"
-                        }
+                        backgroundColor: "#f3e5f5",
+                        color: "#7b1fa2",
+                        fontWeight: "600",
+                        padding: "1rem",
+                        margin: "0.5rem 0"
                     }'>
                         폰트 스타일 바
                     </vs-bar>
@@ -70,27 +66,23 @@ export const AllVariations: Story = {
                     <h3>위치 설정 (상대 위치로 시각화)</h3>
                     <div style="position: relative; height: 120px; border: 1px dashed #ccc; margin: 0.5rem 0;">
                         <vs-bar position="absolute" :style-set='{
-                            $component: {
-                                backgroundColor: "#ffebee",
-                                border: "1px solid #f44336",
-                                top: "10px",
-                                left: "10px",
-                                width: "200px",
-                                padding: "0.5rem"
-                            }
+                            backgroundColor: "#ffebee",
+                            border: "1px solid #f44336",
+                            top: "10px",
+                            left: "10px",
+                            width: "200px",
+                            padding: "0.5rem"
                         }'>
                             Absolute 위치
                         </vs-bar>
 
                         <vs-bar position="absolute" :style-set='{
-                            $component: {
-                                backgroundColor: "#e8f5e8",
-                                border: "1px solid #4caf50",
-                                bottom: "10px",
-                                right: "10px",
-                                width: "200px",
-                                padding: "0.5rem"
-                            }
+                            backgroundColor: "#e8f5e8",
+                            border: "1px solid #4caf50",
+                            bottom: "10px",
+                            right: "10px",
+                            width: "200px",
+                            padding: "0.5rem"
                         }'>
                             Absolute 우하단
                         </vs-bar>

--- a/packages/vlossom/src/components/vs-bar/__stories__/vs-bar.stories.ts
+++ b/packages/vlossom/src/components/vs-bar/__stories__/vs-bar.stories.ts
@@ -19,13 +19,11 @@ const meta: Meta<typeof VsBar> = {
         components: { VsBar },
         setup() {
             const preDefinedStyleSet: VsBarStyleSet = {
-                $component: {
-                    backgroundColor: '#2c3e50',
-                    height: '60px',
-                    padding: '0 1.5rem',
-                    color: '#ffffff',
-                    boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
-                },
+                backgroundColor: '#2c3e50',
+                height: '60px',
+                padding: '0 1.5rem',
+                color: '#ffffff',
+                boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
             };
 
             useVlossom().styleSet = {
@@ -89,17 +87,15 @@ export const NavigationBar: Story = {
         position: 'fixed',
         primary: true,
         styleSet: {
-            $component: {
-                top: 0,
-                left: 0,
-                width: '100%',
-                height: '64px',
-                padding: '0 2rem',
-                zIndex: 1000,
-                backgroundColor: '#1976d2',
-                color: '#ffffff',
-                boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
-            },
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '64px',
+            padding: '0 2rem',
+            zIndex: 1000,
+            backgroundColor: '#1976d2',
+            color: '#ffffff',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
         },
     },
     render: (args: any) => ({
@@ -132,15 +128,13 @@ export const StatusBar: Story = {
     args: {
         position: 'fixed',
         styleSet: {
-            $component: {
-                left: 0,
-                bottom: 0,
-                height: '32px',
-                padding: '0 1rem',
-                backgroundColor: '#f5f5f5',
-                color: '#666666',
-                border: '1px solid #e0e0e0',
-            },
+            left: 0,
+            bottom: 0,
+            height: '32px',
+            padding: '0 1rem',
+            backgroundColor: '#f5f5f5',
+            color: '#666666',
+            border: '1px solid #e0e0e0',
         },
     },
     render: (args: any) => ({
@@ -169,14 +163,12 @@ export const Toolbar: Story = {
     args: {
         position: 'absolute',
         styleSet: {
-            $component: {
-                left: 0,
-                top: 0,
-                width: '56px',
-                height: '100%',
-                backgroundColor: '#2c3e50',
-                padding: '2.4rem 0',
-            },
+            left: 0,
+            top: 0,
+            width: '56px',
+            height: '100%',
+            backgroundColor: '#2c3e50',
+            padding: '2.4rem 0',
         },
     },
     render: (args: any) => ({
@@ -214,21 +206,21 @@ export const Positions: Story = {
             <div style="display: flex; flex-direction: column; gap: 1rem; padding: 1rem;">
                 <div>
                     <h4>Default (relative)</h4>
-                    <vs-bar :style-set='{ $component: { backgroundColor: "#e3f2fd", padding: "0.5rem", border: "1px solid #2196f3" } }'>
+                    <vs-bar :style-set='{ backgroundColor: "#e3f2fd", padding: "0.5rem", border: "1px solid #2196f3" }'>
                         Default Position Bar
                     </vs-bar>
                 </div>
 
                 <div style="position: relative; height: 100px; border: 1px solid #ddd;">
                     <h4>Absolute Position</h4>
-                    <vs-bar position="absolute" :style-set='{ $component: { backgroundColor: "#fff3e0", padding: "0.5rem", top: "30px", left: "10px", border: "1px solid #ff9800" } }'>
+                    <vs-bar position="absolute" :style-set='{ backgroundColor: "#fff3e0", padding: "0.5rem", top: "30px", left: "10px", border: "1px solid #ff9800" }'>
                         Absolute Bar
                     </vs-bar>
                 </div>
 
                 <div class="relative">
                     <h4>Fixed Position</h4>
-                    <vs-bar position="fixed" :style-set='{ $component: { backgroundColor: "#f3e5f5", padding: "0.5rem", border: "1px solid #9c27b0" } }'>
+                    <vs-bar position="fixed" :style-set='{ backgroundColor: "#f3e5f5", padding: "0.5rem", border: "1px solid #9c27b0" }'>
                         Fixed Bar
                     </vs-bar>
                 </div>
@@ -250,9 +242,7 @@ export const ColorScheme: Story = {
         components: { VsBar },
         setup() {
             const styleSet = {
-                $component: {
-                    padding: '0.5rem',
-                },
+                padding: '0.5rem',
             };
             return { args, styleSet };
         },
@@ -290,14 +280,12 @@ export const StyleSet: Story = {
     }),
     args: {
         styleSet: {
-            $component: {
-                backgroundColor: '#e91e63',
-                border: '2px solid #ad1457',
-                color: '#ffffff',
-                height: '56px',
-                padding: '0 2rem',
-                boxShadow: '0 4px 8px rgba(233, 30, 99, 0.3)',
-            },
+            backgroundColor: '#e91e63',
+            border: '2px solid #ad1457',
+            color: '#ffffff',
+            height: '56px',
+            padding: '0 2rem',
+            boxShadow: '0 4px 8px rgba(233, 30, 99, 0.3)',
         },
     },
 };

--- a/packages/vlossom/src/components/vs-bar/types.ts
+++ b/packages/vlossom/src/components/vs-bar/types.ts
@@ -11,6 +11,4 @@ export type { VsBar };
 
 export interface VsBarRef extends ComponentPublicInstance<typeof VsBar> {}
 
-export interface VsBarStyleSet {
-    $component?: CSSProperties;
-}
+export interface VsBarStyleSet extends CSSProperties {}

--- a/packages/vlossom/src/components/vs-block/README.ko.md
+++ b/packages/vlossom/src/components/vs-block/README.ko.md
@@ -59,9 +59,8 @@
 ## Types
 
 ```typescript
-interface VsBlockStyleSet {
+interface VsBlockStyleSet extends CSSProperties {
     $blockBorder?: string;
-    $component?: CSSProperties;
     $title?: CSSProperties;
     $content?: CSSProperties;
 }
@@ -74,10 +73,8 @@ interface VsBlockStyleSet {
     <vs-block
         :style-set="{
             $blockBorder: '2px solid #6200ea',
-            $component: {
-                borderRadius: '1rem',
-                boxShadow: '0 4px 16px rgba(0,0,0,0.12)',
-            },
+            borderRadius: '1rem',
+            boxShadow: '0 4px 16px rgba(0,0,0,0.12)',
             $title: {
                 backgroundColor: '#6200ea',
                 color: '#ffffff',

--- a/packages/vlossom/src/components/vs-block/README.md
+++ b/packages/vlossom/src/components/vs-block/README.md
@@ -59,9 +59,8 @@ A content block component with an optional title area and a scrollable content r
 ## Types
 
 ```typescript
-interface VsBlockStyleSet {
+interface VsBlockStyleSet extends CSSProperties {
     $blockBorder?: string;
-    $component?: CSSProperties;
     $title?: CSSProperties;
     $content?: CSSProperties;
 }
@@ -74,10 +73,8 @@ interface VsBlockStyleSet {
     <vs-block
         :style-set="{
             $blockBorder: '2px solid #6200ea',
-            $component: {
-                borderRadius: '1rem',
-                boxShadow: '0 4px 16px rgba(0,0,0,0.12)',
-            },
+            borderRadius: '1rem',
+            boxShadow: '0 4px 16px rgba(0,0,0,0.12)',
             $title: {
                 backgroundColor: '#6200ea',
                 color: '#ffffff',

--- a/packages/vlossom/src/components/vs-block/VsBlock.vue
+++ b/packages/vlossom/src/components/vs-block/VsBlock.vue
@@ -1,7 +1,7 @@
 <template>
     <vs-responsive
         :class="['vs-block', colorSchemeClass]"
-        :style="{ ...styleSetVariables, ...componentStyleSet.$component }"
+        :style="{ ...styleSetVariables, ...componentInlineStyle }"
         :grid
         :width
     >
@@ -47,13 +47,11 @@ export default defineComponent({
         const baseStyleSet: ComputedRef<VsBlockStyleSet> = computed(() => ({}));
         const additionalStyleSet: ComputedRef<Partial<VsBlockStyleSet>> = computed(() => {
             return objectUtil.shake({
-                $component: objectUtil.shake({
-                    height: height.value === undefined ? undefined : stringUtil.toStringSize(height.value),
-                }),
+                height: height.value === undefined ? undefined : stringUtil.toStringSize(height.value),
             });
         });
 
-        const { componentStyleSet, styleSetVariables } = useStyleSet<VsBlockStyleSet>(
+        const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet<VsBlockStyleSet>(
             componentName,
             styleSet,
             baseStyleSet,
@@ -64,6 +62,7 @@ export default defineComponent({
             colorSchemeClass,
             componentStyleSet,
             styleSetVariables,
+            componentInlineStyle,
         };
     },
 });

--- a/packages/vlossom/src/components/vs-block/__stories__/vs-block.stories.ts
+++ b/packages/vlossom/src/components/vs-block/__stories__/vs-block.stories.ts
@@ -45,11 +45,9 @@ const meta: Meta<typeof VsBlock> = {
         setup() {
             const preDefinedStyleSet: VsBlockStyleSet = {
                 $blockBorder: '1px solid #e9ecef',
-                $component: {
-                    backgroundColor: '#f8f9fa',
-                    borderRadius: '8px',
-                    color: '#495057',
-                },
+                backgroundColor: '#f8f9fa',
+                borderRadius: '8px',
+                color: '#495057',
                 $title: {
                     backgroundColor: '#f8f9fa',
                     color: '#212529',
@@ -192,12 +190,10 @@ export const StyleSet: Story = {
     args: {
         styleSet: {
             $blockBorder: '2px solid #2196f3',
-            $component: {
-                backgroundColor: '#e3f2fd',
-                borderRadius: '12px',
-                boxShadow: '0 4px 12px rgba(33, 150, 243, 0.15)',
-                color: '#1565c0',
-            },
+            backgroundColor: '#e3f2fd',
+            borderRadius: '12px',
+            boxShadow: '0 4px 12px rgba(33, 150, 243, 0.15)',
+            color: '#1565c0',
             $title: {
                 backgroundColor: '#e3f2fd',
                 color: '#1976d2',
@@ -269,7 +265,7 @@ export const StyleCustomization: Story = {
         },
         template: `
             <div style="display: flex; flex-direction: column; gap: 1rem;">
-                <vs-block :style-set="{ $blockBorder: '3px dashed #9c27b0', $component: { borderRadius: '16px' } }">
+                <vs-block :style-set="{ $blockBorder: '3px dashed #9c27b0', borderRadius: '16px' }">
                     <template #title>Border 커스텀</template>
                     border 변수로 테두리 스타일을 변경할 수 있습니다.
                 </vs-block>
@@ -284,7 +280,7 @@ export const StyleCustomization: Story = {
                     content 영역의 배경색, 패딩, 폰트 크기 등을 변경할 수 있습니다.
                 </vs-block>
 
-                <vs-block :style-set="{ $blockBorder: '2px solid #ff5722', $component: { backgroundColor: '#ffebee', borderRadius: '20px', boxShadow: '0 8px 16px rgba(244, 67, 54, 0.2)' }, $title: { backgroundColor: '#ff5722', color: '#fff', padding: '1rem 2rem' }, $content: { padding: '2rem', lineHeight: '1.8' } }">
+                <vs-block :style-set="{ $blockBorder: '2px solid #ff5722', backgroundColor: '#ffebee', borderRadius: '20px', boxShadow: '0 8px 16px rgba(244, 67, 54, 0.2)', $title: { backgroundColor: '#ff5722', color: '#fff', padding: '1rem 2rem' }, $content: { padding: '2rem', lineHeight: '1.8' } }">
                     <template #title>종합 커스텀</template>
                     모든 영역을 동시에 커스터마이징하여 완전히 새로운 디자인을 만들 수 있습니다.
                 </vs-block>

--- a/packages/vlossom/src/components/vs-block/types.ts
+++ b/packages/vlossom/src/components/vs-block/types.ts
@@ -11,9 +11,8 @@ export type { VsBlock };
 
 export interface VsBlockRef extends ComponentPublicInstance<typeof VsBlock> {}
 
-export interface VsBlockStyleSet {
+export interface VsBlockStyleSet extends CSSProperties {
     $blockBorder?: string;
-    $component?: CSSProperties;
     $title?: CSSProperties;
     $content?: CSSProperties;
 }

--- a/packages/vlossom/src/components/vs-button/README.ko.md
+++ b/packages/vlossom/src/components/vs-button/README.ko.md
@@ -89,8 +89,7 @@ async function submit() {
 ## Types
 
 ```typescript
-interface VsButtonStyleSet {
-    $component?: CSSProperties;
+interface VsButtonStyleSet extends CSSProperties {
     $content?: CSSProperties;
     $loading?: VsLoadingStyleSet;
 }
@@ -105,16 +104,14 @@ interface VsButtonStyleSet {
 <template>
     <vs-button
         :style-set="{
-            $component: {
-                borderRadius: '2rem',
-                fontWeight: 'bold',
-                padding: '0.5rem 2rem',
-            },
+            borderRadius: '2rem',
+            fontWeight: 'bold',
+            padding: '0.5rem 2rem',
             $content: {
                 letterSpacing: '0.05em',
             },
             $loading: {
-                $component: { width: '25%', height: '50%' },
+                width: '25%', height: '50%',
             },
         }"
     >

--- a/packages/vlossom/src/components/vs-button/README.md
+++ b/packages/vlossom/src/components/vs-button/README.md
@@ -89,8 +89,7 @@ async function submit() {
 ## Types
 
 ```typescript
-interface VsButtonStyleSet {
-    $component?: CSSProperties;
+interface VsButtonStyleSet extends CSSProperties {
     $content?: CSSProperties;
     $loading?: VsLoadingStyleSet;
 }
@@ -105,16 +104,14 @@ interface VsButtonStyleSet {
 <template>
     <vs-button
         :style-set="{
-            $component: {
-                borderRadius: '2rem',
-                fontWeight: 'bold',
-                padding: '0.5rem 2rem',
-            },
+            borderRadius: '2rem',
+            fontWeight: 'bold',
+            padding: '0.5rem 2rem',
             $content: {
                 letterSpacing: '0.05em',
             },
             $loading: {
-                $component: { width: '25%', height: '50%' },
+                width: '25%', height: '50%',
             },
         }"
     >

--- a/packages/vlossom/src/components/vs-button/VsButton.vue
+++ b/packages/vlossom/src/components/vs-button/VsButton.vue
@@ -3,7 +3,7 @@
         ref="buttonRef"
         :type="type"
         :class="['vs-button', colorSchemeClass, classObj]"
-        :style="{ ...styleSetVariables, ...componentStyleSet.$component }"
+        :style="{ ...styleSetVariables, ...componentInlineStyle }"
         :disabled
         :tabindex="disabled || loading ? -1 : 0"
     >
@@ -46,14 +46,12 @@ export default defineComponent({
             return {
                 $loading: {
                     $color: primary.value ? 'var(--vs-cs-font-primary)' : undefined,
-                    $component: {
-                        width: '30%',
-                        height: '60%',
-                    },
+                    width: '30%',
+                    height: '60%',
                 },
             };
         });
-        const { componentStyleSet, styleSetVariables } = useStyleSet<VsButtonStyleSet>(
+        const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet<VsButtonStyleSet>(
             componentName,
             styleSet,
             baseStyleSet,
@@ -80,7 +78,7 @@ export default defineComponent({
             }
         });
 
-        return { colorSchemeClass, styleSetVariables, classObj, buttonRef, componentStyleSet };
+        return { colorSchemeClass, styleSetVariables, componentInlineStyle, classObj, buttonRef, componentStyleSet };
     },
 });
 </script>

--- a/packages/vlossom/src/components/vs-button/__stories__/vs-button.stories.ts
+++ b/packages/vlossom/src/components/vs-button/__stories__/vs-button.stories.ts
@@ -18,15 +18,13 @@ const meta: Meta<typeof VsButton> = {
         components: { VsButton },
         setup() {
             const preDefinedStyleSet: VsButtonStyleSet = {
-                $component: {
-                    backgroundColor: '#1e88e5',
-                    border: '2px solid #1e88e5',
-                    borderRadius: '8px',
-                    color: '#fff',
-                    height: '3rem',
-                    width: 'auto',
-                    padding: '0 1.5rem',
-                },
+                backgroundColor: '#1e88e5',
+                border: '2px solid #1e88e5',
+                borderRadius: '8px',
+                color: '#fff',
+                height: '3rem',
+                width: 'auto',
+                padding: '0 1.5rem',
             } as const;
 
             useVlossom().styleSet = {
@@ -245,15 +243,13 @@ export const StyleSet: Story = {
     }),
     args: {
         styleSet: {
-            $component: {
-                backgroundColor: '#e188e5',
-                border: '2px solid #e188e5',
-                borderRadius: '12px',
-                color: '#fff',
-                width: 'auto',
-                height: '4rem',
-                padding: '0 2rem',
-            },
+            backgroundColor: '#e188e5',
+            border: '2px solid #e188e5',
+            borderRadius: '12px',
+            color: '#fff',
+            width: 'auto',
+            height: '4rem',
+            padding: '0 2rem',
         },
     },
 };

--- a/packages/vlossom/src/components/vs-button/types.ts
+++ b/packages/vlossom/src/components/vs-button/types.ts
@@ -12,8 +12,7 @@ export type { VsButton };
 
 export interface VsButtonRef extends ComponentPublicInstance<typeof VsButton> {}
 
-export interface VsButtonStyleSet {
-    $component?: CSSProperties;
+export interface VsButtonStyleSet extends CSSProperties {
     $content?: CSSProperties;
     $loading?: VsLoadingStyleSet;
 }

--- a/packages/vlossom/src/components/vs-checkbox/README.ko.md
+++ b/packages/vlossom/src/components/vs-checkbox/README.ko.md
@@ -139,18 +139,16 @@ async function confirmChange(from, to) {
 ## Types
 
 ```typescript
-interface VsCheckboxStyleSet {
+interface VsCheckboxStyleSet extends CSSProperties {
     $checkboxCheckedColor?: string;
     $checkboxColor?: string;
     $checkboxSize?: string;
-    $component?: CSSProperties;
     $checkbox?: CSSProperties;
     $checkboxLabel?: CSSProperties;
     $wrapper?: VsInputWrapperStyleSet;
 }
 
-interface VsCheckboxSetStyleSet {
-    $component?: CSSProperties;
+interface VsCheckboxSetStyleSet extends CSSProperties {
     $checkbox?: Omit<VsCheckboxStyleSet, '$wrapper'>;
     $wrapper?: VsInputWrapperStyleSet;
 }

--- a/packages/vlossom/src/components/vs-checkbox/README.md
+++ b/packages/vlossom/src/components/vs-checkbox/README.md
@@ -139,18 +139,16 @@ async function confirmChange(from, to) {
 ## Types
 
 ```typescript
-interface VsCheckboxStyleSet {
+interface VsCheckboxStyleSet extends CSSProperties {
     $checkboxCheckedColor?: string;
     $checkboxColor?: string;
     $checkboxSize?: string;
-    $component?: CSSProperties;
     $checkbox?: CSSProperties;
     $checkboxLabel?: CSSProperties;
     $wrapper?: VsInputWrapperStyleSet;
 }
 
-interface VsCheckboxSetStyleSet {
-    $component?: CSSProperties;
+interface VsCheckboxSetStyleSet extends CSSProperties {
     $checkbox?: Omit<VsCheckboxStyleSet, '$wrapper'>;
     $wrapper?: VsInputWrapperStyleSet;
 }

--- a/packages/vlossom/src/components/vs-checkbox/VsCheckbox.vue
+++ b/packages/vlossom/src/components/vs-checkbox/VsCheckbox.vue
@@ -19,7 +19,7 @@
 
         <div
             :class="['vs-checkbox', colorSchemeClass, classObj]"
-            :style="{ ...styleSetVariables, ...componentStyleSet.$component }"
+            :style="{ ...styleSetVariables, ...componentInlineStyle }"
         >
             <label class="vs-checkbox-wrap" :for="computedId">
                 <input
@@ -123,7 +123,10 @@ export default defineComponent({
 
         const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { componentStyleSet, styleSetVariables } = useStyleSet<VsCheckboxStyleSet>(componentName, styleSet);
+        const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet<VsCheckboxStyleSet>(
+            componentName,
+            styleSet,
+        );
 
         const inputValue = ref(modelValue.value);
 
@@ -248,6 +251,7 @@ export default defineComponent({
             colorSchemeClass,
             componentStyleSet,
             styleSetVariables,
+            componentInlineStyle,
             classObj,
             stateBoxClasses,
             computedId,

--- a/packages/vlossom/src/components/vs-checkbox/VsCheckboxSet.vue
+++ b/packages/vlossom/src/components/vs-checkbox/VsCheckboxSet.vue
@@ -17,7 +17,7 @@
             <slot name="label" />
         </template>
 
-        <div :class="['vs-checkbox-set', colorSchemeClass, classObj]" :style="componentStyleSet.$component">
+        <div :class="['vs-checkbox-set', colorSchemeClass, classObj]" :style="componentInlineStyle">
             <vs-checkbox
                 v-for="(option, index) in options"
                 :key="getOptionValue(option)"
@@ -124,7 +124,7 @@ export default defineComponent({
 
         const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { componentStyleSet } = useStyleSet<VsCheckboxSetStyleSet>(componentName, styleSet);
+        const { componentStyleSet, componentInlineStyle } = useStyleSet<VsCheckboxSetStyleSet>(componentName, styleSet);
 
         const { requiredCheck, maxCheck, minCheck } = useVsCheckboxSetRules(required, max, min);
 
@@ -215,6 +215,7 @@ export default defineComponent({
             checkboxRefs,
             colorSchemeClass,
             componentStyleSet,
+            componentInlineStyle,
             classObj,
             computedId,
             computedMessages,

--- a/packages/vlossom/src/components/vs-checkbox/__stories__/vs-checkbox-set.stories.ts
+++ b/packages/vlossom/src/components/vs-checkbox/__stories__/vs-checkbox-set.stories.ts
@@ -111,9 +111,7 @@ export const StyleSet: Story = {
         label: 'Custom Style',
         options: ['Option 1', 'Option 2', 'Option 3'],
         styleSet: {
-            $component: {
-                gap: '2rem',
-            },
+            gap: '2rem',
             $checkbox: {
                 $checkboxColor: '#7c3aed',
                 $checkboxSize: '1.2rem',

--- a/packages/vlossom/src/components/vs-checkbox/types.ts
+++ b/packages/vlossom/src/components/vs-checkbox/types.ts
@@ -19,19 +19,17 @@ export interface VsCheckboxRef extends ComponentPublicInstance<typeof VsCheckbox
 
 export interface VsCheckboxSetRef extends ComponentPublicInstance<typeof VsCheckboxSet>, FocusableRef, FormChildRef {}
 
-export interface VsCheckboxStyleSet {
+export interface VsCheckboxStyleSet extends CSSProperties {
     $checkboxCheckedColor?: string;
     $checkboxColor?: string;
     $checkboxSize?: string;
 
-    $component?: CSSProperties;
     $checkbox?: CSSProperties;
     $checkboxLabel?: CSSProperties;
     $wrapper?: VsInputWrapperStyleSet;
 }
 
-export interface VsCheckboxSetStyleSet {
-    $component?: CSSProperties;
+export interface VsCheckboxSetStyleSet extends CSSProperties {
     $checkbox?: Omit<VsCheckboxStyleSet, '$wrapper'>;
     $wrapper?: VsInputWrapperStyleSet;
 }

--- a/packages/vlossom/src/components/vs-chip/README.ko.md
+++ b/packages/vlossom/src/components/vs-chip/README.ko.md
@@ -76,9 +76,8 @@
 ## Types
 
 ```typescript
-interface VsChipStyleSet {
+interface VsChipStyleSet extends CSSProperties {
     $height?: string;
-    $component?: CSSProperties;
     $icon?: CSSProperties;
     $closeButton?: CSSProperties;
 }
@@ -92,11 +91,9 @@ interface VsChipStyleSet {
         closable
         :style-set="{
             $height: '2rem',
-            $component: {
-                borderRadius: '0.25rem',
-                backgroundColor: '#e8f5e9',
-                color: '#2e7d32',
-            },
+            borderRadius: '0.25rem',
+            backgroundColor: '#e8f5e9',
+            color: '#2e7d32',
             $icon: {
                 color: '#2e7d32',
             },

--- a/packages/vlossom/src/components/vs-chip/README.md
+++ b/packages/vlossom/src/components/vs-chip/README.md
@@ -76,9 +76,8 @@ A compact element for displaying tags, labels, or status indicators with optiona
 ## Types
 
 ```typescript
-interface VsChipStyleSet {
+interface VsChipStyleSet extends CSSProperties {
     $height?: string;
-    $component?: CSSProperties;
     $icon?: CSSProperties;
     $closeButton?: CSSProperties;
 }
@@ -92,11 +91,9 @@ interface VsChipStyleSet {
         closable
         :style-set="{
             $height: '2rem',
-            $component: {
-                borderRadius: '0.25rem',
-                backgroundColor: '#e8f5e9',
-                color: '#2e7d32',
-            },
+            borderRadius: '0.25rem',
+            backgroundColor: '#e8f5e9',
+            color: '#2e7d32',
             $icon: {
                 color: '#2e7d32',
             },

--- a/packages/vlossom/src/components/vs-chip/VsChip.vue
+++ b/packages/vlossom/src/components/vs-chip/VsChip.vue
@@ -1,7 +1,7 @@
 <template>
     <div
         :class="['vs-chip', 'vs-inline-gap', colorSchemeClass, classObj]"
-        :style="{ ...styleSetVariables, ...componentStyleSet.$component }"
+        :style="{ ...styleSetVariables, ...componentInlineStyle }"
     >
         <span v-if="!!$slots.icon" class="vs-chip-icon" :style="componentStyleSet.$icon">
             <slot name="icon" />
@@ -53,7 +53,10 @@ export default defineComponent({
 
         const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { componentStyleSet, styleSetVariables } = useStyleSet<VsChipStyleSet>(componentName, styleSet);
+        const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet<VsChipStyleSet>(
+            componentName,
+            styleSet,
+        );
 
         const sizeClass = computed(() => (size.value ? `vs-${size.value}` : ''));
 
@@ -67,6 +70,7 @@ export default defineComponent({
             colorSchemeClass,
             componentStyleSet,
             styleSetVariables,
+            componentInlineStyle,
             classObj,
             closeIcon,
         };

--- a/packages/vlossom/src/components/vs-chip/__stories__/vs-chip.stories.ts
+++ b/packages/vlossom/src/components/vs-chip/__stories__/vs-chip.stories.ts
@@ -19,14 +19,12 @@ const meta: Meta<typeof VsChip> = {
         setup() {
             const preDefinedStyleSet: VsChipStyleSet = {
                 $height: '2rem',
-                $component: {
-                    backgroundColor: '#e3f2fd',
-                    border: '1px solid #2196f3',
-                    borderRadius: '16px',
-                    color: '#1976d2',
-                    padding: '0 0.75rem',
-                    width: 'auto',
-                },
+                backgroundColor: '#e3f2fd',
+                border: '1px solid #2196f3',
+                borderRadius: '16px',
+                color: '#1976d2',
+                padding: '0 0.75rem',
+                width: 'auto',
             } as const;
 
             useVlossom().styleSet = {
@@ -201,15 +199,13 @@ export const StyleSet: Story = {
     args: {
         styleSet: {
             $height: '2.5rem',
-            $component: {
-                backgroundColor: '#f3e5f5',
-                border: '2px solid #9c27b0',
-                borderRadius: '20px',
-                color: '#7b1fa2',
-                opacity: 0.8,
-                padding: '0 1rem',
-                width: 'auto',
-            },
+            backgroundColor: '#f3e5f5',
+            border: '2px solid #9c27b0',
+            borderRadius: '20px',
+            color: '#7b1fa2',
+            opacity: 0.8,
+            padding: '0 1rem',
+            width: 'auto',
         },
     },
 };

--- a/packages/vlossom/src/components/vs-chip/types.ts
+++ b/packages/vlossom/src/components/vs-chip/types.ts
@@ -11,9 +11,8 @@ export type { VsChip };
 
 export interface VsChipRef extends ComponentPublicInstance<typeof VsChip> {}
 
-export interface VsChipStyleSet {
+export interface VsChipStyleSet extends CSSProperties {
     $height?: string;
-    $component?: CSSProperties;
     $icon?: CSSProperties;
     $closeButton?: CSSProperties;
 }

--- a/packages/vlossom/src/components/vs-dimmed/README.ko.md
+++ b/packages/vlossom/src/components/vs-dimmed/README.ko.md
@@ -57,9 +57,7 @@ const dimmedRef = ref(null);
 ## Types
 
 ```typescript
-interface VsDimmedStyleSet {
-    $component?: CSSProperties;
-}
+interface VsDimmedStyleSet extends CSSProperties {}
 ```
 
 ### StyleSet 사용 예시
@@ -69,11 +67,9 @@ interface VsDimmedStyleSet {
     <vs-dimmed
         v-model="isVisible"
         :style-set="{
-            $component: {
-                backgroundColor: '#000000',
-                opacity: 0.6,
-                backdropFilter: 'blur(4px)',
-            },
+            backgroundColor: '#000000',
+            opacity: 0.6,
+            backdropFilter: 'blur(4px)',
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-dimmed/README.md
+++ b/packages/vlossom/src/components/vs-dimmed/README.md
@@ -57,9 +57,7 @@ const dimmedRef = ref(null);
 ## Types
 
 ```typescript
-interface VsDimmedStyleSet {
-    $component?: CSSProperties;
-}
+interface VsDimmedStyleSet extends CSSProperties {}
 ```
 
 ### StyleSet Example
@@ -69,11 +67,9 @@ interface VsDimmedStyleSet {
     <vs-dimmed
         v-model="isVisible"
         :style-set="{
-            $component: {
-                backgroundColor: '#000000',
-                opacity: 0.6,
-                backdropFilter: 'blur(4px)',
-            },
+            backgroundColor: '#000000',
+            opacity: 0.6,
+            backdropFilter: 'blur(4px)',
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-dimmed/VsDimmed.vue
+++ b/packages/vlossom/src/components/vs-dimmed/VsDimmed.vue
@@ -3,7 +3,7 @@
         <div
             v-if="isShow"
             class="vs-dimmed"
-            :style="componentStyleSet.$component"
+            :style="componentInlineStyle"
             aria-hidden="true"
         />
     </Transition>
@@ -33,7 +33,7 @@ export default defineComponent({
 
         const isShow = ref(modelValue.value);
 
-        const { componentStyleSet } = useStyleSet<VsDimmedStyleSet>(componentName, styleSet);
+        const { componentStyleSet, componentInlineStyle } = useStyleSet<VsDimmedStyleSet>(componentName, styleSet);
 
         function show() {
             isShow.value = true;
@@ -54,6 +54,7 @@ export default defineComponent({
         return {
             isShow,
             componentStyleSet,
+            componentInlineStyle,
             show,
             hide,
         };

--- a/packages/vlossom/src/components/vs-dimmed/VsDimmed.vue
+++ b/packages/vlossom/src/components/vs-dimmed/VsDimmed.vue
@@ -1,11 +1,6 @@
 <template>
     <Transition name="dimmed">
-        <div
-            v-if="isShow"
-            class="vs-dimmed"
-            :style="componentInlineStyle"
-            aria-hidden="true"
-        />
+        <div v-if="isShow" class="vs-dimmed" :style="componentInlineStyle" aria-hidden="true" />
     </Transition>
 </template>
 
@@ -33,7 +28,7 @@ export default defineComponent({
 
         const isShow = ref(modelValue.value);
 
-        const { componentStyleSet, componentInlineStyle } = useStyleSet<VsDimmedStyleSet>(componentName, styleSet);
+        const { componentInlineStyle } = useStyleSet<VsDimmedStyleSet>(componentName, styleSet);
 
         function show() {
             isShow.value = true;
@@ -53,7 +48,6 @@ export default defineComponent({
 
         return {
             isShow,
-            componentStyleSet,
             componentInlineStyle,
             show,
             hide,

--- a/packages/vlossom/src/components/vs-dimmed/__stories__/vs-dimmed.stories.ts
+++ b/packages/vlossom/src/components/vs-dimmed/__stories__/vs-dimmed.stories.ts
@@ -73,10 +73,8 @@ export const StyleSet: Story = {
     args: {
         modelValue: true,
         styleSet: {
-            $component: {
-                backgroundColor: 'rgba(255, 0, 0, 1)',
-                opacity: 0.5,
-            },
+            backgroundColor: 'rgba(255, 0, 0, 1)',
+            opacity: 0.5,
         },
     },
     render: (args: any) => ({
@@ -102,10 +100,8 @@ export const PreDefinedStyleSet: Story = {
         components: { VsDimmed },
         setup() {
             const preDefinedStyleSet: VsDimmedStyleSet = {
-                $component: {
-                    backgroundColor: 'rgba(0, 255, 0, 1)',
-                    opacity: 0.6,
-                },
+                backgroundColor: 'rgba(0, 255, 0, 1)',
+                opacity: 0.6,
             };
 
             useVlossom().styleSet = {

--- a/packages/vlossom/src/components/vs-dimmed/types.ts
+++ b/packages/vlossom/src/components/vs-dimmed/types.ts
@@ -14,6 +14,4 @@ export interface VsDimmedRef extends ComponentPublicInstance<typeof VsDimmed> {
     hide: () => void;
 }
 
-export interface VsDimmedStyleSet {
-    $component?: CSSProperties;
-}
+export interface VsDimmedStyleSet extends CSSProperties {}

--- a/packages/vlossom/src/components/vs-divider/README.ko.md
+++ b/packages/vlossom/src/components/vs-divider/README.ko.md
@@ -59,14 +59,13 @@
 ## Types
 
 ```typescript
-interface VsDividerStyleSet {
+interface VsDividerStyleSet extends CSSProperties {
     $border?: string;
     $horizontalWidth?: string;
     $horizontalMargin?: string;
     $verticalHeight?: string;
     $verticalMargin?: string;
 
-    $component?: CSSProperties;
 }
 ```
 

--- a/packages/vlossom/src/components/vs-divider/README.md
+++ b/packages/vlossom/src/components/vs-divider/README.md
@@ -59,14 +59,13 @@ A horizontal or vertical line separator used to visually divide content sections
 ## Types
 
 ```typescript
-interface VsDividerStyleSet {
+interface VsDividerStyleSet extends CSSProperties {
     $border?: string;
     $horizontalWidth?: string;
     $horizontalMargin?: string;
     $verticalHeight?: string;
     $verticalMargin?: string;
 
-    $component?: CSSProperties;
 }
 ```
 

--- a/packages/vlossom/src/components/vs-divider/VsDivider.vue
+++ b/packages/vlossom/src/components/vs-divider/VsDivider.vue
@@ -27,10 +27,7 @@ export default defineComponent({
 
         const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet<VsDividerStyleSet>(
-            componentName,
-            styleSet,
-        );
+        const { styleSetVariables, componentInlineStyle } = useStyleSet<VsDividerStyleSet>(componentName, styleSet);
 
         const classObj = computed(() => ({
             'vs-vertical': vertical.value,
@@ -39,7 +36,6 @@ export default defineComponent({
 
         return {
             colorSchemeClass,
-            componentStyleSet,
             styleSetVariables,
             componentInlineStyle,
             classObj,

--- a/packages/vlossom/src/components/vs-divider/VsDivider.vue
+++ b/packages/vlossom/src/components/vs-divider/VsDivider.vue
@@ -1,7 +1,7 @@
 <template>
     <div
         :class="['vs-divider', colorSchemeClass, classObj]"
-        :style="{ ...styleSetVariables, ...componentStyleSet.$component }"
+        :style="{ ...styleSetVariables, ...componentInlineStyle }"
     />
 </template>
 
@@ -27,7 +27,10 @@ export default defineComponent({
 
         const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { componentStyleSet, styleSetVariables } = useStyleSet<VsDividerStyleSet>(componentName, styleSet);
+        const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet<VsDividerStyleSet>(
+            componentName,
+            styleSet,
+        );
 
         const classObj = computed(() => ({
             'vs-vertical': vertical.value,
@@ -38,6 +41,7 @@ export default defineComponent({
             colorSchemeClass,
             componentStyleSet,
             styleSetVariables,
+            componentInlineStyle,
             classObj,
         };
     },

--- a/packages/vlossom/src/components/vs-divider/types.ts
+++ b/packages/vlossom/src/components/vs-divider/types.ts
@@ -11,12 +11,10 @@ export type { VsDivider };
 
 export interface VsDividerRef extends ComponentPublicInstance<typeof VsDivider> {}
 
-export interface VsDividerStyleSet {
+export interface VsDividerStyleSet extends CSSProperties {
     $border?: string;
     $horizontalWidth?: string;
     $horizontalMargin?: string;
     $verticalHeight?: string;
     $verticalMargin?: string;
-
-    $component?: CSSProperties;
 }

--- a/packages/vlossom/src/components/vs-drawer/README.ko.md
+++ b/packages/vlossom/src/components/vs-drawer/README.ko.md
@@ -100,9 +100,8 @@ const drawerOpen = ref(false);
 ## 타입
 
 ```typescript
-interface VsDrawerStyleSet {
+interface VsDrawerStyleSet extends CSSProperties {
     $size?: string;
-    $component?: CSSProperties;
     $dimmed?: VsDimmedStyleSet;
     $header?: CSSProperties;
     $content?: CSSProperties;
@@ -121,7 +120,7 @@ interface VsDrawerStyleSet {
         v-model="open"
         :style-set="{
             $size: '400px',
-            $component: { backgroundColor: '#1a1a2e' },
+            backgroundColor: '#1a1a2e',
             $header: { padding: '1.5rem', borderBottom: '1px solid #eee' },
             $content: { padding: '1.5rem' },
             $footer: { padding: '1rem', borderTop: '1px solid #eee' },

--- a/packages/vlossom/src/components/vs-drawer/README.md
+++ b/packages/vlossom/src/components/vs-drawer/README.md
@@ -100,9 +100,8 @@ Set the `layout` prop to register the drawer with the layout store. Combine with
 ## Types
 
 ```typescript
-interface VsDrawerStyleSet {
+interface VsDrawerStyleSet extends CSSProperties {
     $size?: string;
-    $component?: CSSProperties;
     $dimmed?: VsDimmedStyleSet;
     $header?: CSSProperties;
     $content?: CSSProperties;
@@ -121,7 +120,7 @@ interface VsDrawerStyleSet {
         v-model="open"
         :style-set="{
             $size: '400px',
-            $component: { backgroundColor: '#1a1a2e' },
+            backgroundColor: '#1a1a2e',
             $header: { padding: '1.5rem', borderBottom: '1px solid #eee' },
             $content: { padding: '1.5rem' },
             $footer: { padding: '1rem', borderTop: '1px solid #eee' },

--- a/packages/vlossom/src/components/vs-drawer/VsDrawer.vue
+++ b/packages/vlossom/src/components/vs-drawer/VsDrawer.vue
@@ -4,7 +4,7 @@
             v-show="isOpen"
             ref="drawerRef"
             :class="['vs-drawer', colorSchemeClass, { 'vs-drawer-dimmed': dimmed }]"
-            :style="{ ...styleSetVariables, ...componentStyleSet.$component }"
+            :style="{ ...styleSetVariables, ...componentInlineStyle }"
         >
             <vs-dimmed
                 v-if="dimmed"
@@ -140,13 +140,11 @@ export default defineComponent({
         const additionalStyleSet: ComputedRef<Partial<VsDrawerStyleSet>> = computed(() => {
             return objectUtil.shake({
                 $size: drawerSize.value,
-                $component: objectUtil.shake({
-                    position: fixed.value ? 'fixed' : undefined,
-                }),
+                position: fixed.value ? 'fixed' : undefined,
             });
         });
 
-        const { styleSetVariables, componentStyleSet } = useStyleSet<VsDrawerStyleSet>(
+        const { styleSetVariables, componentStyleSet, componentInlineStyle } = useStyleSet<VsDrawerStyleSet>(
             componentName,
             styleSet,
             baseStyleSet,
@@ -264,6 +262,7 @@ export default defineComponent({
             colorSchemeClass,
             componentStyleSet,
             styleSetVariables,
+            componentInlineStyle,
             isOpen,
             ANIMATION_DURATION,
             onClickDimmed,

--- a/packages/vlossom/src/components/vs-drawer/__tests__/vs-drawer.test.ts
+++ b/packages/vlossom/src/components/vs-drawer/__tests__/vs-drawer.test.ts
@@ -212,7 +212,7 @@ describe('VsDrawer', () => {
             expect(wrapper.vm.styleSetVariables).toEqual({
                 '--vs-drawer-size': '20%',
             });
-            expect(wrapper.vm.componentStyleSet.$component?.position).toBe('fixed');
+            expect(wrapper.vm.componentStyleSet.position).toBe('fixed');
         });
     });
 

--- a/packages/vlossom/src/components/vs-drawer/types.ts
+++ b/packages/vlossom/src/components/vs-drawer/types.ts
@@ -15,9 +15,8 @@ export interface VsDrawerRef extends ComponentPublicInstance<typeof VsDrawer> {
     closeDrawer: () => void;
 }
 
-export interface VsDrawerStyleSet {
+export interface VsDrawerStyleSet extends CSSProperties {
     $size?: string;
-    $component?: CSSProperties;
     $dimmed?: VsDimmedStyleSet;
     $header?: CSSProperties;
     $content?: CSSProperties;

--- a/packages/vlossom/src/components/vs-expandable/README.ko.md
+++ b/packages/vlossom/src/components/vs-expandable/README.ko.md
@@ -36,7 +36,7 @@ const isOpen = ref(false);
     <vs-expandable
         :open="isOpen"
         :style-set="{
-            $component: { backgroundColor: '#f0f4ff', padding: '1.5rem', borderRadius: '8px' },
+            backgroundColor: '#f0f4ff', padding: '1.5rem', borderRadius: '8px',
         }"
     >
         <p>스타일이 적용된 확장 가능한 콘텐츠.</p>
@@ -54,9 +54,7 @@ const isOpen = ref(false);
 ## 타입
 
 ```typescript
-interface VsExpandableStyleSet {
-    $component?: CSSProperties;
-}
+interface VsExpandableStyleSet extends CSSProperties {}
 ```
 
 ### StyleSet 예시
@@ -66,7 +64,7 @@ interface VsExpandableStyleSet {
     <vs-expandable
         :open="true"
         :style-set="{
-            $component: { backgroundColor: '#fff8e1', padding: '2rem', borderLeft: '4px solid orange' },
+            backgroundColor: '#fff8e1', padding: '2rem', borderLeft: '4px solid orange',
         }"
     >
         <p>강조된 확장 가능한 콘텐츠.</p>

--- a/packages/vlossom/src/components/vs-expandable/README.md
+++ b/packages/vlossom/src/components/vs-expandable/README.md
@@ -36,7 +36,7 @@ const isOpen = ref(false);
     <vs-expandable
         :open="isOpen"
         :style-set="{
-            $component: { backgroundColor: '#f0f4ff', padding: '1.5rem', borderRadius: '8px' },
+            backgroundColor: '#f0f4ff', padding: '1.5rem', borderRadius: '8px',
         }"
     >
         <p>Styled expandable content.</p>
@@ -54,9 +54,7 @@ const isOpen = ref(false);
 ## Types
 
 ```typescript
-interface VsExpandableStyleSet {
-    $component?: CSSProperties;
-}
+interface VsExpandableStyleSet extends CSSProperties {}
 ```
 
 ### StyleSet Example
@@ -66,7 +64,7 @@ interface VsExpandableStyleSet {
     <vs-expandable
         :open="true"
         :style-set="{
-            $component: { backgroundColor: '#fff8e1', padding: '2rem', borderLeft: '4px solid orange' },
+            backgroundColor: '#fff8e1', padding: '2rem', borderLeft: '4px solid orange',
         }"
     >
         <p>Highlighted expandable content.</p>

--- a/packages/vlossom/src/components/vs-expandable/VsExpandable.vue
+++ b/packages/vlossom/src/components/vs-expandable/VsExpandable.vue
@@ -1,7 +1,7 @@
 <template>
     <Transition name="vs-expand" @before-enter="beforeEnter" @enter="enter" @before-leave="beforeLeave" @leave="leave">
         <div v-if="open" class="vs-expandable-wrapper">
-            <div class="vs-expandable-content" :style="componentStyleSet.$component">
+            <div class="vs-expandable-content" :style="componentInlineStyle">
                 <slot />
             </div>
         </div>
@@ -26,7 +26,7 @@ export default defineComponent({
     setup(props) {
         const { styleSet } = toRefs(props);
 
-        const { componentStyleSet } = useStyleSet<VsExpandableStyleSet>(componentName, styleSet);
+        const { componentStyleSet, componentInlineStyle } = useStyleSet<VsExpandableStyleSet>(componentName, styleSet);
 
         function beforeEnter(el: Element) {
             const element = el as HTMLElement;
@@ -85,6 +85,7 @@ export default defineComponent({
 
         return {
             componentStyleSet,
+            componentInlineStyle,
             beforeEnter,
             enter,
             beforeLeave,

--- a/packages/vlossom/src/components/vs-expandable/VsExpandable.vue
+++ b/packages/vlossom/src/components/vs-expandable/VsExpandable.vue
@@ -26,7 +26,7 @@ export default defineComponent({
     setup(props) {
         const { styleSet } = toRefs(props);
 
-        const { componentStyleSet, componentInlineStyle } = useStyleSet<VsExpandableStyleSet>(componentName, styleSet);
+        const { componentInlineStyle } = useStyleSet<VsExpandableStyleSet>(componentName, styleSet);
 
         function beforeEnter(el: Element) {
             const element = el as HTMLElement;
@@ -84,7 +84,6 @@ export default defineComponent({
         }
 
         return {
-            componentStyleSet,
             componentInlineStyle,
             beforeEnter,
             enter,

--- a/packages/vlossom/src/components/vs-expandable/types.ts
+++ b/packages/vlossom/src/components/vs-expandable/types.ts
@@ -11,6 +11,4 @@ export type { VsExpandable };
 
 export interface VsExpandableRef extends ComponentPublicInstance<typeof VsExpandable> {}
 
-export interface VsExpandableStyleSet {
-    $component?: CSSProperties;
-}
+export interface VsExpandableStyleSet extends CSSProperties {}

--- a/packages/vlossom/src/components/vs-file-drop/README.ko.md
+++ b/packages/vlossom/src/components/vs-file-drop/README.ko.md
@@ -95,10 +95,9 @@ const files = ref([]);
 ## 타입
 
 ```typescript
-interface VsFileDropStyleSet {
+interface VsFileDropStyleSet extends CSSProperties {
     $dragBackgroundColor?: string;
     $iconColor?: string;
-    $component?: CSSProperties;
     $placeholder?: CSSProperties;
     $files?: CSSProperties;
     $closeButton?: CSSProperties;
@@ -120,7 +119,7 @@ interface VsFileDropStyleSet {
         :style-set="{
             $dragBackgroundColor: '#e8f4fd',
             $iconColor: '#0066cc',
-            $component: { borderRadius: '12px' },
+            borderRadius: '12px',
             $placeholder: { color: '#666' },
         }"
     />

--- a/packages/vlossom/src/components/vs-file-drop/README.md
+++ b/packages/vlossom/src/components/vs-file-drop/README.md
@@ -95,10 +95,9 @@ const files = ref([]);
 ## Types
 
 ```typescript
-interface VsFileDropStyleSet {
+interface VsFileDropStyleSet extends CSSProperties {
     $dragBackgroundColor?: string;
     $iconColor?: string;
-    $component?: CSSProperties;
     $placeholder?: CSSProperties;
     $files?: CSSProperties;
     $closeButton?: CSSProperties;
@@ -120,7 +119,7 @@ interface VsFileDropStyleSet {
         :style-set="{
             $dragBackgroundColor: '#e8f4fd',
             $iconColor: '#0066cc',
-            $component: { borderRadius: '12px' },
+            borderRadius: '12px',
             $placeholder: { color: '#666' },
         }"
     />

--- a/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
+++ b/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
@@ -20,7 +20,7 @@
 
         <div
             :class="['vs-file-drop', colorSchemeClass, classObj, stateBoxClasses]"
-            :style="{ ...styleSetVariables, ...componentStyleSet.$component }"
+            :style="{ ...styleSetVariables, ...componentInlineStyle }"
             @drop.prevent.stop="handleFileDrop"
             @dragenter.prevent.stop="setDragging(true)"
             @dragover.prevent.stop="setDragging(true)"
@@ -164,22 +164,18 @@ export default defineComponent({
 
         const baseStyleSet: Ref<VsFileDropStyleSet> = ref({
             $chip: {
-                $component: {
-                    width: '100%',
-                },
+                width: '100%',
             },
         });
 
         const additionalStyleSet = computed<Partial<VsFileDropStyleSet>>(() => {
             return objectUtil.shake({
-                $component: objectUtil.shake({
-                    width: width.value,
-                    height: height.value,
-                }),
+                width: width.value,
+                height: height.value,
             });
         });
 
-        const { componentStyleSet, styleSetVariables } = useStyleSet<VsFileDropStyleSet>(
+        const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet<VsFileDropStyleSet>(
             componentName,
             styleSet,
             baseStyleSet,
@@ -375,6 +371,7 @@ export default defineComponent({
             colorSchemeClass,
             componentStyleSet,
             styleSetVariables,
+            componentInlineStyle,
             classObj,
             stateBoxClasses,
             dragging,

--- a/packages/vlossom/src/components/vs-file-drop/__stories__/vs-file-drop.stories.ts
+++ b/packages/vlossom/src/components/vs-file-drop/__stories__/vs-file-drop.stories.ts
@@ -33,10 +33,8 @@ const meta: Meta<typeof VsFileDrop> = {
 
             const preDefinedStyleSet: VsFileDropStyleSet = {
                 $dragBackgroundColor: '#e3f2fd',
-                $component: {
-                    border: '2px dashed #1e88e5',
-                    borderRadius: '12px',
-                },
+                border: '2px dashed #1e88e5',
+                borderRadius: '12px',
                 $files: {
                     padding: '2rem',
                 },
@@ -434,11 +432,9 @@ export const StyleSet: Story = {
         placeholder: '커스텀 파일 드롭',
         styleSet: {
             $dragBackgroundColor: '#ffccbc',
-            $component: {
-                border: '2px dashed #ff5722',
-                borderRadius: '16px',
-                backgroundColor: '#ffebee',
-            },
+            border: '2px dashed #ff5722',
+            borderRadius: '16px',
+            backgroundColor: '#ffebee',
             $files: {
                 padding: '2rem',
             },

--- a/packages/vlossom/src/components/vs-file-drop/types.ts
+++ b/packages/vlossom/src/components/vs-file-drop/types.ts
@@ -16,10 +16,9 @@ export interface VsFileDropRef extends ComponentPublicInstance<typeof VsFileDrop
 
 export type FileDropValueType = File[];
 
-export interface VsFileDropStyleSet {
+export interface VsFileDropStyleSet extends CSSProperties {
     $dragBackgroundColor?: string;
     $iconColor?: string;
-    $component?: CSSProperties;
     $placeholder?: CSSProperties;
     $files?: CSSProperties;
     $closeButton?: CSSProperties;

--- a/packages/vlossom/src/components/vs-footer/README.ko.md
+++ b/packages/vlossom/src/components/vs-footer/README.ko.md
@@ -78,9 +78,7 @@
 interface VsFooterStyleSet extends VsBarStyleSet {}
 
 // VsBarStyleSet:
-interface VsBarStyleSet {
-    $component?: CSSProperties;
-}
+interface VsBarStyleSet extends CSSProperties {}
 ```
 
 > [!NOTE]
@@ -92,12 +90,10 @@ interface VsBarStyleSet {
 <template>
     <vs-footer
         :style-set="{
-            $component: {
-                backgroundColor: '#1a1a2e',
-                color: '#ffffff',
-                padding: '0 2rem',
-                height: '4rem',
-            },
+            backgroundColor: '#1a1a2e',
+            color: '#ffffff',
+            padding: '0 2rem',
+            height: '4rem',
         }"
     >
         <span>사용자 정의 스타일 푸터</span>

--- a/packages/vlossom/src/components/vs-footer/README.md
+++ b/packages/vlossom/src/components/vs-footer/README.md
@@ -78,9 +78,7 @@ Set the `layout` prop to register the footer with the layout store so `VsContain
 interface VsFooterStyleSet extends VsBarStyleSet {}
 
 // VsBarStyleSet:
-interface VsBarStyleSet {
-    $component?: CSSProperties;
-}
+interface VsBarStyleSet extends CSSProperties {}
 ```
 
 > [!NOTE]
@@ -92,12 +90,10 @@ interface VsBarStyleSet {
 <template>
     <vs-footer
         :style-set="{
-            $component: {
-                backgroundColor: '#1a1a2e',
-                color: '#ffffff',
-                padding: '0 2rem',
-                height: '4rem',
-            },
+            backgroundColor: '#1a1a2e',
+            color: '#ffffff',
+            padding: '0 2rem',
+            height: '4rem',
         }"
     >
         <span>Custom styled footer</span>

--- a/packages/vlossom/src/components/vs-footer/VsFooter.vue
+++ b/packages/vlossom/src/components/vs-footer/VsFooter.vue
@@ -36,20 +36,16 @@ export default defineComponent({
         const isPositioned = computed(() => position.value && ['absolute', 'fixed', 'sticky'].includes(position.value));
 
         const baseStyleSet: ComputedRef<VsFooterStyleSet> = computed(() => ({
-            $component: {
-                height: '3rem',
-                zIndex: 'var(--vs-bar-z-index)',
-                bottom: 0,
-                left: 0,
-            },
+            height: '3rem',
+            zIndex: 'var(--vs-bar-z-index)',
+            bottom: 0,
+            left: 0,
         }));
         const additionalStyleSet: ComputedRef<Partial<VsFooterStyleSet>> = computed(() => {
             return objectUtil.shake({
-                $component: objectUtil.shake({
-                    height: height.value || undefined,
-                    position: position.value || undefined,
-                    ...(isPositioned.value ? {} : { bottom: 0, left: 0 }),
-                }),
+                height: height.value || undefined,
+                position: position.value || undefined,
+                ...(isPositioned.value ? {} : { bottom: 0, left: 0 }),
             });
         });
         const { componentStyleSet } = useStyleSet<VsFooterStyleSet>(
@@ -72,7 +68,7 @@ export default defineComponent({
             }
             const footerLayout: BarLayout = {
                 position: position.value || 'relative',
-                height: (componentStyleSet.value.$component?.height as string) || '3rem',
+                height: (componentStyleSet.value.height as string) || '3rem',
             };
             layoutStore.setFooter(footerLayout);
         });

--- a/packages/vlossom/src/components/vs-footer/__stories__/vs-footer.stories.ts
+++ b/packages/vlossom/src/components/vs-footer/__stories__/vs-footer.stories.ts
@@ -19,16 +19,14 @@ const meta: Meta<typeof VsFooter> = {
         components: { VsFooter },
         setup() {
             const preDefinedStyleSet: VsFooterStyleSet = {
-                $component: {
-                    backgroundColor: '#1976d2',
-                    border: '1px solid #1976d2',
-                    borderRadius: '0',
-                    color: '#fff',
-                    height: '4rem',
-                    padding: '0 1.5rem',
-                    width: '100%',
-                    zIndex: 'var(--vs-bar-z-index)',
-                },
+                backgroundColor: '#1976d2',
+                border: '1px solid #1976d2',
+                borderRadius: '0',
+                color: '#fff',
+                height: '4rem',
+                padding: '0 1.5rem',
+                width: '100%',
+                zIndex: 'var(--vs-bar-z-index)',
             };
 
             useVlossom().styleSet = {
@@ -105,9 +103,7 @@ export const ColorScheme: Story = {
         components: { VsFooter },
         setup() {
             const styleSet = {
-                $component: {
-                    padding: '0.5rem',
-                },
+                padding: '0.5rem',
             };
             return { args, styleSet };
         },
@@ -145,16 +141,14 @@ export const StyleSet: Story = {
     }),
     args: {
         styleSet: {
-            $component: {
-                backgroundColor: '#e188e5',
-                border: '2px solid #e188e5',
-                borderRadius: '8px',
-                color: '#fff',
-                height: '5rem',
-                padding: '0 2rem',
-                width: '100%',
-                zIndex: 'var(--vs-bar-z-index)',
-            },
+            backgroundColor: '#e188e5',
+            border: '2px solid #e188e5',
+            borderRadius: '8px',
+            color: '#fff',
+            height: '5rem',
+            padding: '0 2rem',
+            width: '100%',
+            zIndex: 'var(--vs-bar-z-index)',
         },
     },
 };

--- a/packages/vlossom/src/components/vs-footer/__tests__/vs-footer.test.ts
+++ b/packages/vlossom/src/components/vs-footer/__tests__/vs-footer.test.ts
@@ -67,7 +67,7 @@ describe('VsFooter', () => {
             });
 
             // then
-            expect(wrapper.vm.componentStyleSet.$component?.height).toBe('4rem');
+            expect(wrapper.vm.componentStyleSet.height).toBe('4rem');
         });
 
         it('position prop이 absolute로 설정되면 positioned 상태가 되어야 한다', () => {
@@ -80,9 +80,9 @@ describe('VsFooter', () => {
 
             // then
             expect(wrapper.props('position')).toBe('absolute');
-            expect(wrapper.vm.componentStyleSet.$component?.position).toBe('absolute');
-            expect(wrapper.vm.componentStyleSet.$component?.bottom).toBe(0);
-            expect(wrapper.vm.componentStyleSet.$component?.left).toBe(0);
+            expect(wrapper.vm.componentStyleSet.position).toBe('absolute');
+            expect(wrapper.vm.componentStyleSet.bottom).toBe(0);
+            expect(wrapper.vm.componentStyleSet.left).toBe(0);
         });
 
         it('position prop이 fixed로 설정되면 positioned 상태가 되어야 한다', () => {
@@ -95,9 +95,9 @@ describe('VsFooter', () => {
 
             // then
             expect(wrapper.props('position')).toBe('fixed');
-            expect(wrapper.vm.componentStyleSet.$component?.position).toBe('fixed');
-            expect(wrapper.vm.componentStyleSet.$component?.bottom).toBe(0);
-            expect(wrapper.vm.componentStyleSet.$component?.left).toBe(0);
+            expect(wrapper.vm.componentStyleSet.position).toBe('fixed');
+            expect(wrapper.vm.componentStyleSet.bottom).toBe(0);
+            expect(wrapper.vm.componentStyleSet.left).toBe(0);
         });
 
         it('position prop이 sticky로 설정되면 positioned 상태가 되어야 한다', () => {
@@ -110,9 +110,9 @@ describe('VsFooter', () => {
 
             // then
             expect(wrapper.props('position')).toBe('sticky');
-            expect(wrapper.vm.componentStyleSet.$component?.position).toBe('sticky');
-            expect(wrapper.vm.componentStyleSet.$component?.bottom).toBe(0);
-            expect(wrapper.vm.componentStyleSet.$component?.left).toBe(0);
+            expect(wrapper.vm.componentStyleSet.position).toBe('sticky');
+            expect(wrapper.vm.componentStyleSet.bottom).toBe(0);
+            expect(wrapper.vm.componentStyleSet.left).toBe(0);
         });
 
         it('position과 height가 모두 주어지면 positioned 상태에서 height가 적용되어야 한다', () => {
@@ -126,9 +126,9 @@ describe('VsFooter', () => {
 
             // then
             expect(wrapper.props('position')).toBe('absolute');
-            expect(wrapper.vm.componentStyleSet.$component?.height).toBe('5rem');
-            expect(wrapper.vm.componentStyleSet.$component?.bottom).toBe(0);
-            expect(wrapper.vm.componentStyleSet.$component?.left).toBe(0);
+            expect(wrapper.vm.componentStyleSet.height).toBe('5rem');
+            expect(wrapper.vm.componentStyleSet.bottom).toBe(0);
+            expect(wrapper.vm.componentStyleSet.left).toBe(0);
         });
 
         it('position이 relative일 때도 height가 적용되어야 한다', () => {
@@ -142,7 +142,7 @@ describe('VsFooter', () => {
 
             // then
             expect(wrapper.props('position')).toBe('relative');
-            expect(wrapper.vm.componentStyleSet.$component?.height).toBe('6rem');
+            expect(wrapper.vm.componentStyleSet.height).toBe('6rem');
         });
 
         it('position이 없어도 height가 적용되어야 한다', () => {
@@ -155,7 +155,7 @@ describe('VsFooter', () => {
 
             // then
             expect(wrapper.props('position')).toBeUndefined();
-            expect(wrapper.vm.componentStyleSet.$component?.height).toBe('7rem');
+            expect(wrapper.vm.componentStyleSet.height).toBe('7rem');
         });
     });
 

--- a/packages/vlossom/src/components/vs-grid/README.ko.md
+++ b/packages/vlossom/src/components/vs-grid/README.ko.md
@@ -63,8 +63,7 @@
 ## 타입
 
 ```typescript
-interface VsGridStyleSet {
-    $component?: CSSProperties;
+interface VsGridStyleSet extends CSSProperties {
     $gridSize?: number;
 }
 ```
@@ -76,7 +75,7 @@ interface VsGridStyleSet {
     <vs-grid
         :style-set="{
             $gridSize: 6,
-            $component: { backgroundColor: '#f5f5f5', padding: '1rem', borderRadius: '8px' },
+            backgroundColor: '#f5f5f5', padding: '1rem', borderRadius: '8px',
         }"
     >
         <div>항목 1</div>

--- a/packages/vlossom/src/components/vs-grid/README.md
+++ b/packages/vlossom/src/components/vs-grid/README.md
@@ -63,8 +63,7 @@ A responsive CSS grid container that supports a configurable number of columns, 
 ## Types
 
 ```typescript
-interface VsGridStyleSet {
-    $component?: CSSProperties;
+interface VsGridStyleSet extends CSSProperties {
     $gridSize?: number;
 }
 ```
@@ -76,7 +75,7 @@ interface VsGridStyleSet {
     <vs-grid
         :style-set="{
             $gridSize: 6,
-            $component: { backgroundColor: '#f5f5f5', padding: '1rem', borderRadius: '8px' },
+            backgroundColor: '#f5f5f5', padding: '1rem', borderRadius: '8px',
         }"
     >
         <div>Item 1</div>

--- a/packages/vlossom/src/components/vs-grid/VsGrid.vue
+++ b/packages/vlossom/src/components/vs-grid/VsGrid.vue
@@ -1,5 +1,5 @@
 <template>
-    <component :is="tag" class="vs-grid" :style="[componentStyleSet.$component, styleSetVariables]">
+    <component :is="tag" class="vs-grid" :style="[componentInlineStyle, styleSetVariables]">
         <slot />
     </component>
 </template>
@@ -28,17 +28,15 @@ export default defineComponent({
         const baseStyleSet: ComputedRef<VsGridStyleSet> = computed(() => ({}));
         const additionalStyleSet: ComputedRef<Partial<VsGridStyleSet>> = computed(() => {
             return objectUtil.shake({
-                $component: objectUtil.shake({
-                    width: width.value === undefined ? undefined : stringUtil.toStringSize(width.value),
-                    height: height.value === undefined ? undefined : stringUtil.toStringSize(height.value),
-                    columnGap: columnGap.value === undefined ? undefined : stringUtil.toStringSize(columnGap.value),
-                    rowGap: rowGap.value === undefined ? undefined : stringUtil.toStringSize(rowGap.value),
-                }),
+                width: width.value === undefined ? undefined : stringUtil.toStringSize(width.value),
+                height: height.value === undefined ? undefined : stringUtil.toStringSize(height.value),
+                columnGap: columnGap.value === undefined ? undefined : stringUtil.toStringSize(columnGap.value),
+                rowGap: rowGap.value === undefined ? undefined : stringUtil.toStringSize(rowGap.value),
                 $gridSize: gridSize.value === undefined ? undefined : Number(gridSize.value),
             });
         });
 
-        const { componentStyleSet, styleSetVariables } = useStyleSet<VsGridStyleSet>(
+        const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet<VsGridStyleSet>(
             componentName,
             styleSet,
             baseStyleSet,
@@ -48,6 +46,7 @@ export default defineComponent({
         return {
             componentStyleSet,
             styleSetVariables,
+            componentInlineStyle,
         };
     },
 });

--- a/packages/vlossom/src/components/vs-grid/VsGrid.vue
+++ b/packages/vlossom/src/components/vs-grid/VsGrid.vue
@@ -1,5 +1,5 @@
 <template>
-    <component :is="tag" class="vs-grid" :style="[componentInlineStyle, styleSetVariables]">
+    <component :is="tag" class="vs-grid" :style="{ ...styleSetVariables, ...componentInlineStyle }">
         <slot />
     </component>
 </template>
@@ -36,7 +36,7 @@ export default defineComponent({
             });
         });
 
-        const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet<VsGridStyleSet>(
+        const { styleSetVariables, componentInlineStyle } = useStyleSet<VsGridStyleSet>(
             componentName,
             styleSet,
             baseStyleSet,
@@ -44,7 +44,6 @@ export default defineComponent({
         );
 
         return {
-            componentStyleSet,
             styleSetVariables,
             componentInlineStyle,
         };

--- a/packages/vlossom/src/components/vs-grid/__tests__/vs-grid.test.ts
+++ b/packages/vlossom/src/components/vs-grid/__tests__/vs-grid.test.ts
@@ -27,7 +27,7 @@ describe('VsGrid', () => {
             });
 
             // then
-            expect(wrapper.vm.componentStyleSet.$component).toMatchObject({
+            expect(wrapper.vm.componentStyleSet).toMatchObject({
                 width: '600px',
                 height: '500px',
             });
@@ -57,7 +57,7 @@ describe('VsGrid', () => {
             });
 
             // then
-            expect(wrapper.vm.componentStyleSet.$component).toMatchObject({
+            expect(wrapper.vm.componentStyleSet).toMatchObject({
                 columnGap: '20px',
                 rowGap: '25px',
             });

--- a/packages/vlossom/src/components/vs-grid/__tests__/vs-grid.test.ts
+++ b/packages/vlossom/src/components/vs-grid/__tests__/vs-grid.test.ts
@@ -27,7 +27,7 @@ describe('VsGrid', () => {
             });
 
             // then
-            expect(wrapper.vm.componentStyleSet).toMatchObject({
+            expect(wrapper.vm.componentInlineStyle).toMatchObject({
                 width: '600px',
                 height: '500px',
             });
@@ -47,7 +47,7 @@ describe('VsGrid', () => {
             });
         });
 
-        it('columnGap, rowGap이 주어지면 componentStyleSet에 적용되어야 한다', () => {
+        it('columnGap, rowGap이 주어지면 componentInlineStyle에 적용되어야 한다', () => {
             // given, when
             const wrapper = mount(VsGrid, {
                 props: {
@@ -57,7 +57,7 @@ describe('VsGrid', () => {
             });
 
             // then
-            expect(wrapper.vm.componentStyleSet).toMatchObject({
+            expect(wrapper.vm.componentInlineStyle).toMatchObject({
                 columnGap: '20px',
                 rowGap: '25px',
             });

--- a/packages/vlossom/src/components/vs-grid/types.ts
+++ b/packages/vlossom/src/components/vs-grid/types.ts
@@ -11,7 +11,6 @@ export type { VsGrid };
 
 export interface VsGridRef extends ComponentPublicInstance<typeof VsGrid> {}
 
-export interface VsGridStyleSet {
+export interface VsGridStyleSet extends CSSProperties {
     $gridSize?: number;
-    $component?: CSSProperties;
 }

--- a/packages/vlossom/src/components/vs-header/README.ko.md
+++ b/packages/vlossom/src/components/vs-header/README.ko.md
@@ -78,9 +78,7 @@
 interface VsHeaderStyleSet extends VsBarStyleSet {}
 
 // VsBarStyleSet:
-interface VsBarStyleSet {
-    $component?: CSSProperties;
-}
+interface VsBarStyleSet extends CSSProperties {}
 ```
 
 > [!NOTE]
@@ -92,12 +90,10 @@ interface VsBarStyleSet {
 <template>
     <vs-header
         :style-set="{
-            $component: {
-                backgroundColor: '#2c3e50',
-                color: '#ffffff',
-                padding: '0 2rem',
-                boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
-            },
+            backgroundColor: '#2c3e50',
+            color: '#ffffff',
+            padding: '0 2rem',
+            boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
         }"
     >
         <h1>스타일이 적용된 헤더</h1>

--- a/packages/vlossom/src/components/vs-header/README.md
+++ b/packages/vlossom/src/components/vs-header/README.md
@@ -78,9 +78,7 @@ Set the `layout` prop to register the header with the layout store so `VsContain
 interface VsHeaderStyleSet extends VsBarStyleSet {}
 
 // VsBarStyleSet:
-interface VsBarStyleSet {
-    $component?: CSSProperties;
-}
+interface VsBarStyleSet extends CSSProperties {}
 ```
 
 > [!NOTE]
@@ -92,12 +90,10 @@ interface VsBarStyleSet {
 <template>
     <vs-header
         :style-set="{
-            $component: {
-                backgroundColor: '#2c3e50',
-                color: '#ffffff',
-                padding: '0 2rem',
-                boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
-            },
+            backgroundColor: '#2c3e50',
+            color: '#ffffff',
+            padding: '0 2rem',
+            boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
         }"
     >
         <h1>Styled Header</h1>

--- a/packages/vlossom/src/components/vs-header/VsHeader.vue
+++ b/packages/vlossom/src/components/vs-header/VsHeader.vue
@@ -36,20 +36,16 @@ export default defineComponent({
         const isPositioned = computed(() => position.value && ['absolute', 'fixed', 'sticky'].includes(position.value));
 
         const baseStyleSet: ComputedRef<VsHeaderStyleSet> = computed(() => ({
-            $component: {
-                height: '3rem',
-                zIndex: 'var(--vs-bar-z-index)',
-                top: 0,
-                left: 0,
-            },
+            height: '3rem',
+            zIndex: 'var(--vs-bar-z-index)',
+            top: 0,
+            left: 0,
         }));
         const additionalStyleSet: ComputedRef<Partial<VsHeaderStyleSet>> = computed(() => {
             return objectUtil.shake({
-                $component: objectUtil.shake({
-                    height: height.value || undefined,
-                    position: position.value || undefined,
-                    ...(isPositioned.value ? {} : { top: 0, left: 0 }),
-                }),
+                height: height.value || undefined,
+                position: position.value || undefined,
+                ...(isPositioned.value ? {} : { top: 0, left: 0 }),
             });
         });
         const { componentStyleSet } = useStyleSet<VsHeaderStyleSet>(
@@ -72,7 +68,7 @@ export default defineComponent({
             }
             const headerLayout: BarLayout = {
                 position: position.value || 'relative',
-                height: (componentStyleSet.value.$component?.height as string) || '3rem',
+                height: (componentStyleSet.value.height as string) || '3rem',
             };
             layoutStore.setHeader(headerLayout);
         });

--- a/packages/vlossom/src/components/vs-header/__stories__/vs-header.stories.ts
+++ b/packages/vlossom/src/components/vs-header/__stories__/vs-header.stories.ts
@@ -19,16 +19,14 @@ const meta: Meta<typeof VsHeader> = {
         components: { VsHeader },
         setup() {
             const preDefinedStyleSet: VsHeaderStyleSet = {
-                $component: {
-                    backgroundColor: '#1976d2',
-                    border: '1px solid #1976d2',
-                    borderRadius: '0',
-                    color: '#fff',
-                    height: '4rem',
-                    padding: '0 1.5rem',
-                    width: '100%',
-                    zIndex: 'var(--vs-bar-z-index)',
-                },
+                backgroundColor: '#1976d2',
+                border: '1px solid #1976d2',
+                borderRadius: '0',
+                color: '#fff',
+                height: '4rem',
+                padding: '0 1.5rem',
+                width: '100%',
+                zIndex: 'var(--vs-bar-z-index)',
             };
 
             useVlossom().styleSet = {
@@ -105,9 +103,7 @@ export const ColorScheme: Story = {
         components: { VsHeader },
         setup() {
             const styleSet = {
-                $component: {
-                    padding: '0.5rem',
-                },
+                padding: '0.5rem',
             };
             return { args, styleSet };
         },
@@ -145,16 +141,14 @@ export const StyleSet: Story = {
     }),
     args: {
         styleSet: {
-            $component: {
-                backgroundColor: '#e188e5',
-                border: '2px solid #e188e5',
-                borderRadius: '8px',
-                color: '#fff',
-                height: '5rem',
-                padding: '0 2rem',
-                width: '100%',
-                zIndex: 'var(--vs-bar-z-index)',
-            },
+            backgroundColor: '#e188e5',
+            border: '2px solid #e188e5',
+            borderRadius: '8px',
+            color: '#fff',
+            height: '5rem',
+            padding: '0 2rem',
+            width: '100%',
+            zIndex: 'var(--vs-bar-z-index)',
         },
     },
 };

--- a/packages/vlossom/src/components/vs-header/__tests__/vs-header.test.ts
+++ b/packages/vlossom/src/components/vs-header/__tests__/vs-header.test.ts
@@ -67,7 +67,7 @@ describe('VsHeader', () => {
             });
 
             // then
-            expect(wrapper.vm.componentStyleSet.$component?.height).toBe('4rem');
+            expect(wrapper.vm.componentStyleSet.height).toBe('4rem');
         });
 
         it('position prop이 absolute로 설정되면 positioned 상태가 되어야 한다', () => {
@@ -80,9 +80,9 @@ describe('VsHeader', () => {
 
             // then
             expect(wrapper.props('position')).toBe('absolute');
-            expect(wrapper.vm.componentStyleSet.$component?.position).toBe('absolute');
-            expect(wrapper.vm.componentStyleSet.$component?.top).toBe(0);
-            expect(wrapper.vm.componentStyleSet.$component?.left).toBe(0);
+            expect(wrapper.vm.componentStyleSet.position).toBe('absolute');
+            expect(wrapper.vm.componentStyleSet.top).toBe(0);
+            expect(wrapper.vm.componentStyleSet.left).toBe(0);
         });
 
         it('position prop이 fixed로 설정되면 positioned 상태가 되어야 한다', () => {
@@ -95,9 +95,9 @@ describe('VsHeader', () => {
 
             // then
             expect(wrapper.props('position')).toBe('fixed');
-            expect(wrapper.vm.componentStyleSet.$component?.position).toBe('fixed');
-            expect(wrapper.vm.componentStyleSet.$component?.top).toBe(0);
-            expect(wrapper.vm.componentStyleSet.$component?.left).toBe(0);
+            expect(wrapper.vm.componentStyleSet.position).toBe('fixed');
+            expect(wrapper.vm.componentStyleSet.top).toBe(0);
+            expect(wrapper.vm.componentStyleSet.left).toBe(0);
         });
 
         it('position prop이 sticky로 설정되면 positioned 상태가 되어야 한다', () => {
@@ -110,9 +110,9 @@ describe('VsHeader', () => {
 
             // then
             expect(wrapper.props('position')).toBe('sticky');
-            expect(wrapper.vm.componentStyleSet.$component?.position).toBe('sticky');
-            expect(wrapper.vm.componentStyleSet.$component?.top).toBe(0);
-            expect(wrapper.vm.componentStyleSet.$component?.left).toBe(0);
+            expect(wrapper.vm.componentStyleSet.position).toBe('sticky');
+            expect(wrapper.vm.componentStyleSet.top).toBe(0);
+            expect(wrapper.vm.componentStyleSet.left).toBe(0);
         });
 
         it('position과 height가 모두 주어지면 positioned 상태에서 height가 적용되어야 한다', () => {
@@ -126,9 +126,9 @@ describe('VsHeader', () => {
 
             // then
             expect(wrapper.props('position')).toBe('absolute');
-            expect(wrapper.vm.componentStyleSet.$component?.height).toBe('5rem');
-            expect(wrapper.vm.componentStyleSet.$component?.top).toBe(0);
-            expect(wrapper.vm.componentStyleSet.$component?.left).toBe(0);
+            expect(wrapper.vm.componentStyleSet.height).toBe('5rem');
+            expect(wrapper.vm.componentStyleSet.top).toBe(0);
+            expect(wrapper.vm.componentStyleSet.left).toBe(0);
         });
 
         it('position이 relative일 때도 height가 적용되어야 한다', () => {
@@ -142,7 +142,7 @@ describe('VsHeader', () => {
 
             // then
             expect(wrapper.props('position')).toBe('relative');
-            expect(wrapper.vm.componentStyleSet.$component?.height).toBe('6rem');
+            expect(wrapper.vm.componentStyleSet.height).toBe('6rem');
         });
 
         it('position이 없어도 height가 적용되어야 한다', () => {
@@ -155,7 +155,7 @@ describe('VsHeader', () => {
 
             // then
             expect(wrapper.props('position')).toBeUndefined();
-            expect(wrapper.vm.componentStyleSet.$component?.height).toBe('7rem');
+            expect(wrapper.vm.componentStyleSet.height).toBe('7rem');
         });
     });
 

--- a/packages/vlossom/src/components/vs-image/README.ko.md
+++ b/packages/vlossom/src/components/vs-image/README.ko.md
@@ -70,11 +70,10 @@
 ## Types
 
 ```typescript
-interface VsImageStyleSet {
+interface VsImageStyleSet extends CSSProperties {
     $width?: string;
     $height?: string;
     $skeleton?: VsSkeletonStyleSet;
-    $component?: CSSProperties;
 }
 ```
 
@@ -91,8 +90,8 @@ interface VsImageStyleSet {
         :style-set="{
             $width: '200px',
             $height: '200px',
-            $component: { borderRadius: '8px', objectFit: 'cover' },
-            $skeleton: { $component: { borderRadius: '8px' } },
+            borderRadius: '8px', objectFit: 'cover',
+            $skeleton: { borderRadius: '8px' },
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-image/README.md
+++ b/packages/vlossom/src/components/vs-image/README.md
@@ -70,11 +70,10 @@ Disable the skeleton placeholder during loading.
 ## Types
 
 ```typescript
-interface VsImageStyleSet {
+interface VsImageStyleSet extends CSSProperties {
     $width?: string;
     $height?: string;
     $skeleton?: VsSkeletonStyleSet;
-    $component?: CSSProperties;
 }
 ```
 
@@ -91,8 +90,8 @@ interface VsImageStyleSet {
         :style-set="{
             $width: '200px',
             $height: '200px',
-            $component: { borderRadius: '8px', objectFit: 'cover' },
-            $skeleton: { $component: { borderRadius: '8px' } },
+            borderRadius: '8px', objectFit: 'cover',
+            $skeleton: { borderRadius: '8px' },
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-image/VsImage.vue
+++ b/packages/vlossom/src/components/vs-image/VsImage.vue
@@ -9,7 +9,7 @@
             :alt="alt"
             @load.stop="onImageLoad"
             @error.stop="onImageError"
-            :style="{ ...componentStyleSet.$component }"
+            :style="componentInlineStyle"
         />
     </div>
 </template>
@@ -43,7 +43,7 @@ export default defineComponent({
 
         const baseStyleSet: ComputedRef<VsImageStyleSet> = computed(() => ({}));
 
-        const { componentStyleSet, styleSetVariables } = useStyleSet<VsImageStyleSet>(
+        const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet<VsImageStyleSet>(
             componentName,
             styleSet,
             baseStyleSet,
@@ -103,6 +103,7 @@ export default defineComponent({
         return {
             componentStyleSet,
             styleSetVariables,
+            componentInlineStyle,
             computedSrc,
             vsImageRef,
             isLoading,

--- a/packages/vlossom/src/components/vs-image/__stories__/vs-Image.stories.ts
+++ b/packages/vlossom/src/components/vs-image/__stories__/vs-Image.stories.ts
@@ -103,12 +103,10 @@ export const SkeletonStyleSet: Story = {
             $width: '200px',
             $height: '200px',
             $skeleton: {
-                $component: {
-                    width: '200px',
-                    height: '200px',
-                    borderRadius: '50%',
-                    backgroundColor: '#e0e0e0',
-                },
+                width: '200px',
+                height: '200px',
+                borderRadius: '50%',
+                backgroundColor: '#e0e0e0',
             },
         },
     },

--- a/packages/vlossom/src/components/vs-image/types.ts
+++ b/packages/vlossom/src/components/vs-image/types.ts
@@ -12,9 +12,8 @@ export type { VsImage };
 
 export interface VsImageRef extends ComponentPublicInstance<typeof VsImage> {}
 
-export interface VsImageStyleSet {
+export interface VsImageStyleSet extends CSSProperties {
     $width?: string;
     $height?: string;
     $skeleton?: VsSkeletonStyleSet;
-    $component?: CSSProperties;
 }

--- a/packages/vlossom/src/components/vs-inner-scroll/README.ko.md
+++ b/packages/vlossom/src/components/vs-inner-scroll/README.ko.md
@@ -62,8 +62,7 @@
 ## Types
 
 ```typescript
-interface VsInnerScrollStyleSet {
-    $component?: CSSProperties;
+interface VsInnerScrollStyleSet extends CSSProperties {
     $header?: CSSProperties;
     $content?: CSSProperties;
     $footer?: CSSProperties;
@@ -77,7 +76,7 @@ interface VsInnerScrollStyleSet {
     <vs-inner-scroll
         style="height: 400px;"
         :style-set="{
-            $component: { backgroundColor: '#f5f5f5' },
+            backgroundColor: '#f5f5f5',
             $header: { padding: '1rem', borderBottom: '1px solid #ddd' },
             $content: { padding: '1rem' },
             $footer: { padding: '0.5rem', borderTop: '1px solid #ddd' },

--- a/packages/vlossom/src/components/vs-inner-scroll/README.md
+++ b/packages/vlossom/src/components/vs-inner-scroll/README.md
@@ -62,8 +62,7 @@ A layout component that provides a scrollable content area with optional sticky 
 ## Types
 
 ```typescript
-interface VsInnerScrollStyleSet {
-    $component?: CSSProperties;
+interface VsInnerScrollStyleSet extends CSSProperties {
     $header?: CSSProperties;
     $content?: CSSProperties;
     $footer?: CSSProperties;
@@ -77,7 +76,7 @@ interface VsInnerScrollStyleSet {
     <vs-inner-scroll
         style="height: 400px;"
         :style-set="{
-            $component: { backgroundColor: '#f5f5f5' },
+            backgroundColor: '#f5f5f5',
             $header: { padding: '1rem', borderBottom: '1px solid #ddd' },
             $content: { padding: '1rem' },
             $footer: { padding: '0.5rem', borderTop: '1px solid #ddd' },

--- a/packages/vlossom/src/components/vs-inner-scroll/VsInnerScroll.vue
+++ b/packages/vlossom/src/components/vs-inner-scroll/VsInnerScroll.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="vs-inner-scroll" :style="componentStyleSet.$component">
+    <div class="vs-inner-scroll" :style="componentInlineStyle">
         <div v-if="$slots['header']" class="vs-inner-scroll-header" :style="componentStyleSet.$header">
             <slot name="header" />
         </div>
@@ -40,7 +40,7 @@ export default defineComponent({
         const { styleSet } = toRefs(props);
         const bodyRef: TemplateRef<HTMLElement> = useTemplateRef('bodyRef');
 
-        const { componentStyleSet } = useStyleSet<VsInnerScrollStyleSet>(componentName, styleSet);
+        const { componentStyleSet, componentInlineStyle } = useStyleSet<VsInnerScrollStyleSet>(componentName, styleSet);
 
         function hasScroll() {
             if (!bodyRef.value) {
@@ -50,7 +50,7 @@ export default defineComponent({
             return bodyRef.value.scrollHeight > bodyRef.value.clientHeight;
         }
 
-        return { componentStyleSet, hasScroll, bodyRef };
+        return { componentStyleSet, componentInlineStyle, hasScroll, bodyRef };
     },
 });
 </script>

--- a/packages/vlossom/src/components/vs-inner-scroll/types.ts
+++ b/packages/vlossom/src/components/vs-inner-scroll/types.ts
@@ -13,8 +13,7 @@ export interface VsInnerScrollRef extends ComponentPublicInstance<typeof VsInner
     hasScroll: () => boolean;
 }
 
-export interface VsInnerScrollStyleSet {
-    $component?: CSSProperties;
+export interface VsInnerScrollStyleSet extends CSSProperties {
     $header?: CSSProperties;
     $content?: CSSProperties;
     $footer?: CSSProperties;

--- a/packages/vlossom/src/components/vs-input-wrapper/README.ko.md
+++ b/packages/vlossom/src/components/vs-input-wrapper/README.ko.md
@@ -79,8 +79,7 @@
 ## Types
 
 ```typescript
-interface VsInputWrapperStyleSet {
-    $component?: CSSProperties;
+interface VsInputWrapperStyleSet extends CSSProperties {
     $label?: CSSProperties;
     $messages?: CSSProperties;
     $message?: VsMessageStyleSet;
@@ -97,10 +96,10 @@ interface VsInputWrapperStyleSet {
     <vs-input-wrapper
         label="스타일 적용 래퍼"
         :style-set="{
-            $component: { padding: '1rem', backgroundColor: '#f9f9f9' },
+            padding: '1rem', backgroundColor: '#f9f9f9',
             $label: { color: '#333', fontWeight: '600' },
             $messages: { marginTop: '0.5rem' },
-            $message: { $component: { fontSize: '0.75rem' } },
+            $message: { fontSize: '0.75rem' },
         }"
     >
         <input type="text" />

--- a/packages/vlossom/src/components/vs-input-wrapper/README.md
+++ b/packages/vlossom/src/components/vs-input-wrapper/README.md
@@ -79,8 +79,7 @@ A layout wrapper for form inputs that provides a label, validation messages area
 ## Types
 
 ```typescript
-interface VsInputWrapperStyleSet {
-    $component?: CSSProperties;
+interface VsInputWrapperStyleSet extends CSSProperties {
     $label?: CSSProperties;
     $messages?: CSSProperties;
     $message?: VsMessageStyleSet;
@@ -97,10 +96,10 @@ interface VsInputWrapperStyleSet {
     <vs-input-wrapper
         label="Styled Wrapper"
         :style-set="{
-            $component: { padding: '1rem', backgroundColor: '#f9f9f9' },
+            padding: '1rem', backgroundColor: '#f9f9f9',
             $label: { color: '#333', fontWeight: '600' },
             $messages: { marginTop: '0.5rem' },
-            $message: { $component: { fontSize: '0.75rem' } },
+            $message: { fontSize: '0.75rem' },
         }"
     >
         <input type="text" />

--- a/packages/vlossom/src/components/vs-input-wrapper/VsInputWrapper.vue
+++ b/packages/vlossom/src/components/vs-input-wrapper/VsInputWrapper.vue
@@ -3,7 +3,7 @@
         :class="['vs-input-wrapper', { 'shake-horizontal': needToShake }]"
         :width
         :grid
-        :style="componentStyleSet.$component"
+        :style="componentInlineStyle"
     >
         <component :is="groupLabel ? 'fieldset' : 'div'">
             <component
@@ -69,7 +69,7 @@ export default defineComponent({
     setup(props) {
         const { shake, styleSet } = toRefs(props);
 
-        const { componentStyleSet } = useStyleSet(
+        const { componentStyleSet, componentInlineStyle } = useStyleSet(
             componentName,
             styleSet,
             computed(() => ({
@@ -85,7 +85,7 @@ export default defineComponent({
             }, 600);
         });
 
-        return { needToShake, componentStyleSet };
+        return { needToShake, componentStyleSet, componentInlineStyle };
     },
 });
 </script>

--- a/packages/vlossom/src/components/vs-input-wrapper/types.ts
+++ b/packages/vlossom/src/components/vs-input-wrapper/types.ts
@@ -12,8 +12,7 @@ export type { VsInputWrapper };
 
 export interface VsInputWrapperRef extends ComponentPublicInstance<typeof VsInputWrapper> {}
 
-export interface VsInputWrapperStyleSet {
-    $component?: CSSProperties;
+export interface VsInputWrapperStyleSet extends CSSProperties {
     $label?: CSSProperties;
     $messages?: CSSProperties;
     $message?: VsMessageStyleSet;

--- a/packages/vlossom/src/components/vs-input/README.ko.md
+++ b/packages/vlossom/src/components/vs-input/README.ko.md
@@ -108,11 +108,10 @@ const text = ref('');
 ## Types
 
 ```typescript
-interface VsInputStyleSet {
+interface VsInputStyleSet extends CSSProperties {
     $prepend?: CSSProperties;
     $append?: CSSProperties;
     $input?: CSSProperties;
-    $component?: CSSProperties;
     $wrapper?: VsInputWrapperStyleSet;
 }
 ```
@@ -128,7 +127,7 @@ interface VsInputStyleSet {
         v-model="value"
         label="스타일 적용 입력"
         :style-set="{
-            $component: { borderRadius: '20px', height: '3rem' },
+            borderRadius: '20px', height: '3rem',
             $input: { fontSize: '1rem' },
             $prepend: { backgroundColor: '#eee', padding: '0 0.5rem' },
             $append: { backgroundColor: '#eee', padding: '0 0.5rem' },

--- a/packages/vlossom/src/components/vs-input/README.md
+++ b/packages/vlossom/src/components/vs-input/README.md
@@ -108,11 +108,10 @@ const text = ref('');
 ## Types
 
 ```typescript
-interface VsInputStyleSet {
+interface VsInputStyleSet extends CSSProperties {
     $prepend?: CSSProperties;
     $append?: CSSProperties;
     $input?: CSSProperties;
-    $component?: CSSProperties;
     $wrapper?: VsInputWrapperStyleSet;
 }
 ```
@@ -128,7 +127,7 @@ interface VsInputStyleSet {
         v-model="value"
         label="Styled Input"
         :style-set="{
-            $component: { borderRadius: '20px', height: '3rem' },
+            borderRadius: '20px', height: '3rem',
             $input: { fontSize: '1rem' },
             $prepend: { backgroundColor: '#eee', padding: '0 0.5rem' },
             $append: { backgroundColor: '#eee', padding: '0 0.5rem' },

--- a/packages/vlossom/src/components/vs-input/VsInput.vue
+++ b/packages/vlossom/src/components/vs-input/VsInput.vue
@@ -18,7 +18,7 @@
             <slot name="label" />
         </template>
 
-        <div :class="['vs-input', colorSchemeClass, classObj, stateBoxClasses]" :style="componentStyleSet.$component">
+        <div :class="['vs-input', colorSchemeClass, classObj, stateBoxClasses]" :style="componentInlineStyle">
             <div v-if="$slots['prepend']" class="vs-prepend" :style="componentStyleSet.$prepend">
                 <slot name="prepend" />
             </div>
@@ -132,7 +132,10 @@ export default defineComponent({
 
         const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { componentStyleSet, styleSetVariables } = useStyleSet<VsInputStyleSet>(componentName, styleSet);
+        const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet<VsInputStyleSet>(
+            componentName,
+            styleSet,
+        );
 
         const { modifyStringValue } = useStringModifier(modelModifiers);
         const { requiredCheck, maxCheck, minCheck } = useVsInputRules(required, max, min, type);
@@ -238,6 +241,7 @@ export default defineComponent({
             colorSchemeClass,
             componentStyleSet,
             styleSetVariables,
+            componentInlineStyle,
             inputValue,
             computedMessages,
             computedDisabled,

--- a/packages/vlossom/src/components/vs-input/__stories__/vs-input.stories.ts
+++ b/packages/vlossom/src/components/vs-input/__stories__/vs-input.stories.ts
@@ -525,12 +525,10 @@ export const StyleSet: Story = {
         label: '커스텀 스타일',
         placeholder: '커스텀 입력 필드',
         styleSet: {
-            $component: {
-                backgroundColor: '#f0f8ff',
-                border: '2px solid #1e88e5',
-                borderRadius: '12px',
-                height: '3.5rem',
-            },
+            backgroundColor: '#f0f8ff',
+            border: '2px solid #1e88e5',
+            borderRadius: '12px',
+            height: '3.5rem',
             $input: {
                 fontSize: '1.1rem',
                 fontWeight: '600',

--- a/packages/vlossom/src/components/vs-input/types.ts
+++ b/packages/vlossom/src/components/vs-input/types.ts
@@ -19,10 +19,9 @@ export type VsInputValueType = string | number | null;
 
 export type VsInputType = 'email' | 'number' | 'password' | 'search' | 'tel' | 'text' | 'url';
 
-export interface VsInputStyleSet {
+export interface VsInputStyleSet extends CSSProperties {
     $prepend?: CSSProperties;
     $append?: CSSProperties;
     $input?: CSSProperties;
-    $component?: CSSProperties;
     $wrapper?: VsInputWrapperStyleSet;
 }

--- a/packages/vlossom/src/components/vs-label-value/README.ko.md
+++ b/packages/vlossom/src/components/vs-label-value/README.ko.md
@@ -87,9 +87,8 @@
 ## Types
 
 ```typescript
-interface VsLabelValueStyleSet {
+interface VsLabelValueStyleSet extends CSSProperties {
     $border?: string;
-    $component?: CSSProperties;
     $label?: CSSProperties;
     $value?: CSSProperties;
 }
@@ -102,7 +101,7 @@ interface VsLabelValueStyleSet {
     <vs-label-value
         :style-set="{
             $border: '2px solid #007bff',
-            $component: { borderRadius: '8px' },
+            borderRadius: '8px',
             $label: { backgroundColor: '#e7f0ff', color: '#007bff', fontWeight: '700' },
             $value: { padding: '0 1.5rem' },
         }"

--- a/packages/vlossom/src/components/vs-label-value/README.md
+++ b/packages/vlossom/src/components/vs-label-value/README.md
@@ -87,9 +87,8 @@ Switch to vertical layout on small containers automatically.
 ## Types
 
 ```typescript
-interface VsLabelValueStyleSet {
+interface VsLabelValueStyleSet extends CSSProperties {
     $border?: string;
-    $component?: CSSProperties;
     $label?: CSSProperties;
     $value?: CSSProperties;
 }
@@ -102,7 +101,7 @@ interface VsLabelValueStyleSet {
     <vs-label-value
         :style-set="{
             $border: '2px solid #007bff',
-            $component: { borderRadius: '8px' },
+            borderRadius: '8px',
             $label: { backgroundColor: '#e7f0ff', color: '#007bff', fontWeight: '700' },
             $value: { padding: '0 1.5rem' },
         }"

--- a/packages/vlossom/src/components/vs-label-value/VsLabelValue.vue
+++ b/packages/vlossom/src/components/vs-label-value/VsLabelValue.vue
@@ -1,7 +1,7 @@
 <template>
     <vs-responsive
         :class="['vs-label-value', colorSchemeClass, classObj]"
-        :style="{ ...styleSetVariables, ...componentStyleSet.$component }"
+        :style="{ ...styleSetVariables, ...componentInlineStyle }"
         :width
         :grid
     >
@@ -40,7 +40,10 @@ export default defineComponent({
 
         const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { styleSetVariables, componentStyleSet } = useStyleSet<VsLabelValueStyleSet>(componentName, styleSet);
+        const { styleSetVariables, componentStyleSet, componentInlineStyle } = useStyleSet<VsLabelValueStyleSet>(
+            componentName,
+            styleSet,
+        );
 
         const classObj = computed(() => ({
             'vs-dense': dense.value,
@@ -54,6 +57,7 @@ export default defineComponent({
             colorSchemeClass,
             styleSetVariables,
             componentStyleSet,
+            componentInlineStyle,
         };
     },
 });

--- a/packages/vlossom/src/components/vs-label-value/types.ts
+++ b/packages/vlossom/src/components/vs-label-value/types.ts
@@ -11,9 +11,8 @@ export type { VsLabelValue };
 
 export interface VsLabelValueRef extends ComponentPublicInstance<typeof VsLabelValue> {}
 
-export interface VsLabelValueStyleSet {
+export interface VsLabelValueStyleSet extends CSSProperties {
     $border?: string;
-    $component?: CSSProperties;
     $label?: CSSProperties;
     $value?: CSSProperties;
 }

--- a/packages/vlossom/src/components/vs-loading/README.ko.md
+++ b/packages/vlossom/src/components/vs-loading/README.ko.md
@@ -50,10 +50,9 @@
 ## Types
 
 ```typescript
-interface VsLoadingStyleSet {
+interface VsLoadingStyleSet extends CSSProperties {
     $barColor?: string;
     $barWidth?: string;
-    $component?: CSSProperties;
 }
 ```
 
@@ -65,7 +64,7 @@ interface VsLoadingStyleSet {
         :style-set="{
             $barColor: '#ff6b6b',
             $barWidth: '15%',
-            $component: { width: '6rem', height: '8rem' },
+            width: '6rem', height: '8rem',
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-loading/README.md
+++ b/packages/vlossom/src/components/vs-loading/README.md
@@ -50,10 +50,9 @@ An animated loading indicator composed of five vertical bars with a wave animati
 ## Types
 
 ```typescript
-interface VsLoadingStyleSet {
+interface VsLoadingStyleSet extends CSSProperties {
     $barColor?: string;
     $barWidth?: string;
-    $component?: CSSProperties;
 }
 ```
 
@@ -65,7 +64,7 @@ interface VsLoadingStyleSet {
         :style-set="{
             $barColor: '#ff6b6b',
             $barWidth: '15%',
-            $component: { width: '6rem', height: '8rem' },
+            width: '6rem', height: '8rem',
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-loading/VsLoading.vue
+++ b/packages/vlossom/src/components/vs-loading/VsLoading.vue
@@ -38,14 +38,14 @@ export default defineComponent({
             });
         });
 
-        const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet<VsLoadingStyleSet>(
+        const { styleSetVariables, componentInlineStyle } = useStyleSet<VsLoadingStyleSet>(
             componentName,
             styleSet,
             baseStyleSet,
             additionalStyleSet,
         );
 
-        return { colorSchemeClass, componentStyleSet, styleSetVariables, componentInlineStyle };
+        return { colorSchemeClass, styleSetVariables, componentInlineStyle };
     },
 });
 </script>

--- a/packages/vlossom/src/components/vs-loading/VsLoading.vue
+++ b/packages/vlossom/src/components/vs-loading/VsLoading.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="['vs-loading', colorSchemeClass]" :style="{ ...styleSetVariables, ...componentStyleSet.$component }">
+    <div :class="['vs-loading', colorSchemeClass]" :style="{ ...styleSetVariables, ...componentInlineStyle }">
         <div class="vs-loading-rect vs-loading-rect1" />
         <div class="vs-loading-rect vs-loading-rect2" />
         <div class="vs-loading-rect vs-loading-rect3" />
@@ -32,22 +32,20 @@ export default defineComponent({
 
         const baseStyleSet: ComputedRef<VsLoadingStyleSet> = computed(() => ({}));
         const additionalStyleSet: ComputedRef<VsLoadingStyleSet> = computed(() => {
-            return {
-                $component: objectUtil.shake({
-                    width: width.value === undefined ? undefined : stringUtil.toStringSize(width.value),
-                    height: height.value === undefined ? undefined : stringUtil.toStringSize(height.value),
-                }),
-            };
+            return objectUtil.shake({
+                width: width.value === undefined ? undefined : stringUtil.toStringSize(width.value),
+                height: height.value === undefined ? undefined : stringUtil.toStringSize(height.value),
+            });
         });
 
-        const { componentStyleSet, styleSetVariables } = useStyleSet<VsLoadingStyleSet>(
+        const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet<VsLoadingStyleSet>(
             componentName,
             styleSet,
             baseStyleSet,
             additionalStyleSet,
         );
 
-        return { colorSchemeClass, componentStyleSet, styleSetVariables };
+        return { colorSchemeClass, componentStyleSet, styleSetVariables, componentInlineStyle };
     },
 });
 </script>

--- a/packages/vlossom/src/components/vs-loading/__stories__/vs-loading.stories.ts
+++ b/packages/vlossom/src/components/vs-loading/__stories__/vs-loading.stories.ts
@@ -12,10 +12,8 @@ const meta: Meta<typeof VsLoading> = {
         setup() {
             const preDefinedStyleSet: VsLoadingStyleSet = {
                 $barColor: 'cyan',
-                $component: {
-                    width: '9rem',
-                    height: '12rem',
-                },
+                width: '9rem',
+                height: '12rem',
             } as const;
 
             useVlossom().styleSet = {
@@ -81,10 +79,8 @@ export const StyleSet: Story = {
     }),
     args: {
         styleSet: {
-            $component: {
-                width: '4rem',
-                height: '4rem',
-            },
+            width: '4rem',
+            height: '4rem',
         },
     },
 };

--- a/packages/vlossom/src/components/vs-loading/__tests__/vs-loading.test.ts
+++ b/packages/vlossom/src/components/vs-loading/__tests__/vs-loading.test.ts
@@ -41,7 +41,7 @@ describe('VsLoading', () => {
             });
 
             // then
-            expect(wrapper.vm.componentStyleSet.$component).toEqual({
+            expect(wrapper.vm.componentStyleSet).toMatchObject({
                 width: '200px',
                 height: '150px',
             });
@@ -61,7 +61,7 @@ describe('VsLoading', () => {
             });
 
             // then
-            expect(wrapper.vm.componentStyleSet.$component).toEqual({
+            expect(wrapper.vm.componentStyleSet).toMatchObject({
                 width: '300px',
                 height: '250px',
             });

--- a/packages/vlossom/src/components/vs-loading/__tests__/vs-loading.test.ts
+++ b/packages/vlossom/src/components/vs-loading/__tests__/vs-loading.test.ts
@@ -41,7 +41,7 @@ describe('VsLoading', () => {
             });
 
             // then
-            expect(wrapper.vm.componentStyleSet).toMatchObject({
+            expect(wrapper.vm.componentInlineStyle).toMatchObject({
                 width: '200px',
                 height: '150px',
             });
@@ -61,7 +61,7 @@ describe('VsLoading', () => {
             });
 
             // then
-            expect(wrapper.vm.componentStyleSet).toMatchObject({
+            expect(wrapper.vm.componentInlineStyle).toMatchObject({
                 width: '300px',
                 height: '250px',
             });

--- a/packages/vlossom/src/components/vs-loading/types.ts
+++ b/packages/vlossom/src/components/vs-loading/types.ts
@@ -11,8 +11,7 @@ export type { VsLoading };
 
 export interface VsLoadingRef extends ComponentPublicInstance<typeof VsLoading> {}
 
-export interface VsLoadingStyleSet {
+export interface VsLoadingStyleSet extends CSSProperties {
     $barColor?: string;
     $barWidth?: string;
-    $component?: CSSProperties;
 }

--- a/packages/vlossom/src/components/vs-message/README.ko.md
+++ b/packages/vlossom/src/components/vs-message/README.ko.md
@@ -45,9 +45,8 @@ idle, info, success, warning, error 등 다양한 UI 상태에 맞는 아이콘�
 ## Types
 
 ```typescript
-interface VsMessageStyleSet {
+interface VsMessageStyleSet extends CSSProperties {
     $size?: string;
-    $component?: CSSProperties;
 }
 ```
 
@@ -60,7 +59,7 @@ interface VsMessageStyleSet {
         state="info"
         :style-set="{
             $size: '1rem',
-            $component: { padding: '0.25rem 0' },
+            padding: '0.25rem 0',
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-message/README.md
+++ b/packages/vlossom/src/components/vs-message/README.md
@@ -45,9 +45,8 @@ When no state is specified, the `idle` state is used (default color).
 ## Types
 
 ```typescript
-interface VsMessageStyleSet {
+interface VsMessageStyleSet extends CSSProperties {
     $size?: string;
-    $component?: CSSProperties;
 }
 ```
 
@@ -60,7 +59,7 @@ interface VsMessageStyleSet {
         state="info"
         :style-set="{
             $size: '1rem',
-            $component: { padding: '0.25rem 0' },
+            padding: '0.25rem 0',
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-message/VsMessage.vue
+++ b/packages/vlossom/src/components/vs-message/VsMessage.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="['vs-message', colorClass]" :style="{ ...componentInlineStyle, ...styleSetVariables }">
+    <div :class="['vs-message', colorClass]" :style="{ ...styleSetVariables, ...componentInlineStyle }">
         <i class="vs-message-icon">
             <vs-render :content="icon" />
         </i>
@@ -47,13 +47,13 @@ export default defineComponent({
             }
         });
 
-        const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet(componentName, styleSet);
+        const { styleSetVariables, componentInlineStyle } = useStyleSet(componentName, styleSet);
 
         const icon = computed(() => {
             return messageIcons[state.value];
         });
 
-        return { colorClass, icon, componentStyleSet, styleSetVariables, componentInlineStyle };
+        return { colorClass, icon, styleSetVariables, componentInlineStyle };
     },
 });
 </script>

--- a/packages/vlossom/src/components/vs-message/VsMessage.vue
+++ b/packages/vlossom/src/components/vs-message/VsMessage.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="['vs-message', colorClass]" :style="{ ...componentStyleSet.$component, ...styleSetVariables }">
+    <div :class="['vs-message', colorClass]" :style="{ ...componentInlineStyle, ...styleSetVariables }">
         <i class="vs-message-icon">
             <vs-render :content="icon" />
         </i>
@@ -47,13 +47,13 @@ export default defineComponent({
             }
         });
 
-        const { componentStyleSet, styleSetVariables } = useStyleSet(componentName, styleSet);
+        const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet(componentName, styleSet);
 
         const icon = computed(() => {
             return messageIcons[state.value];
         });
 
-        return { colorClass, icon, componentStyleSet, styleSetVariables };
+        return { colorClass, icon, componentStyleSet, styleSetVariables, componentInlineStyle };
     },
 });
 </script>

--- a/packages/vlossom/src/components/vs-message/types.ts
+++ b/packages/vlossom/src/components/vs-message/types.ts
@@ -11,7 +11,6 @@ export type { VsMessage };
 
 export interface VsMessageRef extends ComponentPublicInstance<typeof VsMessage> {}
 
-export interface VsMessageStyleSet {
+export interface VsMessageStyleSet extends CSSProperties {
     $size?: string;
-    $component?: CSSProperties;
 }

--- a/packages/vlossom/src/components/vs-modal/README.ko.md
+++ b/packages/vlossom/src/components/vs-modal/README.ko.md
@@ -115,8 +115,7 @@ async function confirmClose() {
 ## Types
 
 ```typescript
-interface VsModalNodeStyleSet {
-    $component?: CSSProperties;
+interface VsModalNodeStyleSet extends CSSProperties {
     $dimmed?: VsDimmedStyleSet;
 }
 ```
@@ -132,14 +131,12 @@ interface VsModalNodeStyleSet {
         v-model="isOpen"
         :dimmed="true"
         :style-set="{
-            $component: {
-                borderRadius: '16px',
-                padding: '2rem',
-                backgroundColor: '#fff',
-                boxShadow: '0 8px 32px rgba(0,0,0,0.2)',
-            },
+            borderRadius: '16px',
+            padding: '2rem',
+            backgroundColor: '#fff',
+            boxShadow: '0 8px 32px rgba(0,0,0,0.2)',
             $dimmed: {
-                $component: { backgroundColor: 'rgba(0,0,0,0.6)' },
+                backgroundColor: 'rgba(0,0,0,0.6)',
             },
         }"
     >

--- a/packages/vlossom/src/components/vs-modal/README.md
+++ b/packages/vlossom/src/components/vs-modal/README.md
@@ -115,8 +115,7 @@ async function confirmClose() {
 ## Types
 
 ```typescript
-interface VsModalNodeStyleSet {
-    $component?: CSSProperties;
+interface VsModalNodeStyleSet extends CSSProperties {
     $dimmed?: VsDimmedStyleSet;
 }
 ```
@@ -132,14 +131,12 @@ interface VsModalNodeStyleSet {
         v-model="isOpen"
         :dimmed="true"
         :style-set="{
-            $component: {
-                borderRadius: '16px',
-                padding: '2rem',
-                backgroundColor: '#fff',
-                boxShadow: '0 8px 32px rgba(0,0,0,0.2)',
-            },
+            borderRadius: '16px',
+            padding: '2rem',
+            backgroundColor: '#fff',
+            boxShadow: '0 8px 32px rgba(0,0,0,0.2)',
             $dimmed: {
-                $component: { backgroundColor: 'rgba(0,0,0,0.6)' },
+                backgroundColor: 'rgba(0,0,0,0.6)',
             },
         }"
     >

--- a/packages/vlossom/src/components/vs-modal/VsModalNode.vue
+++ b/packages/vlossom/src/components/vs-modal/VsModalNode.vue
@@ -12,7 +12,7 @@
                 role="dialog"
                 aria-label="Modal"
                 :aria-modal="true"
-                :style="componentStyleSet.$component"
+                :style="componentInlineStyle"
             >
                 <slot />
             </div>
@@ -104,12 +104,10 @@ export default defineComponent({
                 result['height'] = stringUtil.toStringSize(height);
             }
 
-            return objectUtil.shake({
-                $component: objectUtil.shake(result),
-            });
+            return objectUtil.shake(result);
         });
 
-        const { componentStyleSet } = useStyleSet<VsModalNodeStyleSet>(
+        const { componentStyleSet, componentInlineStyle } = useStyleSet<VsModalNodeStyleSet>(
             componentName,
             styleSet,
             baseStyleSet,
@@ -176,6 +174,7 @@ export default defineComponent({
         return {
             colorSchemeClass,
             componentStyleSet,
+            componentInlineStyle,
             focusLock,
             onClickDimmed,
         };

--- a/packages/vlossom/src/components/vs-modal/__stories__/vs-modal-node.stories.ts
+++ b/packages/vlossom/src/components/vs-modal/__stories__/vs-modal-node.stories.ts
@@ -21,16 +21,14 @@ const meta: Meta<typeof VsModalNode> = {
         components: { VsModalNode },
         setup() {
             const preDefinedStyleSet: VsModalNodeStyleSet = {
-                $component: {
-                    backgroundColor: '#ffffff',
-                    border: '1px solid #e0e0e0',
-                    borderRadius: '8px',
-                    boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)',
-                    color: '#333333',
-                    padding: '2rem',
-                    width: '500px',
-                    height: '400px',
-                },
+                backgroundColor: '#ffffff',
+                border: '1px solid #e0e0e0',
+                borderRadius: '8px',
+                boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)',
+                color: '#333333',
+                padding: '2rem',
+                width: '500px',
+                height: '400px',
             } as const;
 
             useVlossom().styleSet = {
@@ -236,16 +234,14 @@ export const StyleSet: Story = {
     },
     args: {
         styleSet: {
-            $component: {
-                backgroundColor: '#f8f9fa',
-                border: '2px solid #1e88e5',
-                borderRadius: '12px',
-                boxShadow: '0 8px 16px rgba(0, 0, 0, 0.15)',
-                color: '#1e88e5',
-                padding: '2rem',
-                width: '550px',
-                height: '450px',
-            },
+            backgroundColor: '#f8f9fa',
+            border: '2px solid #1e88e5',
+            borderRadius: '12px',
+            boxShadow: '0 8px 16px rgba(0, 0, 0, 0.15)',
+            color: '#1e88e5',
+            padding: '2rem',
+            width: '550px',
+            height: '450px',
         },
     },
     render: (args: any) => ({

--- a/packages/vlossom/src/components/vs-modal/__tests__/vs-modal-node.test.ts
+++ b/packages/vlossom/src/components/vs-modal/__tests__/vs-modal-node.test.ts
@@ -11,7 +11,7 @@ describe('VsModalNode', () => {
             });
 
             // then
-            expect(wrapper.vm.componentStyleSet.$component).toEqual({
+            expect(wrapper.vm.componentStyleSet).toMatchObject({
                 width: '70%',
                 height: '66%',
             });
@@ -24,7 +24,7 @@ describe('VsModalNode', () => {
             });
 
             // then
-            expect(wrapper.vm.componentStyleSet.$component).toEqual({
+            expect(wrapper.vm.componentStyleSet).toMatchObject({
                 width: '500px',
                 height: '500px',
             });
@@ -39,7 +39,7 @@ describe('VsModalNode', () => {
             });
 
             // then
-            expect(wrapper.vm.componentStyleSet.$component).toEqual({
+            expect(wrapper.vm.componentStyleSet).toMatchObject({
                 width: '600px',
                 height: '400px',
             });
@@ -54,7 +54,7 @@ describe('VsModalNode', () => {
             });
 
             // then
-            expect(wrapper.vm.componentStyleSet.$component).toEqual({
+            expect(wrapper.vm.componentStyleSet).toMatchObject({
                 width: '600px',
                 height: '50%',
             });
@@ -69,7 +69,7 @@ describe('VsModalNode', () => {
             });
 
             // then
-            expect(wrapper.vm.componentStyleSet.$component).toEqual({
+            expect(wrapper.vm.componentStyleSet).toMatchObject({
                 width: '45%',
                 height: '400px',
             });

--- a/packages/vlossom/src/components/vs-modal/types.ts
+++ b/packages/vlossom/src/components/vs-modal/types.ts
@@ -20,7 +20,6 @@ export interface VsModalNodeRef extends ComponentPublicInstance<typeof VsModalNo
 
 export interface VsModalViewRef extends ComponentPublicInstance<typeof VsModalView> {}
 
-export interface VsModalNodeStyleSet {
-    $component?: CSSProperties;
+export interface VsModalNodeStyleSet extends CSSProperties {
     $dimmed?: VsDimmedStyleSet;
 }

--- a/packages/vlossom/src/components/vs-page/README.ko.md
+++ b/packages/vlossom/src/components/vs-page/README.ko.md
@@ -44,8 +44,7 @@
 ## Types
 
 ```typescript
-interface VsPageStyleSet {
-    $component?: CSSProperties;
+interface VsPageStyleSet extends CSSProperties {
     $title?: CSSProperties;
     $description?: CSSProperties;
     $content?: CSSProperties;
@@ -58,7 +57,7 @@ interface VsPageStyleSet {
 <template>
     <vs-page
         :style-set="{
-            $component: { backgroundColor: '#f9f9f9', padding: '2rem' },
+            backgroundColor: '#f9f9f9', padding: '2rem',
             $title: { color: '#333', fontSize: '1.5rem', fontWeight: 'bold' },
             $description: { color: '#666', fontSize: '0.9rem' },
             $content: { paddingTop: '1rem' },

--- a/packages/vlossom/src/components/vs-page/README.md
+++ b/packages/vlossom/src/components/vs-page/README.md
@@ -44,8 +44,7 @@ A layout component that provides a structured page container with title, descrip
 ## Types
 
 ```typescript
-interface VsPageStyleSet {
-    $component?: CSSProperties;
+interface VsPageStyleSet extends CSSProperties {
     $title?: CSSProperties;
     $description?: CSSProperties;
     $content?: CSSProperties;
@@ -58,7 +57,7 @@ interface VsPageStyleSet {
 <template>
     <vs-page
         :style-set="{
-            $component: { backgroundColor: '#f9f9f9', padding: '2rem' },
+            backgroundColor: '#f9f9f9', padding: '2rem',
             $title: { color: '#333', fontSize: '1.5rem', fontWeight: 'bold' },
             $description: { color: '#666', fontSize: '0.9rem' },
             $content: { paddingTop: '1rem' },

--- a/packages/vlossom/src/components/vs-page/VsPage.vue
+++ b/packages/vlossom/src/components/vs-page/VsPage.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="vs-page" :style="componentStyleSet.$component">
+    <div class="vs-page" :style="componentInlineStyle">
         <div v-if="$slots['title']" class="vs-page-title" :style="componentStyleSet.$title">
             <slot name="title" />
         </div>
@@ -29,10 +29,11 @@ export default defineComponent({
     setup(props) {
         const { styleSet } = toRefs(props);
 
-        const { componentStyleSet } = useStyleSet<VsPageStyleSet>(componentName, styleSet);
+        const { componentStyleSet, componentInlineStyle } = useStyleSet<VsPageStyleSet>(componentName, styleSet);
 
         return {
             componentStyleSet,
+            componentInlineStyle,
         };
     },
 });

--- a/packages/vlossom/src/components/vs-page/__stories__/vs-page.stories.ts
+++ b/packages/vlossom/src/components/vs-page/__stories__/vs-page.stories.ts
@@ -51,9 +51,7 @@ const meta: Meta<typeof VsPage> = {
         components: { VsPage },
         setup() {
             const preDefinedStyleSet: VsPageStyleSet = {
-                $component: {
-                    padding: '4rem 5rem',
-                },
+                padding: '4rem 5rem',
                 $title: {
                     padding: '0 0 1rem 0',
                 },
@@ -194,9 +192,7 @@ export const StyleSet: Story = {
     },
     args: {
         styleSet: {
-            $component: {
-                padding: '1.2rem 3rem',
-            },
+            padding: '1.2rem 3rem',
         },
     },
 };
@@ -213,9 +209,7 @@ export const NestedStyleSet: Story = {
     },
     args: {
         styleSet: {
-            $component: {
-                padding: '2rem',
-            },
+            padding: '2rem',
             $title: {
                 padding: '0 0 1.5rem 0',
             },

--- a/packages/vlossom/src/components/vs-page/types.ts
+++ b/packages/vlossom/src/components/vs-page/types.ts
@@ -11,8 +11,7 @@ export type { VsPage };
 
 export interface VsPageRef extends ComponentPublicInstance<typeof VsPage> {}
 
-export interface VsPageStyleSet {
-    $component?: CSSProperties;
+export interface VsPageStyleSet extends CSSProperties {
     $title?: CSSProperties;
     $description?: CSSProperties;
     $content?: CSSProperties;

--- a/packages/vlossom/src/components/vs-pagination/README.ko.md
+++ b/packages/vlossom/src/components/vs-pagination/README.ko.md
@@ -62,15 +62,15 @@ const page = ref(0);
 
 ```typescript
 interface VsPaginationStyleSet extends CSSProperties {
-    $selectedButtonBackgroundColor?: string;
-    $selectedButtonFontColor?: string;
-    $pageButton?: Omit<VsButtonStyleSet, '$loading'>;
+    $pageButton?: Omit<VsButtonStyleSet, '$loading'> & {
+        $selected?: Omit<VsButtonStyleSet, '$loading'>;
+    };
     $controlButton?: Omit<VsButtonStyleSet, '$loading'>;
 }
 ```
 
 > [!NOTE]
-> `$pageButton`과 `$controlButton`은 [VsButtonStyleSet](../vs-button/README.md#types)(`$loading` 제외)을 사용합니다.
+> `$pageButton`과 `$controlButton`은 [VsButtonStyleSet](../vs-button/README.md#types)(`$loading` 제외)을 사용합니다. `$pageButton.$selected`는 현재 선택된 페이지 버튼에 적용됩니다.
 
 ### StyleSet 사용 예시
 
@@ -80,9 +80,13 @@ interface VsPaginationStyleSet extends CSSProperties {
         v-model="page"
         :length="10"
         :style-set="{
-            $selectedButtonBackgroundColor: '#4f46e5',
-            $selectedButtonFontColor: '#ffffff',
             gap: '0.25rem',
+            $pageButton: {
+                $selected: {
+                    backgroundColor: '#4f46e5',
+                    color: '#ffffff',
+                },
+            },
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-pagination/README.ko.md
+++ b/packages/vlossom/src/components/vs-pagination/README.ko.md
@@ -61,10 +61,9 @@ const page = ref(0);
 ## Types
 
 ```typescript
-interface VsPaginationStyleSet {
+interface VsPaginationStyleSet extends CSSProperties {
     $selectedButtonBackgroundColor?: string;
     $selectedButtonFontColor?: string;
-    $component?: CSSProperties;
     $pageButton?: Omit<VsButtonStyleSet, '$loading'>;
     $controlButton?: Omit<VsButtonStyleSet, '$loading'>;
 }
@@ -83,7 +82,7 @@ interface VsPaginationStyleSet {
         :style-set="{
             $selectedButtonBackgroundColor: '#4f46e5',
             $selectedButtonFontColor: '#ffffff',
-            $component: { gap: '0.25rem' },
+            gap: '0.25rem',
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-pagination/README.md
+++ b/packages/vlossom/src/components/vs-pagination/README.md
@@ -62,15 +62,15 @@ const page = ref(0);
 
 ```typescript
 interface VsPaginationStyleSet extends CSSProperties {
-    $selectedButtonBackgroundColor?: string;
-    $selectedButtonFontColor?: string;
-    $pageButton?: Omit<VsButtonStyleSet, '$loading'>;
+    $pageButton?: Omit<VsButtonStyleSet, '$loading'> & {
+        $selected?: Omit<VsButtonStyleSet, '$loading'>;
+    };
     $controlButton?: Omit<VsButtonStyleSet, '$loading'>;
 }
 ```
 
 > [!NOTE]
-> `$pageButton` and `$controlButton` use [VsButtonStyleSet](../vs-button/README.md#types) (excluding `$loading`).
+> `$pageButton` and `$controlButton` use [VsButtonStyleSet](../vs-button/README.md#types) (excluding `$loading`). The `$pageButton.$selected` style is applied to the currently selected page button.
 
 ### StyleSet Example
 
@@ -80,9 +80,13 @@ interface VsPaginationStyleSet extends CSSProperties {
         v-model="page"
         :length="10"
         :style-set="{
-            $selectedButtonBackgroundColor: '#4f46e5',
-            $selectedButtonFontColor: '#ffffff',
             gap: '0.25rem',
+            $pageButton: {
+                $selected: {
+                    backgroundColor: '#4f46e5',
+                    color: '#ffffff',
+                },
+            },
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-pagination/README.md
+++ b/packages/vlossom/src/components/vs-pagination/README.md
@@ -61,10 +61,9 @@ const page = ref(0);
 ## Types
 
 ```typescript
-interface VsPaginationStyleSet {
+interface VsPaginationStyleSet extends CSSProperties {
     $selectedButtonBackgroundColor?: string;
     $selectedButtonFontColor?: string;
-    $component?: CSSProperties;
     $pageButton?: Omit<VsButtonStyleSet, '$loading'>;
     $controlButton?: Omit<VsButtonStyleSet, '$loading'>;
 }
@@ -83,7 +82,7 @@ interface VsPaginationStyleSet {
         :style-set="{
             $selectedButtonBackgroundColor: '#4f46e5',
             $selectedButtonFontColor: '#ffffff',
-            $component: { gap: '0.25rem' },
+            gap: '0.25rem',
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-pagination/VsPagination.css
+++ b/packages/vlossom/src/components/vs-pagination/VsPagination.css
@@ -1,9 +1,6 @@
 @reference 'tailwindcss';
 
 .vs-pagination {
-    --vs-pagination-selectedButtonBackgroundColor: initial;
-    --vs-pagination-selectedButtonFontColor: initial;
-
     @apply relative flex items-center justify-center;
 
     gap: 0.5rem;
@@ -18,13 +15,6 @@
         .vs-page-button {
             min-width: 2rem;
             min-height: 2rem;
-        }
-
-        .vs-page-button {
-            &.vs-primary {
-                background-color: var(--vs-pagination-selectedButtonBackgroundColor, var(--vs-cs-bg-primary));
-                color: var(--vs-pagination-selectedButtonFontColor, var(--vs-cs-font-primary));
-            }
         }
     }
 

--- a/packages/vlossom/src/components/vs-pagination/VsPagination.vue
+++ b/packages/vlossom/src/components/vs-pagination/VsPagination.vue
@@ -1,7 +1,7 @@
 <template>
     <div
         :class="['vs-pagination', colorSchemeClass, { 'vs-disabled': disabled }]"
-        :style="{ ...styleSetVariables, ...componentStyleSet.$component }"
+        :style="{ ...styleSetVariables, ...componentInlineStyle }"
     >
         <vs-button
             v-if="edgeButtons"
@@ -145,13 +145,11 @@ export default defineComponent({
         const { computedColorScheme, colorSchemeClass } = useColorScheme(componentName, colorScheme);
         const baseStyleSet: ComputedRef<VsPaginationStyleSet> = computed(() => ({
             $controlButton: {
-                $component: {
-                    padding: '0.4rem',
-                },
+                padding: '0.4rem',
             },
         }));
 
-        const { componentStyleSet, styleSetVariables } = useStyleSet<VsPaginationStyleSet>(
+        const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet<VsPaginationStyleSet>(
             componentName,
             styleSet,
             baseStyleSet,
@@ -237,6 +235,7 @@ export default defineComponent({
             colorSchemeClass,
             componentStyleSet,
             styleSetVariables,
+            componentInlineStyle,
             paginationIcons,
             selectedIndex,
             pages,

--- a/packages/vlossom/src/components/vs-pagination/VsPagination.vue
+++ b/packages/vlossom/src/components/vs-pagination/VsPagination.vue
@@ -16,7 +16,7 @@
             @click.prevent.stop="goFirst()"
         >
             <slot name="first">
-                <vs-render :content="paginationIcons.goFirst" />
+                <vs-render class="size-4" :content="paginationIcons.goFirst" />
             </slot>
         </vs-button>
         <vs-button
@@ -31,7 +31,7 @@
             @click.prevent.stop="goPrev()"
         >
             <slot name="prev">
-                <vs-render :content="paginationIcons.goPrev" />
+                <vs-render class="size-4" :content="paginationIcons.goPrev" />
             </slot>
         </vs-button>
         <div class="vs-page-buttons">
@@ -40,7 +40,7 @@
                 :key="page"
                 class="vs-page-button"
                 :color-scheme="computedColorScheme"
-                :style-set="componentStyleSet.$pageButton"
+                :style-set="getPageButtonStyleSet(page)"
                 :primary="page === selectedIndex + 1"
                 :disabled
                 :ghost
@@ -66,7 +66,7 @@
             @click.prevent.stop="goNext()"
         >
             <slot name="next">
-                <vs-render :content="paginationIcons.goNext" />
+                <vs-render class="size-4" :content="paginationIcons.goNext" />
             </slot>
         </vs-button>
         <vs-button
@@ -82,7 +82,7 @@
             @click.prevent.stop="goLast()"
         >
             <slot name="last">
-                <vs-render :content="paginationIcons.goLast" />
+                <vs-render class="size-4" :content="paginationIcons.goLast" />
             </slot>
         </vs-button>
     </div>
@@ -93,7 +93,7 @@ import { type ComputedRef, computed, defineComponent, toRefs, watch } from 'vue'
 import { VsComponent } from '@/declaration';
 import { useColorScheme, useStyleSet, useIndexSelector } from '@/composables';
 import { getColorSchemeProps, getStyleSetProps } from '@/props';
-import { logUtil } from '@/utils';
+import { logUtil, objectUtil } from '@/utils';
 import type { VsPaginationStyleSet } from './types';
 import { paginationIcons } from './icons';
 
@@ -144,9 +144,7 @@ export default defineComponent({
         const { colorScheme, styleSet, disabled, modelValue, length, showingLength } = toRefs(props);
         const { computedColorScheme, colorSchemeClass } = useColorScheme(componentName, colorScheme);
         const baseStyleSet: ComputedRef<VsPaginationStyleSet> = computed(() => ({
-            $controlButton: {
-                padding: '0.4rem',
-            },
+            $controlButton: { $content: { padding: '0' } },
         }));
 
         const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet<VsPaginationStyleSet>(
@@ -191,6 +189,14 @@ export default defineComponent({
             }
             return pageArr;
         });
+
+        function getPageButtonStyleSet(page: number) {
+            const { $selected = {}, ...base } = componentStyleSet.value.$pageButton ?? {};
+            if (page === selectedIndex.value + 1) {
+                return objectUtil.assign(base, $selected);
+            }
+            return base;
+        }
 
         function setPage(page: number) {
             selectIndex(page);
@@ -239,6 +245,7 @@ export default defineComponent({
             paginationIcons,
             selectedIndex,
             pages,
+            getPageButtonStyleSet,
             goFirst,
             goLast,
             goPrev,

--- a/packages/vlossom/src/components/vs-pagination/__stories__/vs-pagination.stories.ts
+++ b/packages/vlossom/src/components/vs-pagination/__stories__/vs-pagination.stories.ts
@@ -244,21 +244,15 @@ export const StyleSet: Story = {
     args: {
         length: 10,
         styleSet: {
-            $component: {
-                gap: '2rem',
-            },
+            gap: '2rem',
             $pageButton: {
-                $component: {
-                    borderRadius: '50%',
-                    width: '3rem',
-                    height: '3rem',
-                },
+                borderRadius: '50%',
+                width: '3rem',
+                height: '3rem',
             },
             $controlButton: {
-                $component: {
-                    borderRadius: '8px',
-                    padding: '0.6rem',
-                },
+                borderRadius: '8px',
+                padding: '0.6rem',
             },
         },
     },

--- a/packages/vlossom/src/components/vs-pagination/types.ts
+++ b/packages/vlossom/src/components/vs-pagination/types.ts
@@ -19,11 +19,8 @@ export interface VsPaginationRef extends ComponentPublicInstance<typeof VsPagina
 }
 
 export interface VsPaginationStyleSet extends CSSProperties {
-    // TODO: VsStateStyleSet 처리 필요
-    $selectedButtonBackgroundColor?: string;
-    $selectedButtonFontColor?: string;
-    // TODO: VsStateStyleSet 처리 필요 (이렇게 하면 되지 않을까?)
-    // $pageButton?: Omit<VsButtonStyleSet, '$loading'> & { $selected?: CSSProperties; };
-    $pageButton?: Omit<VsButtonStyleSet, '$loading'>;
+    $pageButton?: Omit<VsButtonStyleSet, '$loading'> & {
+        $selected?: Omit<VsButtonStyleSet, '$loading'>;
+    };
     $controlButton?: Omit<VsButtonStyleSet, '$loading'>;
 }

--- a/packages/vlossom/src/components/vs-pagination/types.ts
+++ b/packages/vlossom/src/components/vs-pagination/types.ts
@@ -18,11 +18,10 @@ export interface VsPaginationRef extends ComponentPublicInstance<typeof VsPagina
     setPage: (page: number) => void;
 }
 
-export interface VsPaginationStyleSet {
+export interface VsPaginationStyleSet extends CSSProperties {
     // TODO: VsStateStyleSet 처리 필요
     $selectedButtonBackgroundColor?: string;
     $selectedButtonFontColor?: string;
-    $component?: CSSProperties;
     // TODO: VsStateStyleSet 처리 필요 (이렇게 하면 되지 않을까?)
     // $pageButton?: Omit<VsButtonStyleSet, '$loading'> & { $selected?: CSSProperties; };
     $pageButton?: Omit<VsButtonStyleSet, '$loading'>;

--- a/packages/vlossom/src/components/vs-progress/README.ko.md
+++ b/packages/vlossom/src/components/vs-progress/README.ko.md
@@ -51,7 +51,7 @@
 ## Types
 
 ```typescript
-interface VsProgressStyleSet {
+interface VsProgressStyleSet extends CSSProperties {
     $barBackgroundColor?: string;
     $barBorder?: string;
     $barBorderRadius?: string;
@@ -59,7 +59,6 @@ interface VsProgressStyleSet {
     $labelTextShadow?: string;
     $labelFontColor?: string;
 
-    $component?: CSSProperties;
 }
 ```
 
@@ -76,7 +75,7 @@ interface VsProgressStyleSet {
             $barBorderRadius: '0.5rem',
             $valueBackgroundColor: '#6366f1',
             $labelFontColor: '#ffffff',
-            $component: { height: '1.5rem' },
+            height: '1.5rem',
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-progress/README.md
+++ b/packages/vlossom/src/components/vs-progress/README.md
@@ -51,7 +51,7 @@ A progress bar component that displays the completion status of a task.
 ## Types
 
 ```typescript
-interface VsProgressStyleSet {
+interface VsProgressStyleSet extends CSSProperties {
     $barBackgroundColor?: string;
     $barBorder?: string;
     $barBorderRadius?: string;
@@ -59,7 +59,6 @@ interface VsProgressStyleSet {
     $labelTextShadow?: string;
     $labelFontColor?: string;
 
-    $component?: CSSProperties;
 }
 ```
 
@@ -76,7 +75,7 @@ interface VsProgressStyleSet {
             $barBorderRadius: '0.5rem',
             $valueBackgroundColor: '#6366f1',
             $labelFontColor: '#ffffff',
-            $component: { height: '1.5rem' },
+            height: '1.5rem',
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-progress/VsProgress.vue
+++ b/packages/vlossom/src/components/vs-progress/VsProgress.vue
@@ -1,7 +1,7 @@
 <template>
     <progress
         :class="['vs-progress', colorSchemeClass]"
-        :style="{ ...styleSetVariables, ...componentStyleSet.$component }"
+        :style="{ ...styleSetVariables, ...componentInlineStyle }"
         :value="computedValue"
         :max="computedMax"
         :data-label="label"
@@ -44,7 +44,10 @@ export default defineComponent({
 
         const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { componentStyleSet, styleSetVariables } = useStyleSet<VsProgressStyleSet>(componentName, styleSet);
+        const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet<VsProgressStyleSet>(
+            componentName,
+            styleSet,
+        );
 
         const { value, max } = toRefs(props);
 
@@ -73,6 +76,7 @@ export default defineComponent({
             colorSchemeClass,
             componentStyleSet,
             styleSetVariables,
+            componentInlineStyle,
             computedValue,
             computedMax,
         };

--- a/packages/vlossom/src/components/vs-progress/VsProgress.vue
+++ b/packages/vlossom/src/components/vs-progress/VsProgress.vue
@@ -44,10 +44,7 @@ export default defineComponent({
 
         const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet<VsProgressStyleSet>(
-            componentName,
-            styleSet,
-        );
+        const { styleSetVariables, componentInlineStyle } = useStyleSet<VsProgressStyleSet>(componentName, styleSet);
 
         const { value, max } = toRefs(props);
 
@@ -74,7 +71,6 @@ export default defineComponent({
 
         return {
             colorSchemeClass,
-            componentStyleSet,
             styleSetVariables,
             componentInlineStyle,
             computedValue,

--- a/packages/vlossom/src/components/vs-progress/__stories__/vs-progress.stories.ts
+++ b/packages/vlossom/src/components/vs-progress/__stories__/vs-progress.stories.ts
@@ -25,10 +25,8 @@ const meta: Meta<typeof VsProgress> = {
                 $valueBackgroundColor: '#1e88e5',
                 $labelFontColor: '#fff',
                 $labelTextShadow: '1px 1px 2px rgba(0,0,0,0.3)',
-                $component: {
-                    width: '20rem',
-                    height: '1.5rem',
-                },
+                width: '20rem',
+                height: '1.5rem',
             } as const;
 
             useVlossom().styleSet = {
@@ -185,10 +183,8 @@ export const StyleSet: Story = {
             $valueBackgroundColor: '#e188e5',
             $labelFontColor: '#fff',
             $labelTextShadow: '2px 2px 4px rgba(0,0,0,0.4)',
-            $component: {
-                width: '25rem',
-                height: '2rem',
-            },
+            width: '25rem',
+            height: '2rem',
         },
     },
 };

--- a/packages/vlossom/src/components/vs-progress/types.ts
+++ b/packages/vlossom/src/components/vs-progress/types.ts
@@ -11,13 +11,11 @@ export type { VsProgress };
 
 export interface VsProgressRef extends ComponentPublicInstance<typeof VsProgress> {}
 
-export interface VsProgressStyleSet {
+export interface VsProgressStyleSet extends CSSProperties {
     $barBackgroundColor?: string;
     $barBorder?: string;
     $barBorderRadius?: string;
     $valueBackgroundColor?: string;
     $labelTextShadow?: string;
     $labelFontColor?: string;
-
-    $component?: CSSProperties;
 }

--- a/packages/vlossom/src/components/vs-radio/README.ko.md
+++ b/packages/vlossom/src/components/vs-radio/README.ko.md
@@ -142,8 +142,7 @@ interface VsRadioStyleSet {
     $wrapper?: VsInputWrapperStyleSet;
 }
 
-interface VsRadioSetStyleSet {
-    $component?: CSSProperties;
+interface VsRadioSetStyleSet extends CSSProperties {
     $radio?: VsRadioStyleSet;
     $wrapper?: VsInputWrapperStyleSet;
 }
@@ -160,7 +159,7 @@ interface VsRadioSetStyleSet {
         v-model="selected"
         :options="options"
         :style-set="{
-            $component: { gap: '1rem' },
+            gap: '1rem',
             $radio: {
                 $radioColor: '#6366f1',
                 $radioSize: '1.2rem',

--- a/packages/vlossom/src/components/vs-radio/README.md
+++ b/packages/vlossom/src/components/vs-radio/README.md
@@ -142,8 +142,7 @@ interface VsRadioStyleSet {
     $wrapper?: VsInputWrapperStyleSet;
 }
 
-interface VsRadioSetStyleSet {
-    $component?: CSSProperties;
+interface VsRadioSetStyleSet extends CSSProperties {
     $radio?: VsRadioStyleSet;
     $wrapper?: VsInputWrapperStyleSet;
 }
@@ -160,7 +159,7 @@ interface VsRadioSetStyleSet {
         v-model="selected"
         :options="options"
         :style-set="{
-            $component: { gap: '1rem' },
+            gap: '1rem',
             $radio: {
                 $radioColor: '#6366f1',
                 $radioSize: '1.2rem',

--- a/packages/vlossom/src/components/vs-radio/VsRadioSet.vue
+++ b/packages/vlossom/src/components/vs-radio/VsRadioSet.vue
@@ -17,7 +17,7 @@
             <slot name="label" />
         </template>
 
-        <div :class="['vs-radio-set', colorSchemeClass, classObj]" :style="componentStyleSet.$component">
+        <div :class="['vs-radio-set', colorSchemeClass, classObj]" :style="componentInlineStyle">
             <vs-radio
                 v-for="(option, index) in options"
                 :key="getOptionValue(option)"
@@ -116,7 +116,7 @@ export default defineComponent({
 
         const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { componentStyleSet } = useStyleSet<VsRadioSetStyleSet>(componentName, styleSet);
+        const { componentStyleSet, componentInlineStyle } = useStyleSet<VsRadioSetStyleSet>(componentName, styleSet);
 
         const { getOptionLabel, getOptionValue } = useInputOption(inputValue, options, optionLabel, optionValue);
 
@@ -199,6 +199,7 @@ export default defineComponent({
             radioRefs,
             colorSchemeClass,
             componentStyleSet,
+            componentInlineStyle,
             classObj,
             computedId,
             computedMessages,

--- a/packages/vlossom/src/components/vs-radio/__stories__/vs-radio-set.stories.ts
+++ b/packages/vlossom/src/components/vs-radio/__stories__/vs-radio-set.stories.ts
@@ -133,9 +133,7 @@ export const StyleSet: Story = {
         label: 'Custom Style',
         options: ['Option 1', 'Option 2', 'Option 3'],
         styleSet: {
-            $component: {
-                gap: '2rem',
-            },
+            gap: '2rem',
             $radio: {
                 $radioColor: '#7c3aed',
                 $radioSize: '1.2rem',

--- a/packages/vlossom/src/components/vs-radio/types.ts
+++ b/packages/vlossom/src/components/vs-radio/types.ts
@@ -25,8 +25,7 @@ export interface VsRadioStyleSet {
     $wrapper?: VsInputWrapperStyleSet;
 }
 
-export interface VsRadioSetStyleSet {
-    $component?: CSSProperties;
+export interface VsRadioSetStyleSet extends CSSProperties {
     $radio?: VsRadioStyleSet;
     $wrapper?: VsInputWrapperStyleSet;
 }

--- a/packages/vlossom/src/components/vs-search-input/README.ko.md
+++ b/packages/vlossom/src/components/vs-search-input/README.ko.md
@@ -91,7 +91,7 @@ interface VsSearchInputStyleSet extends VsInputStyleSet {
 ```
 
 > [!NOTE]
-> [VsInputStyleSet](../vs-input/README.md#types)의 모든 속성(`$prepend`, `$append`, `$input`, `$component`, `$wrapper`)을 상속합니다. `$toggle`은 [VsToggleStyleSet](../vs-toggle/README.md#types)을 사용합니다.
+> [VsInputStyleSet](../vs-input/README.md#types)의 모든 속성(`$prepend`, `$append`, `$input`, `$wrapper`)과 `CSSProperties`를 상속합니다. `$toggle`은 [VsToggleStyleSet](../vs-toggle/README.md#types)을 사용합니다.
 
 ### StyleSet 사용 예시
 
@@ -100,7 +100,7 @@ interface VsSearchInputStyleSet extends VsInputStyleSet {
     <vs-search-input
         v-model="query"
         :style-set="{
-            $component: { borderRadius: '1rem' },
+            borderRadius: '1rem',
             $input: { height: '2.5rem' },
         }"
     />

--- a/packages/vlossom/src/components/vs-search-input/README.md
+++ b/packages/vlossom/src/components/vs-search-input/README.md
@@ -91,7 +91,7 @@ interface VsSearchInputStyleSet extends VsInputStyleSet {
 ```
 
 > [!NOTE]
-> Inherits all properties from [VsInputStyleSet](../vs-input/README.md#types) (`$prepend`, `$append`, `$input`, `$component`, `$wrapper`). `$toggle` uses [VsToggleStyleSet](../vs-toggle/README.md#types).
+> Inherits all properties from [VsInputStyleSet](../vs-input/README.md#types) (`$prepend`, `$append`, `$input`, `$wrapper`) and `CSSProperties`. `$toggle` uses [VsToggleStyleSet](../vs-toggle/README.md#types).
 
 ### StyleSet Example
 
@@ -100,7 +100,7 @@ interface VsSearchInputStyleSet extends VsInputStyleSet {
     <vs-search-input
         v-model="query"
         :style-set="{
-            $component: { borderRadius: '1rem' },
+            borderRadius: '1rem',
             $input: { height: '2.5rem' },
         }"
     />

--- a/packages/vlossom/src/components/vs-search-input/__stories__/vs-search-input.stories.ts
+++ b/packages/vlossom/src/components/vs-search-input/__stories__/vs-search-input.stories.ts
@@ -239,12 +239,10 @@ export const StyleSet: Story = {
         useRegex: true,
         useCaseSensitive: true,
         styleSet: {
-            $component: {
-                backgroundColor: '#f0f8ff',
-                border: '2px solid #1e88e5',
-                borderRadius: '12px',
-                height: '3.5rem',
-            },
+            backgroundColor: '#f0f8ff',
+            border: '2px solid #1e88e5',
+            borderRadius: '12px',
+            height: '3.5rem',
             $input: {
                 color: '#1565c0',
                 fontSize: '1.1rem',

--- a/packages/vlossom/src/components/vs-select/README.ko.md
+++ b/packages/vlossom/src/components/vs-select/README.ko.md
@@ -112,22 +112,19 @@ const options = [
 ```typescript
 interface VsSelectStyleSet extends CSSProperties {
     $height?: string;
-    $focused?: {
-        border?: string;
-        borderRadius?: string;
-        backgroundColor?: string;
-    };
     $wrapper?: VsInputWrapperStyleSet;
     $chip?: VsChipStyleSet;
     $selectAllCheckbox?: VsCheckboxStyleSet;
     $options?: VsGroupedListStyleSet;
-    $option?: CSSProperties;
-    $selectedOption?: CSSProperties;
+    $option?: CSSProperties & {
+        $focused?: CSSProperties;
+        $selected?: CSSProperties;
+    };
 }
 ```
 
 > [!NOTE]
-> `$wrapper`는 [VsInputWrapperStyleSet](../vs-input-wrapper/README.md#types), `$chip`은 [VsChipStyleSet](../vs-chip/README.md#types), `$selectAllCheckbox`는 [VsCheckboxStyleSet](../vs-checkbox/README.md#types), `$options`는 [VsGroupedListStyleSet](../vs-grouped-list/README.md#types)을 사용합니다.
+> `$wrapper`는 [VsInputWrapperStyleSet](../vs-input-wrapper/README.md#types), `$chip`은 [VsChipStyleSet](../vs-chip/README.md#types), `$selectAllCheckbox`는 [VsCheckboxStyleSet](../vs-checkbox/README.md#types), `$options`는 [VsGroupedListStyleSet](../vs-grouped-list/README.md#types)을 사용합니다. `$option.$focused`는 키보드로 포커스된 옵션에 적용되고, `$option.$selected`는 선택된 옵션에 적용됩니다.
 
 ### StyleSet 사용 예시
 
@@ -138,9 +135,11 @@ interface VsSelectStyleSet extends CSSProperties {
         :options="options"
         :style-set="{
             $height: '2.5rem',
-            $focused: { border: '2px solid #6366f1' },
-            $option: { padding: '0.5rem 1rem' },
-            $selectedOption: { backgroundColor: '#ede9fe', fontWeight: 'bold' },
+            $option: {
+                padding: '0.5rem 1rem',
+                $focused: { backgroundColor: '#eef2ff' },
+                $selected: { backgroundColor: '#ede9fe', fontWeight: 'bold' },
+            },
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-select/README.ko.md
+++ b/packages/vlossom/src/components/vs-select/README.ko.md
@@ -110,14 +110,13 @@ const options = [
 ## Types
 
 ```typescript
-interface VsSelectStyleSet {
+interface VsSelectStyleSet extends CSSProperties {
     $height?: string;
     $focused?: {
         border?: string;
         borderRadius?: string;
         backgroundColor?: string;
     };
-    $component?: CSSProperties;
     $wrapper?: VsInputWrapperStyleSet;
     $chip?: VsChipStyleSet;
     $selectAllCheckbox?: VsCheckboxStyleSet;

--- a/packages/vlossom/src/components/vs-select/README.md
+++ b/packages/vlossom/src/components/vs-select/README.md
@@ -110,14 +110,13 @@ const options = [
 ## Types
 
 ```typescript
-interface VsSelectStyleSet {
+interface VsSelectStyleSet extends CSSProperties {
     $height?: string;
     $focused?: {
         border?: string;
         borderRadius?: string;
         backgroundColor?: string;
     };
-    $component?: CSSProperties;
     $wrapper?: VsInputWrapperStyleSet;
     $chip?: VsChipStyleSet;
     $selectAllCheckbox?: VsCheckboxStyleSet;

--- a/packages/vlossom/src/components/vs-select/README.md
+++ b/packages/vlossom/src/components/vs-select/README.md
@@ -112,22 +112,19 @@ const options = [
 ```typescript
 interface VsSelectStyleSet extends CSSProperties {
     $height?: string;
-    $focused?: {
-        border?: string;
-        borderRadius?: string;
-        backgroundColor?: string;
-    };
     $wrapper?: VsInputWrapperStyleSet;
     $chip?: VsChipStyleSet;
     $selectAllCheckbox?: VsCheckboxStyleSet;
     $options?: VsGroupedListStyleSet;
-    $option?: CSSProperties;
-    $selectedOption?: CSSProperties;
+    $option?: CSSProperties & {
+        $focused?: CSSProperties;
+        $selected?: CSSProperties;
+    };
 }
 ```
 
 > [!NOTE]
-> `$wrapper` uses [VsInputWrapperStyleSet](../vs-input-wrapper/README.md#types), `$chip` uses [VsChipStyleSet](../vs-chip/README.md#types), `$selectAllCheckbox` uses [VsCheckboxStyleSet](../vs-checkbox/README.md#types), and `$options` uses [VsGroupedListStyleSet](../vs-grouped-list/README.md#types).
+> `$wrapper` uses [VsInputWrapperStyleSet](../vs-input-wrapper/README.md#types), `$chip` uses [VsChipStyleSet](../vs-chip/README.md#types), `$selectAllCheckbox` uses [VsCheckboxStyleSet](../vs-checkbox/README.md#types), and `$options` uses [VsGroupedListStyleSet](../vs-grouped-list/README.md#types). The `$option.$focused` style is applied to the keyboard-focused option, and `$option.$selected` is applied to selected options.
 
 ### StyleSet Example
 
@@ -138,9 +135,11 @@ interface VsSelectStyleSet extends CSSProperties {
         :options="options"
         :style-set="{
             $height: '2.5rem',
-            $focused: { border: '2px solid #6366f1' },
-            $option: { padding: '0.5rem 1rem' },
-            $selectedOption: { backgroundColor: '#ede9fe', fontWeight: 'bold' },
+            $option: {
+                padding: '0.5rem 1rem',
+                $focused: { backgroundColor: '#eef2ff' },
+                $selected: { backgroundColor: '#ede9fe', fontWeight: 'bold' },
+            },
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-select/VsSelect.css
+++ b/packages/vlossom/src/components/vs-select/VsSelect.css
@@ -57,10 +57,6 @@
 }
 
 .vs-select-options {
-    --vs-select-focused-border: initial;
-    --vs-select-focused-borderRadius: initial;
-    --vs-select-focused-backgroundColor: initial;
-
     @apply overflow-hidden;
 
     border: 1px solid var(--vs-cs-line);
@@ -72,7 +68,7 @@
 
         &.vs-focusable-active {
             @apply box-content;
-            background-color: var(--vs-select-focused-backgroundColor, var(--vs-cs-bg-colored)) !important;
+            background-color: var(--vs-cs-bg-colored);
         }
     }
 

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -86,12 +86,12 @@
                                 'vs-select-focusable',
                                 { selected: isSelected(itemSlotProps.id) },
                             ]"
-                            :style="componentStyleSet.$option"
+                            :style="getOptionStyleSet(itemSlotProps.id)"
                             :data-id="itemSlotProps.id"
                             :data-focusable="itemSlotProps.disabled ? undefined : true"
                         >
                             <slot name="option" v-bind="{ ...itemSlotProps, selected: isSelected(itemSlotProps.id) }">
-                                <div class="vs-select-option" :style="getOptionStyleSet(itemSlotProps.id)">
+                                <div class="vs-select-option">
                                     {{ itemSlotProps.label }}
                                 </div>
                             </slot>
@@ -455,10 +455,15 @@ export default defineComponent({
         }
 
         function getOptionStyleSet(optionId: string): CSSProperties {
-            return {
-                ...componentStyleSet.value.$option,
-                ...(isSelected(optionId) ? componentStyleSet.value.$selectedOption : {}),
-            };
+            const { $focused = {}, $selected = {}, ...base } = componentStyleSet.value.$option ?? {};
+            const isOptionFocused = currentFocusableElement.value?.dataset?.['id'] === optionId;
+            if (isSelected(optionId)) {
+                return objectUtil.assign(base, $selected);
+            }
+            if (isOptionFocused) {
+                return objectUtil.assign(base, $focused);
+            }
+            return base;
         }
 
         function closeOptions() {

--- a/packages/vlossom/src/components/vs-select/VsSelectTrigger.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelectTrigger.vue
@@ -2,7 +2,7 @@
     <div
         ref="triggerRef"
         :class="['vs-select-trigger', stateBoxClasses, triggerClassObj]"
-        :style="inlineStyle"
+        :style="componentInlineStyle"
         tabindex="0"
         @focus="$emit('focus', $event)"
         @blur="$emit('blur', $event)"
@@ -17,7 +17,7 @@
                     <vs-chip
                         :color-scheme
                         :closable="closableChips"
-                        :style-set="styleSet?.$chip"
+                        :style-set="componentStyleSet.$chip"
                         primary
                         size="xs"
                         @close="$emit('deselect', selectedOptions[0].id)"
@@ -32,7 +32,7 @@
                         :key="option.id"
                         :color-scheme
                         :closable="closableChips"
-                        :style-set="styleSet?.$chip"
+                        :style-set="componentStyleSet.$chip"
                         primary
                         size="xs"
                         @close="$emit('deselect', option.id)"
@@ -62,8 +62,8 @@
 
 <script lang="ts">
 import { computed, defineComponent, toRefs, useTemplateRef, type PropType, type TemplateRef } from 'vue';
-import type { ColorScheme, OptionItem, UIState } from '@/declaration';
-import { extractInlineStyle, useStateClass } from '@/composables';
+import { VsComponent, type ColorScheme, type OptionItem, type UIState } from '@/declaration';
+import { useStateClass, useStyleSet } from '@/composables';
 import { closeIcon } from '@/icons';
 import type { VsSelectStyleSet } from './types';
 import { selectIcons } from './icons';
@@ -100,7 +100,10 @@ export default defineComponent({
 
         const { stateBoxClasses } = useStateClass(state);
 
-        const inlineStyle = computed(() => extractInlineStyle(styleSet.value));
+        const { componentInlineStyle, componentStyleSet } = useStyleSet<VsSelectStyleSet>(
+            VsComponent.VsSelect,
+            styleSet,
+        );
 
         const renderClearButton = computed(
             () => !noClear.value && !readonly.value && !disabled.value && !isEmpty.value,
@@ -135,7 +138,8 @@ export default defineComponent({
             renderClearButton,
             displayLabel,
             triggerClassObj,
-            inlineStyle,
+            componentStyleSet,
+            componentInlineStyle,
             focus,
             blur,
         };

--- a/packages/vlossom/src/components/vs-select/VsSelectTrigger.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelectTrigger.vue
@@ -2,7 +2,7 @@
     <div
         ref="triggerRef"
         :class="['vs-select-trigger', stateBoxClasses, triggerClassObj]"
-        :style="styleSet?.$component"
+        :style="inlineStyle"
         tabindex="0"
         @focus="$emit('focus', $event)"
         @blur="$emit('blur', $event)"
@@ -63,7 +63,7 @@
 <script lang="ts">
 import { computed, defineComponent, toRefs, useTemplateRef, type PropType, type TemplateRef } from 'vue';
 import type { ColorScheme, OptionItem, UIState } from '@/declaration';
-import { useStateClass } from '@/composables';
+import { extractInlineStyle, useStateClass } from '@/composables';
 import { closeIcon } from '@/icons';
 import type { VsSelectStyleSet } from './types';
 import { selectIcons } from './icons';
@@ -94,11 +94,13 @@ export default defineComponent({
     },
     emits: ['click', 'deselect', 'clear', 'focus', 'blur'],
     setup(props) {
-        const { isEmpty, selectedOptions, state, noClear, disabled, readonly } = toRefs(props);
+        const { isEmpty, selectedOptions, state, noClear, disabled, readonly, styleSet } = toRefs(props);
 
         const triggerRef: TemplateRef<HTMLElement> = useTemplateRef('triggerRef');
 
         const { stateBoxClasses } = useStateClass(state);
+
+        const inlineStyle = computed(() => extractInlineStyle(styleSet.value));
 
         const renderClearButton = computed(
             () => !noClear.value && !readonly.value && !disabled.value && !isEmpty.value,
@@ -133,6 +135,7 @@ export default defineComponent({
             renderClearButton,
             displayLabel,
             triggerClassObj,
+            inlineStyle,
             focus,
             blur,
         };

--- a/packages/vlossom/src/components/vs-select/__stories__/vs-select.stories.ts
+++ b/packages/vlossom/src/components/vs-select/__stories__/vs-select.stories.ts
@@ -232,9 +232,7 @@ export const StyleSet: Story = {
                 borderRadius: '12px',
                 backgroundColor: '#f5f5f5',
             },
-            $component: {
-                fontSize: '1rem',
-            },
+            fontSize: '1rem',
         },
         modelValue: null,
     },

--- a/packages/vlossom/src/components/vs-select/__stories__/vs-select.stories.ts
+++ b/packages/vlossom/src/components/vs-select/__stories__/vs-select.stories.ts
@@ -227,10 +227,10 @@ export const StyleSet: Story = {
         placeholder: 'Select an option',
         styleSet: {
             $height: '3rem',
-            $focused: {
-                border: '2px solid #2196f3',
-                borderRadius: '12px',
-                backgroundColor: '#f5f5f5',
+            $option: {
+                $focused: {
+                    backgroundColor: '#f5f5f5',
+                },
             },
             fontSize: '1rem',
         },

--- a/packages/vlossom/src/components/vs-select/types.ts
+++ b/packages/vlossom/src/components/vs-select/types.ts
@@ -19,7 +19,7 @@ export interface VsSelectRef extends ComponentPublicInstance<typeof VsSelect> {}
 
 export interface VsSelectTriggerRef extends ComponentPublicInstance<typeof VsSelectTrigger>, FocusableRef {}
 
-export interface VsSelectStyleSet {
+export interface VsSelectStyleSet extends CSSProperties {
     $height?: string;
     // TODO: VsStateStyleSet 처리 필요
     $focused?: {
@@ -27,7 +27,6 @@ export interface VsSelectStyleSet {
         borderRadius?: string;
         backgroundColor?: string;
     };
-    $component?: CSSProperties;
     $wrapper?: VsInputWrapperStyleSet;
     $chip?: VsChipStyleSet;
     $selectAllCheckbox?: VsCheckboxStyleSet;

--- a/packages/vlossom/src/components/vs-select/types.ts
+++ b/packages/vlossom/src/components/vs-select/types.ts
@@ -21,16 +21,12 @@ export interface VsSelectTriggerRef extends ComponentPublicInstance<typeof VsSel
 
 export interface VsSelectStyleSet extends CSSProperties {
     $height?: string;
-    // TODO: VsStateStyleSet 처리 필요
-    $focused?: {
-        border?: string;
-        borderRadius?: string;
-        backgroundColor?: string;
-    };
     $wrapper?: VsInputWrapperStyleSet;
     $chip?: VsChipStyleSet;
     $selectAllCheckbox?: VsCheckboxStyleSet;
     $options?: VsGroupedListStyleSet;
-    $option?: CSSProperties;
-    $selectedOption?: CSSProperties;
+    $option?: CSSProperties & {
+        $focused?: CSSProperties;
+        $selected?: CSSProperties;
+    };
 }

--- a/packages/vlossom/src/components/vs-skeleton/README.ko.md
+++ b/packages/vlossom/src/components/vs-skeleton/README.ko.md
@@ -37,7 +37,7 @@
 <template>
     <vs-skeleton
         :style-set="{
-            $component: { width: '150px', height: '150px', borderRadius: '50%' },
+            width: '150px', height: '150px', borderRadius: '50%',
         }"
     />
 </template>
@@ -53,10 +53,9 @@
 ## Types
 
 ```typescript
-interface VsSkeletonStyleSet {
+interface VsSkeletonStyleSet extends CSSProperties {
     $background?: CSSProperties;
     $content?: CSSProperties;
-    $component?: CSSProperties;
 }
 ```
 
@@ -66,7 +65,7 @@ interface VsSkeletonStyleSet {
 <template>
     <vs-skeleton
         :style-set="{
-            $component: { width: '100%', height: '2rem', borderRadius: '0.5rem' },
+            width: '100%', height: '2rem', borderRadius: '0.5rem',
             $background: { backgroundColor: '#e0e0e0' },
             $content: { color: '#999' },
         }"

--- a/packages/vlossom/src/components/vs-skeleton/README.md
+++ b/packages/vlossom/src/components/vs-skeleton/README.md
@@ -37,7 +37,7 @@ A skeleton loading placeholder component that displays an animated background wh
 <template>
     <vs-skeleton
         :style-set="{
-            $component: { width: '150px', height: '150px', borderRadius: '50%' },
+            width: '150px', height: '150px', borderRadius: '50%',
         }"
     />
 </template>
@@ -53,10 +53,9 @@ A skeleton loading placeholder component that displays an animated background wh
 ## Types
 
 ```typescript
-interface VsSkeletonStyleSet {
+interface VsSkeletonStyleSet extends CSSProperties {
     $background?: CSSProperties;
     $content?: CSSProperties;
-    $component?: CSSProperties;
 }
 ```
 
@@ -66,7 +65,7 @@ interface VsSkeletonStyleSet {
 <template>
     <vs-skeleton
         :style-set="{
-            $component: { width: '100%', height: '2rem', borderRadius: '0.5rem' },
+            width: '100%', height: '2rem', borderRadius: '0.5rem',
             $background: { backgroundColor: '#e0e0e0' },
             $content: { color: '#999' },
         }"

--- a/packages/vlossom/src/components/vs-skeleton/VsSkeleton.vue
+++ b/packages/vlossom/src/components/vs-skeleton/VsSkeleton.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="['vs-skeleton', colorSchemeClass]" :style="componentStyleSet.$component">
+    <div :class="['vs-skeleton', colorSchemeClass]" :style="componentInlineStyle">
         <div class="vs-skeleton-bg" :style="componentStyleSet.$background" />
         <div class="vs-skeleton-content" :style="componentStyleSet.$content">
             <slot />
@@ -26,11 +26,12 @@ export default defineComponent({
 
         const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { componentStyleSet } = useStyleSet<VsSkeletonStyleSet>(componentName, styleSet);
+        const { componentStyleSet, componentInlineStyle } = useStyleSet<VsSkeletonStyleSet>(componentName, styleSet);
 
         return {
             colorSchemeClass,
             componentStyleSet,
+            componentInlineStyle,
         };
     },
 });

--- a/packages/vlossom/src/components/vs-skeleton/__stories__/vs-skeleton.stories.ts
+++ b/packages/vlossom/src/components/vs-skeleton/__stories__/vs-skeleton.stories.ts
@@ -100,7 +100,7 @@ export const StyleSetUsages: Story = {
 
             <vs-grid :grid-size="3" :column-gap="16" :row-gap="16" width="500px" height="200px" class="mt-4">
                 <div class="flex flex-row items-center justify-center">
-                    <vs-avatar :style-set="{ $component: { border: 'unset' } }">
+                    <vs-avatar :style-set="{ border: 'unset' }">
                         <img v-if="!isLoading" src="https://upload.wikimedia.org/wikipedia/en/a/a6/Pok%C3%A9mon_Pikachu_art.png" alt="pikachu">
                         <vs-skeleton color-scheme="yellow" v-else />
                     </vs-avatar>
@@ -127,7 +127,7 @@ export const StyleSetUsages: Story = {
                     </div>
                 </div>
                 <div class="flex flex-row items-center justify-center">
-                    <vs-avatar :style-set="{ $component: { border: 'unset' } }">
+                    <vs-avatar :style-set="{ border: 'unset' }">
                         <img v-if="!isLoading" src="https://upload.wikimedia.org/wikipedia/en/5/59/Pok%C3%A9mon_Squirtle_art.png" alt="pikachu">
                         <vs-skeleton color-scheme="blue" v-else />
                     </vs-avatar>

--- a/packages/vlossom/src/components/vs-skeleton/types.ts
+++ b/packages/vlossom/src/components/vs-skeleton/types.ts
@@ -11,8 +11,7 @@ export type { VsSkeleton };
 
 export interface VsSkeletonRef extends ComponentPublicInstance<typeof VsSkeleton> {}
 
-export interface VsSkeletonStyleSet {
-    $component?: CSSProperties;
+export interface VsSkeletonStyleSet extends CSSProperties {
     $background?: CSSProperties;
     $content?: CSSProperties;
 }

--- a/packages/vlossom/src/components/vs-steps/README.ko.md
+++ b/packages/vlossom/src/components/vs-steps/README.ko.md
@@ -79,14 +79,22 @@ interface VsStepsStyleSet extends CSSProperties {
     $stepSize?: string;
 
     $steps?: CSSProperties;
-    $step?: CSSProperties;
-    $activeStep?: CSSProperties;
-    $label?: CSSProperties;
-    $activeLabel?: CSSProperties;
-    $progress?: CSSProperties;
-    $activeProgress?: CSSProperties;
+    $step?: CSSProperties & {
+        $completed?: CSSProperties;
+        $active?: CSSProperties;
+    };
+    $label?: CSSProperties & {
+        $completed?: CSSProperties;
+        $active?: CSSProperties;
+    };
+    $progress?: CSSProperties & {
+        $active?: CSSProperties;
+    };
 }
 ```
+
+> [!NOTE]
+> `$completed`는 이미 완료된 단계에, `$active`는 현재 단계에 적용됩니다. `$progress`는 progress 트랙(빈 경로), `$progress.$active`는 채워진 부분 스타일입니다.
 
 ### StyleSet 사용 예시
 
@@ -97,10 +105,15 @@ interface VsStepsStyleSet extends CSSProperties {
         :steps="steps"
         :style-set="{
             $stepSize: '2rem',
-            $step: { border: '2px solid #d1d5db' },
-            $activeStep: { backgroundColor: '#6366f1', borderColor: '#6366f1', color: '#fff' },
-            $progress: { backgroundColor: '#a5b4fc' },
-            $activeProgress: { backgroundColor: '#6366f1' },
+            $step: {
+                border: '2px solid #d1d5db',
+                $completed: { backgroundColor: '#a5b4fc', borderColor: '#a5b4fc', color: '#fff' },
+                $active: { backgroundColor: '#6366f1', borderColor: '#6366f1', color: '#fff' },
+            },
+            $progress: {
+                backgroundColor: '#e5e7eb',
+                $active: { backgroundColor: '#6366f1' },
+            },
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-steps/README.ko.md
+++ b/packages/vlossom/src/components/vs-steps/README.ko.md
@@ -75,10 +75,9 @@ const steps = ['1단계', '2단계', '3단계', '4단계'];
 ## Types
 
 ```typescript
-interface VsStepsStyleSet {
+interface VsStepsStyleSet extends CSSProperties {
     $stepSize?: string;
 
-    $component?: CSSProperties;
     $steps?: CSSProperties;
     $step?: CSSProperties;
     $activeStep?: CSSProperties;

--- a/packages/vlossom/src/components/vs-steps/README.md
+++ b/packages/vlossom/src/components/vs-steps/README.md
@@ -79,14 +79,22 @@ interface VsStepsStyleSet extends CSSProperties {
     $stepSize?: string;
 
     $steps?: CSSProperties;
-    $step?: CSSProperties;
-    $activeStep?: CSSProperties;
-    $label?: CSSProperties;
-    $activeLabel?: CSSProperties;
-    $progress?: CSSProperties;
-    $activeProgress?: CSSProperties;
+    $step?: CSSProperties & {
+        $completed?: CSSProperties;
+        $active?: CSSProperties;
+    };
+    $label?: CSSProperties & {
+        $completed?: CSSProperties;
+        $active?: CSSProperties;
+    };
+    $progress?: CSSProperties & {
+        $active?: CSSProperties;
+    };
 }
 ```
+
+> [!NOTE]
+> `$completed` applies to completed steps (passed) and `$active` applies to the current step. `$progress` styles the progress track (empty path) and `$progress.$active` styles the filled portion.
 
 ### StyleSet Example
 
@@ -97,10 +105,15 @@ interface VsStepsStyleSet extends CSSProperties {
         :steps="steps"
         :style-set="{
             $stepSize: '2rem',
-            $step: { border: '2px solid #d1d5db' },
-            $activeStep: { backgroundColor: '#6366f1', borderColor: '#6366f1', color: '#fff' },
-            $progress: { backgroundColor: '#a5b4fc' },
-            $activeProgress: { backgroundColor: '#6366f1' },
+            $step: {
+                border: '2px solid #d1d5db',
+                $completed: { backgroundColor: '#a5b4fc', borderColor: '#a5b4fc', color: '#fff' },
+                $active: { backgroundColor: '#6366f1', borderColor: '#6366f1', color: '#fff' },
+            },
+            $progress: {
+                backgroundColor: '#e5e7eb',
+                $active: { backgroundColor: '#6366f1' },
+            },
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-steps/README.md
+++ b/packages/vlossom/src/components/vs-steps/README.md
@@ -75,10 +75,9 @@ const steps = ['Step 1', 'Step 2', 'Step 3', 'Step 4'];
 ## Types
 
 ```typescript
-interface VsStepsStyleSet {
+interface VsStepsStyleSet extends CSSProperties {
     $stepSize?: string;
 
-    $component?: CSSProperties;
     $steps?: CSSProperties;
     $step?: CSSProperties;
     $activeStep?: CSSProperties;

--- a/packages/vlossom/src/components/vs-steps/VsSteps.vue
+++ b/packages/vlossom/src/components/vs-steps/VsSteps.vue
@@ -5,7 +5,7 @@
         :width
         :grid
     >
-        <div class="vs-step-line">
+        <div class="vs-step-line" :style="trackStyleSet">
             <div class="vs-step-progress" :style="progressStyleSet" />
         </div>
         <ul
@@ -75,9 +75,9 @@ import {
 import { useColorScheme, useStyleSet, useIndexSelector } from '@/composables';
 import { getResponsiveProps, getColorSchemeProps, getStyleSetProps } from '@/props';
 import { NOT_SELECTED, VsComponent } from '@/declaration';
+import { objectUtil, stringUtil } from '@/utils';
 import VsResponsive from '@/components/vs-responsive/VsResponsive.vue';
 import type { VsStepsStyleSet } from './types';
-import { objectUtil, stringUtil } from '@/utils';
 
 const componentName = VsComponent.VsSteps;
 export default defineComponent({
@@ -135,6 +135,11 @@ export default defineComponent({
             handleKeydown,
         } = useIndexSelector(steps, disabled);
 
+        const trackStyleSet: ComputedRef<CSSProperties> = computed(() => {
+            const { $active, ...base } = componentStyleSet.value.$progress ?? {};
+            return base;
+        });
+
         const progressStyleSet: ComputedRef<CSSProperties> = computed(() => {
             const dimensionKey = vertical.value ? 'height' : 'width';
             if (gapCount.value === 0) {
@@ -143,24 +148,31 @@ export default defineComponent({
 
             const percentage = selectedIndex.value === NOT_SELECTED ? 0 : (selectedIndex.value / gapCount.value) * 100;
             return {
-                ...componentStyleSet.value.$progress,
-                ...(isSelected(selectedIndex.value) ? componentStyleSet.value.$activeProgress : {}),
+                ...componentStyleSet.value.$progress?.$active,
                 [dimensionKey]: `${percentage}%`,
             };
         });
 
         function getStepStyleSet(index: number): CSSProperties {
-            return {
-                ...componentStyleSet.value.$step,
-                ...(isPrevious(index) || isSelected(index) ? componentStyleSet.value.$activeStep : {}),
-            };
+            const { $completed = {}, $active = {}, ...base } = componentStyleSet.value.$step ?? {};
+            if (isPrevious(index)) {
+                return objectUtil.assign(base, $completed);
+            }
+            if (isSelected(index)) {
+                return objectUtil.assign(base, $active);
+            }
+            return base;
         }
 
         function getLabelStyleSet(index: number): CSSProperties {
-            return {
-                ...componentStyleSet.value.$label,
-                ...(isPrevious(index) || isSelected(index) ? componentStyleSet.value.$activeLabel : {}),
-            };
+            const { $completed = {}, $active = {}, ...base } = componentStyleSet.value.$label ?? {};
+            if (isPrevious(index)) {
+                return objectUtil.assign(base, $completed);
+            }
+            if (isSelected(index)) {
+                return objectUtil.assign(base, $active);
+            }
+            return base;
         }
 
         onMounted(() => {
@@ -185,6 +197,7 @@ export default defineComponent({
             componentStyleSet,
             styleSetVariables,
             componentInlineStyle,
+            trackStyleSet,
             progressStyleSet,
             getStepStyleSet,
             getLabelStyleSet,

--- a/packages/vlossom/src/components/vs-steps/VsSteps.vue
+++ b/packages/vlossom/src/components/vs-steps/VsSteps.vue
@@ -1,7 +1,7 @@
 <template>
     <vs-responsive
         :class="['vs-steps', colorSchemeClass, { 'vs-vertical': vertical }]"
-        :style="{ ...styleSetVariables, ...componentStyleSet.$component }"
+        :style="{ ...styleSetVariables, ...componentInlineStyle }"
         :width
         :grid
     >
@@ -111,13 +111,11 @@ export default defineComponent({
 
         const additionalStyleSet: ComputedRef<Partial<VsStepsStyleSet>> = computed(() => {
             return objectUtil.shake({
-                $component: {
-                    height: height.value === undefined ? undefined : stringUtil.toStringSize(height.value),
-                },
+                height: height.value === undefined ? undefined : stringUtil.toStringSize(height.value),
             });
         });
 
-        const { componentStyleSet, styleSetVariables } = useStyleSet<VsStepsStyleSet>(
+        const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet<VsStepsStyleSet>(
             componentName,
             styleSet,
             baseStyleSet,
@@ -186,6 +184,7 @@ export default defineComponent({
             colorSchemeClass,
             componentStyleSet,
             styleSetVariables,
+            componentInlineStyle,
             progressStyleSet,
             getStepStyleSet,
             getLabelStyleSet,

--- a/packages/vlossom/src/components/vs-steps/__stories__/vs-steps.stories.ts
+++ b/packages/vlossom/src/components/vs-steps/__stories__/vs-steps.stories.ts
@@ -29,17 +29,24 @@ const meta: Meta<typeof VsSteps> = {
                     padding: '0.5rem',
                     width: '2.5rem',
                     height: '2.5rem',
-                },
-                $activeStep: {
-                    backgroundColor: '#1e88e5',
-                    border: '2px solid #1565c0',
+                    $completed: {
+                        backgroundColor: '#90caf9',
+                        border: '2px solid #64b5f6',
+                    },
+                    $active: {
+                        backgroundColor: '#1e88e5',
+                        border: '2px solid #1565c0',
+                    },
                 },
                 $label: {
                     color: '#666',
-                },
-                $activeLabel: {
-                    color: '#1e88e5',
-                    fontWeight: '700',
+                    $completed: {
+                        color: '#64b5f6',
+                    },
+                    $active: {
+                        color: '#1e88e5',
+                        fontWeight: '700',
+                    },
                 },
             } as const;
 
@@ -484,26 +491,32 @@ export const StyleSet: Story = {
                 borderRadius: '8px',
                 width: '3rem',
                 height: '3rem',
-            },
-            $activeStep: {
-                backgroundColor: '#e91e63',
-                border: '3px solid #c2185b',
-                borderRadius: '50%',
+                $completed: {
+                    backgroundColor: '#f48fb1',
+                    border: '3px solid #f06292',
+                    borderRadius: '50%',
+                },
+                $active: {
+                    backgroundColor: '#e91e63',
+                    border: '3px solid #c2185b',
+                    borderRadius: '50%',
+                },
             },
             $label: {
                 fontSize: '0.875rem',
                 color: '#999',
-            },
-            $activeLabel: {
-                fontSize: '1rem',
-                color: '#e91e63',
-                fontWeight: 'bold',
+                $completed: {
+                    color: '#f06292',
+                },
+                $active: {
+                    fontSize: '1rem',
+                    color: '#e91e63',
+                    fontWeight: 'bold',
+                },
             },
             $progress: {
                 backgroundColor: '#e0e0e0',
-            },
-            $activeProgress: {
-                backgroundColor: '#e91e63',
+                $active: { backgroundColor: '#e91e63' },
             },
         },
         modelValue: 1,

--- a/packages/vlossom/src/components/vs-steps/types.ts
+++ b/packages/vlossom/src/components/vs-steps/types.ts
@@ -15,10 +15,15 @@ export interface VsStepsStyleSet extends CSSProperties {
     $stepSize?: string;
 
     $steps?: CSSProperties;
-    $step?: CSSProperties;
-    $activeStep?: CSSProperties;
-    $label?: CSSProperties;
-    $activeLabel?: CSSProperties;
-    $progress?: CSSProperties;
-    $activeProgress?: CSSProperties;
+    $step?: CSSProperties & {
+        $completed?: CSSProperties;
+        $active?: CSSProperties;
+    };
+    $label?: CSSProperties & {
+        $completed?: CSSProperties;
+        $active?: CSSProperties;
+    };
+    $progress?: CSSProperties & {
+        $active?: CSSProperties;
+    };
 }

--- a/packages/vlossom/src/components/vs-steps/types.ts
+++ b/packages/vlossom/src/components/vs-steps/types.ts
@@ -11,10 +11,9 @@ export type { VsSteps };
 
 export interface VsStepsRef extends ComponentPublicInstance<typeof VsSteps> {}
 
-export interface VsStepsStyleSet {
+export interface VsStepsStyleSet extends CSSProperties {
     $stepSize?: string;
 
-    $component?: CSSProperties;
     $steps?: CSSProperties;
     $step?: CSSProperties;
     $activeStep?: CSSProperties;

--- a/packages/vlossom/src/components/vs-switch/README.ko.md
+++ b/packages/vlossom/src/components/vs-switch/README.ko.md
@@ -91,12 +91,11 @@ async function confirmChange(from, to) {
 ## 타입
 
 ```typescript
-interface VsSwitchStyleSet {
+interface VsSwitchStyleSet extends CSSProperties {
     $handleColor?: string;
     $handleSize?: string;
     $switchButton?: CSSProperties;
     $activeSwitchButton?: CSSProperties;
-    $component?: CSSProperties;
     $wrapper?: VsInputWrapperStyleSet;
 }
 ```
@@ -115,7 +114,7 @@ interface VsSwitchStyleSet {
             $handleSize: '1.4rem',
             $switchButton: { borderRadius: '0.25rem' },
             $activeSwitchButton: { backgroundColor: '#4caf50' },
-            $component: { minHeight: '2.5rem' },
+            minHeight: '2.5rem',
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-switch/README.ko.md
+++ b/packages/vlossom/src/components/vs-switch/README.ko.md
@@ -94,14 +94,15 @@ async function confirmChange(from, to) {
 interface VsSwitchStyleSet extends CSSProperties {
     $handleColor?: string;
     $handleSize?: string;
-    $switchButton?: CSSProperties;
-    $activeSwitchButton?: CSSProperties;
+    $switchButton?: CSSProperties & {
+        $active?: CSSProperties;
+    };
     $wrapper?: VsInputWrapperStyleSet;
 }
 ```
 
 > [!NOTE]
-> `$wrapper`는 [`VsInputWrapperStyleSet`](../vs-input-wrapper/README.ko.md)을 사용합니다.
+> `$wrapper`는 [`VsInputWrapperStyleSet`](../vs-input-wrapper/README.ko.md)을 사용합니다. `$switchButton.$active`는 스위치가 ON 상태일 때 적용됩니다.
 
 ### StyleSet 예시
 
@@ -112,8 +113,10 @@ interface VsSwitchStyleSet extends CSSProperties {
         :style-set="{
             $handleColor: '#ffffff',
             $handleSize: '1.4rem',
-            $switchButton: { borderRadius: '0.25rem' },
-            $activeSwitchButton: { backgroundColor: '#4caf50' },
+            $switchButton: {
+                borderRadius: '0.25rem',
+                $active: { backgroundColor: '#4caf50' },
+            },
             minHeight: '2.5rem',
         }"
     />

--- a/packages/vlossom/src/components/vs-switch/README.md
+++ b/packages/vlossom/src/components/vs-switch/README.md
@@ -91,12 +91,11 @@ async function confirmChange(from, to) {
 ## Types
 
 ```typescript
-interface VsSwitchStyleSet {
+interface VsSwitchStyleSet extends CSSProperties {
     $handleColor?: string;
     $handleSize?: string;
     $switchButton?: CSSProperties;
     $activeSwitchButton?: CSSProperties;
-    $component?: CSSProperties;
     $wrapper?: VsInputWrapperStyleSet;
 }
 ```
@@ -115,7 +114,7 @@ interface VsSwitchStyleSet {
             $handleSize: '1.4rem',
             $switchButton: { borderRadius: '0.25rem' },
             $activeSwitchButton: { backgroundColor: '#4caf50' },
-            $component: { minHeight: '2.5rem' },
+            minHeight: '2.5rem',
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-switch/README.md
+++ b/packages/vlossom/src/components/vs-switch/README.md
@@ -94,14 +94,15 @@ async function confirmChange(from, to) {
 interface VsSwitchStyleSet extends CSSProperties {
     $handleColor?: string;
     $handleSize?: string;
-    $switchButton?: CSSProperties;
-    $activeSwitchButton?: CSSProperties;
+    $switchButton?: CSSProperties & {
+        $active?: CSSProperties;
+    };
     $wrapper?: VsInputWrapperStyleSet;
 }
 ```
 
 > [!NOTE]
-> `$wrapper` uses [`VsInputWrapperStyleSet`](../vs-input-wrapper/README.md).
+> `$wrapper` uses [`VsInputWrapperStyleSet`](../vs-input-wrapper/README.md). The `$switchButton.$active` style is applied when the switch is ON.
 
 ### StyleSet Example
 
@@ -112,8 +113,10 @@ interface VsSwitchStyleSet extends CSSProperties {
         :style-set="{
             $handleColor: '#ffffff',
             $handleSize: '1.4rem',
-            $switchButton: { borderRadius: '0.25rem' },
-            $activeSwitchButton: { backgroundColor: '#4caf50' },
+            $switchButton: {
+                borderRadius: '0.25rem',
+                $active: { backgroundColor: '#4caf50' },
+            },
             minHeight: '2.5rem',
         }"
     />

--- a/packages/vlossom/src/components/vs-switch/VsSwitch.vue
+++ b/packages/vlossom/src/components/vs-switch/VsSwitch.vue
@@ -18,7 +18,7 @@
 
         <div
             :class="['vs-switch', colorSchemeClass, classObj]"
-            :style="{ ...styleSetVariables, ...componentStyleSet.$component }"
+            :style="{ ...styleSetVariables, ...componentInlineStyle }"
         >
             <label class="vs-switch-wrap" :for="computedId">
                 <input
@@ -120,7 +120,10 @@ export default defineComponent({
 
         const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { componentStyleSet, styleSetVariables } = useStyleSet<VsSwitchStyleSet>(componentName, styleSet);
+        const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet<VsSwitchStyleSet>(
+            componentName,
+            styleSet,
+        );
 
         const inputValue = ref(modelValue.value);
 
@@ -236,6 +239,7 @@ export default defineComponent({
             switchRef,
             colorSchemeClass,
             styleSetVariables,
+            componentInlineStyle,
             classObj,
             stateBoxClasses,
             computedId,

--- a/packages/vlossom/src/components/vs-switch/VsSwitch.vue
+++ b/packages/vlossom/src/components/vs-switch/VsSwitch.vue
@@ -65,6 +65,7 @@ import {
     type TemplateRef,
 } from 'vue';
 import { VsComponent } from '@/declaration';
+import { objectUtil } from '@/utils';
 import { getColorSchemeProps, getInputProps, getResponsiveProps, getStyleSetProps } from '@/props';
 import { useColorScheme, useInput, useStateClass, useStyleSet, useValueMatcher } from '@/composables';
 import type { VsSwitchStyleSet } from './types';
@@ -229,10 +230,8 @@ export default defineComponent({
         }
 
         function getSwitchButtonStyle(): CSSProperties {
-            return {
-                ...componentStyleSet.value.$switchButton,
-                ...(isChecked.value ? componentStyleSet.value.$activeSwitchButton : {}),
-            };
+            const { $active = {}, ...base } = componentStyleSet.value.$switchButton ?? {};
+            return objectUtil.assign(base, isChecked.value ? $active : {});
         }
 
         return {

--- a/packages/vlossom/src/components/vs-switch/types.ts
+++ b/packages/vlossom/src/components/vs-switch/types.ts
@@ -16,7 +16,8 @@ export interface VsSwitchRef extends ComponentPublicInstance<typeof VsSwitch>, F
 export interface VsSwitchStyleSet extends CSSProperties {
     $handleColor?: string;
     $handleSize?: string;
-    $switchButton?: CSSProperties;
-    $activeSwitchButton?: CSSProperties;
+    $switchButton?: CSSProperties & {
+        $active?: CSSProperties;
+    };
     $wrapper?: VsInputWrapperStyleSet;
 }

--- a/packages/vlossom/src/components/vs-switch/types.ts
+++ b/packages/vlossom/src/components/vs-switch/types.ts
@@ -13,11 +13,10 @@ export type { VsSwitch };
 
 export interface VsSwitchRef extends ComponentPublicInstance<typeof VsSwitch>, FocusableRef, FormChildRef {}
 
-export interface VsSwitchStyleSet {
+export interface VsSwitchStyleSet extends CSSProperties {
     $handleColor?: string;
     $handleSize?: string;
     $switchButton?: CSSProperties;
     $activeSwitchButton?: CSSProperties;
-    $component?: CSSProperties;
     $wrapper?: VsInputWrapperStyleSet;
 }

--- a/packages/vlossom/src/components/vs-table/README.ko.md
+++ b/packages/vlossom/src/components/vs-table/README.ko.md
@@ -138,8 +138,9 @@ interface VsTableStyleSet extends CSSProperties {
     $toolbar?: CSSProperties;
     $search?: VsSearchInputStyleSet;
     $header?: CSSProperties;
-    $row?: CSSProperties;
-    $selectedRow?: CSSProperties;
+    $row?: CSSProperties & {
+        $selected?: CSSProperties;
+    };
     $cell?: CSSProperties;
 }
 
@@ -178,8 +179,10 @@ interface VsTablePaginationOptions {
         :style-set="{
             borderRadius: '0.5rem', overflow: 'hidden',
             $header: { fontSize: '0.875rem', fontWeight: 700 },
-            $row: { height: '3rem' },
-            $selectedRow: { backgroundColor: '#e3f2fd' },
+            $row: {
+                height: '3rem',
+                $selected: { backgroundColor: '#e3f2fd' },
+            },
             $cell: { padding: '0.5rem 1rem' },
         }"
     />

--- a/packages/vlossom/src/components/vs-table/README.ko.md
+++ b/packages/vlossom/src/components/vs-table/README.ko.md
@@ -134,8 +134,7 @@ const selected = ref([]);
 ## 타입
 
 ```typescript
-interface VsTableStyleSet {
-    $component?: CSSProperties;
+interface VsTableStyleSet extends CSSProperties {
     $toolbar?: CSSProperties;
     $search?: VsSearchInputStyleSet;
     $header?: CSSProperties;
@@ -177,7 +176,7 @@ interface VsTablePaginationOptions {
         :columns="columns"
         :items="items"
         :style-set="{
-            $component: { borderRadius: '0.5rem', overflow: 'hidden' },
+            borderRadius: '0.5rem', overflow: 'hidden',
             $header: { fontSize: '0.875rem', fontWeight: 700 },
             $row: { height: '3rem' },
             $selectedRow: { backgroundColor: '#e3f2fd' },

--- a/packages/vlossom/src/components/vs-table/README.md
+++ b/packages/vlossom/src/components/vs-table/README.md
@@ -138,8 +138,9 @@ interface VsTableStyleSet extends CSSProperties {
     $toolbar?: CSSProperties;
     $search?: VsSearchInputStyleSet;
     $header?: CSSProperties;
-    $row?: CSSProperties;
-    $selectedRow?: CSSProperties;
+    $row?: CSSProperties & {
+        $selected?: CSSProperties;
+    };
     $cell?: CSSProperties;
 }
 
@@ -178,8 +179,10 @@ interface VsTablePaginationOptions {
         :style-set="{
             borderRadius: '0.5rem', overflow: 'hidden',
             $header: { fontSize: '0.875rem', fontWeight: 700 },
-            $row: { height: '3rem' },
-            $selectedRow: { backgroundColor: '#e3f2fd' },
+            $row: {
+                height: '3rem',
+                $selected: { backgroundColor: '#e3f2fd' },
+            },
             $cell: { padding: '0.5rem 1rem' },
         }"
     />

--- a/packages/vlossom/src/components/vs-table/README.md
+++ b/packages/vlossom/src/components/vs-table/README.md
@@ -134,8 +134,7 @@ Provide an `empty` slot to replace the default "NO DATA" placeholder when `items
 ## Types
 
 ```typescript
-interface VsTableStyleSet {
-    $component?: CSSProperties;
+interface VsTableStyleSet extends CSSProperties {
     $toolbar?: CSSProperties;
     $search?: VsSearchInputStyleSet;
     $header?: CSSProperties;
@@ -177,7 +176,7 @@ interface VsTablePaginationOptions {
         :columns="columns"
         :items="items"
         :style-set="{
-            $component: { borderRadius: '0.5rem', overflow: 'hidden' },
+            borderRadius: '0.5rem', overflow: 'hidden',
             $header: { fontSize: '0.875rem', fontWeight: 700 },
             $row: { height: '3rem' },
             $selectedRow: { backgroundColor: '#e3f2fd' },

--- a/packages/vlossom/src/components/vs-table/VsTable.vue
+++ b/packages/vlossom/src/components/vs-table/VsTable.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="['vs-table', colorSchemeClass, classObj]" :style="componentStyleSet.$component">
+    <div :class="['vs-table', colorSchemeClass, classObj]" :style="componentInlineStyle">
         <vs-grid v-if="search || $slots['toolbar']" class="vs-table-toolbar" :column-gap="'1rem'">
             <vs-responsive
                 class="vs-table-toolbar-start"
@@ -300,7 +300,7 @@ export default defineComponent({
         const stickyHeaderTop = ref<string>('0px');
         const { header: vsLayoutHeader } = inject(LAYOUT_STORE_KEY, LayoutStore.getDefaultLayoutStore());
         const { colorSchemeClass, computedColorScheme } = useColorScheme(componentName, colorScheme);
-        const { componentStyleSet } = useStyleSet<VsTableStyleSet>(componentName, styleSet);
+        const { componentStyleSet, componentInlineStyle } = useStyleSet<VsTableStyleSet>(componentName, styleSet);
         const table: TableComposable = useTable(
             props,
             { searchInputRef },
@@ -412,6 +412,7 @@ export default defineComponent({
             colorSchemeClass,
             computedColorScheme,
             componentStyleSet,
+            componentInlineStyle,
             classObj,
             headerRef,
             scrollWrapperRef,

--- a/packages/vlossom/src/components/vs-table/VsTableBodyRow.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableBodyRow.vue
@@ -150,10 +150,8 @@ export default defineComponent({
             };
         });
         const skeletonStyleSet = computed<VsSkeletonStyleSet>(() => ({
-            $component: {
-                height: '100%',
-                minHeight: dense?.value ? 'calc(var(--vs-comp-height-sm))' : 'calc(var(--vs-comp-height-md))',
-            },
+            height: '100%',
+            minHeight: dense?.value ? 'calc(var(--vs-comp-height-sm))' : 'calc(var(--vs-comp-height-md))',
         }));
 
         function getGridColumnWidth(column?: VsTableColumnDef): string {

--- a/packages/vlossom/src/components/vs-table/VsTableBodyRow.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableBodyRow.vue
@@ -43,7 +43,7 @@
 
 <script lang="ts">
 import { defineComponent, inject, computed, type ComputedRef, type PropType, toRefs, type CSSProperties } from 'vue';
-import { stringUtil } from '@/utils';
+import { objectUtil, stringUtil } from '@/utils';
 import { useStateClass } from '@/composables';
 import type { ColorScheme, UIState } from '@/declaration';
 import type { VsSkeletonStyleSet } from './../vs-skeleton/types';
@@ -137,17 +137,9 @@ export default defineComponent({
             };
         });
         const rowStyle = computed<CSSProperties | undefined>(() => {
-            if (isSelected.value) {
-                return {
-                    ...tableStyleSet?.value?.$row,
-                    ...tableStyleSet?.value?.$selectedRow,
-                    ...gridStyle.value,
-                };
-            }
-            return {
-                ...tableStyleSet?.value?.$row,
-                ...gridStyle.value,
-            };
+            const { $selected = {}, ...baseRow } = tableStyleSet?.value?.$row ?? {};
+            const statedRowStyle = isSelected.value ? objectUtil.assign(baseRow, $selected) : baseRow;
+            return objectUtil.assign(statedRowStyle, gridStyle.value ?? {});
         });
         const skeletonStyleSet = computed<VsSkeletonStyleSet>(() => ({
             height: '100%',

--- a/packages/vlossom/src/components/vs-table/VsTableExpandCell.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableExpandCell.vue
@@ -60,13 +60,11 @@ export default defineComponent({
             const size = dense?.value ? '1.4rem' : '1.8rem';
             return {
                 $padding: '0',
-                $component: {
-                    border: 'none',
-                    width: size,
-                    height: size,
-                    backgroundColor: 'var(--vs-cs-bg-colored)',
-                    color: 'var(--vs-cs-font-colored)',
-                },
+                border: 'none',
+                width: size,
+                height: size,
+                backgroundColor: 'var(--vs-cs-bg-colored)',
+                color: 'var(--vs-cs-font-colored)',
             };
         });
 

--- a/packages/vlossom/src/components/vs-table/VsTableExpandedPanel.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableExpandedPanel.vue
@@ -28,11 +28,9 @@ export default defineComponent({
         const { isExpanded } = inject<TableComposable>(TABLE_COMPOSABLE_TOKEN)!;
 
         const expandableStyleSet: ComputedRef<VsExpandableStyleSet> = computed(() => ({
-            $component: {
-                borderTop: '1px dashed var(--vs-cs-line)',
-                backgroundColor: 'var(--vs-no-color)',
-                boxShadow: 'inset 0 0 0.6rem 0 var(--vs-cs-shadow-color)',
-            },
+            borderTop: '1px dashed var(--vs-cs-line)',
+            backgroundColor: 'var(--vs-no-color)',
+            boxShadow: 'inset 0 0 0.6rem 0 var(--vs-cs-shadow-color)',
         }));
 
         return {

--- a/packages/vlossom/src/components/vs-table/VsTableHeader.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableHeader.vue
@@ -42,7 +42,7 @@
 
 <script lang="ts">
 import { defineComponent, inject, computed, type ComputedRef, type CSSProperties } from 'vue';
-import { stringUtil } from '@/utils';
+import { objectUtil, stringUtil } from '@/utils';
 import {
     VsTableSortType,
     TABLE_STYLE_SET_TOKEN,
@@ -92,11 +92,11 @@ export default defineComponent({
                 gridTemplateColumns: cols.join(' '),
             };
         });
-        const headerStyle = computed<CSSProperties | undefined>(() => ({
-            ...tableStyleSet?.value?.$row,
-            ...tableStyleSet?.value?.$header,
-            ...gridStyle.value,
-        }));
+        const headerStyle = computed<CSSProperties | undefined>(() => {
+            const { $selected, ...baseRow } = tableStyleSet?.value?.$row ?? {};
+            const baseRowStyle = objectUtil.assign(baseRow, tableStyleSet?.value?.$header ?? {});
+            return objectUtil.assign(baseRowStyle, gridStyle.value ?? {});
+        });
 
         function getGridColumnWidth(column?: VsTableColumnDef): string {
             if (!column) {

--- a/packages/vlossom/src/components/vs-table/types.ts
+++ b/packages/vlossom/src/components/vs-table/types.ts
@@ -16,8 +16,9 @@ export interface VsTableStyleSet extends CSSProperties {
     $toolbar?: CSSProperties;
     $search?: VsSearchInputStyleSet;
     $header?: CSSProperties;
-    $row?: CSSProperties;
-    $selectedRow?: CSSProperties;
+    $row?: CSSProperties & {
+        $selected?: CSSProperties;
+    };
     $cell?: CSSProperties;
 }
 

--- a/packages/vlossom/src/components/vs-table/types.ts
+++ b/packages/vlossom/src/components/vs-table/types.ts
@@ -12,8 +12,7 @@ declare module 'vue' {
 export const TABLE_STYLE_SET_TOKEN = Symbol('TABLE_STYLE_SET_TOKEN');
 export const TABLE_COLOR_SCHEME_TOKEN = Symbol('TABLE_COLOR_SCHEME_TOKEN');
 
-export interface VsTableStyleSet {
-    $component?: CSSProperties;
+export interface VsTableStyleSet extends CSSProperties {
     $toolbar?: CSSProperties;
     $search?: VsSearchInputStyleSet;
     $header?: CSSProperties;

--- a/packages/vlossom/src/components/vs-tabs/README.ko.md
+++ b/packages/vlossom/src/components/vs-tabs/README.ko.md
@@ -82,14 +82,15 @@ interface VsTabsStyleSet extends CSSProperties {
     $divider?: CSSProperties['border'] & {};
 
     $tabs?: CSSProperties;
-    $tab?: CSSProperties;
-    $activeTab?: CSSProperties;
+    $tab?: CSSProperties & {
+        $active?: CSSProperties;
+    };
     $control?: Omit<VsButtonStyleSet, '$loading'>;
 }
 ```
 
 > [!NOTE]
-> `$control`은 [`VsButtonStyleSet`](../vs-button/README.ko.md)을 사용합니다(`$loading` 제외).
+> `$control`은 [`VsButtonStyleSet`](../vs-button/README.ko.md)을 사용합니다(`$loading` 제외). `$tab.$active`는 현재 선택된 탭에 적용됩니다.
 
 ### StyleSet 예시
 
@@ -101,8 +102,11 @@ interface VsTabsStyleSet extends CSSProperties {
         :style-set="{
             $gap: '0.5rem',
             $divider: '2px solid #e0e0e0',
-            $tab: { borderRadius: '0.25rem', padding: '0.5rem 1.25rem' },
-            $activeTab: { backgroundColor: '#1976d2', color: '#ffffff' },
+            $tab: {
+                borderRadius: '0.25rem',
+                padding: '0.5rem 1.25rem',
+                $active: { backgroundColor: '#1976d2', color: '#ffffff' },
+            },
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-tabs/README.ko.md
+++ b/packages/vlossom/src/components/vs-tabs/README.ko.md
@@ -77,11 +77,10 @@ const tabs = ['탭 1', '탭 2', '탭 3'];
 ## 타입
 
 ```typescript
-interface VsTabsStyleSet {
+interface VsTabsStyleSet extends CSSProperties {
     $gap?: string;
     $divider?: CSSProperties['border'] & {};
 
-    $component?: CSSProperties;
     $tabs?: CSSProperties;
     $tab?: CSSProperties;
     $activeTab?: CSSProperties;

--- a/packages/vlossom/src/components/vs-tabs/README.md
+++ b/packages/vlossom/src/components/vs-tabs/README.md
@@ -77,11 +77,10 @@ const tabs = ['Tab 1', 'Tab 2', 'Tab 3'];
 ## Types
 
 ```typescript
-interface VsTabsStyleSet {
+interface VsTabsStyleSet extends CSSProperties {
     $gap?: string;
     $divider?: CSSProperties['border'] & {};
 
-    $component?: CSSProperties;
     $tabs?: CSSProperties;
     $tab?: CSSProperties;
     $activeTab?: CSSProperties;

--- a/packages/vlossom/src/components/vs-tabs/README.md
+++ b/packages/vlossom/src/components/vs-tabs/README.md
@@ -82,14 +82,15 @@ interface VsTabsStyleSet extends CSSProperties {
     $divider?: CSSProperties['border'] & {};
 
     $tabs?: CSSProperties;
-    $tab?: CSSProperties;
-    $activeTab?: CSSProperties;
+    $tab?: CSSProperties & {
+        $active?: CSSProperties;
+    };
     $control?: Omit<VsButtonStyleSet, '$loading'>;
 }
 ```
 
 > [!NOTE]
-> `$control` uses [`VsButtonStyleSet`](../vs-button/README.md) (excluding `$loading`).
+> `$control` uses [`VsButtonStyleSet`](../vs-button/README.md) (excluding `$loading`). The `$tab.$active` style is applied to the currently selected tab.
 
 ### StyleSet Example
 
@@ -101,8 +102,11 @@ interface VsTabsStyleSet extends CSSProperties {
         :style-set="{
             $gap: '0.5rem',
             $divider: '2px solid #e0e0e0',
-            $tab: { borderRadius: '0.25rem', padding: '0.5rem 1.25rem' },
-            $activeTab: { backgroundColor: '#1976d2', color: '#ffffff' },
+            $tab: {
+                borderRadius: '0.25rem',
+                padding: '0.5rem 1.25rem',
+                $active: { backgroundColor: '#1976d2', color: '#ffffff' },
+            },
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.vue
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.vue
@@ -20,12 +20,7 @@
 
         <div ref="tabsRef" class="vs-tabs-wrap">
             <ul role="tablist" class="vs-tab-list" :style="componentStyleSet.$tabs">
-                <li
-                    v-if="indicatorStyle"
-                    class="vs-tab-indicator"
-                    :style="{ ...indicatorStyle, ...componentStyleSet.$activeTab }"
-                    aria-hidden="true"
-                />
+                <li v-if="indicatorStyle" class="vs-tab-indicator" :style="indicatorStyle" aria-hidden="true" />
                 <li
                     v-for="(tab, index) in tabs"
                     :key="tab"
@@ -248,10 +243,8 @@ export default defineComponent({
         let resizeObserver: ResizeObserver | null = null;
 
         function getTabStyleSet(index: number): CSSProperties {
-            return {
-                ...componentStyleSet.value.$tab,
-                ...(isSelected(index) ? componentStyleSet.value.$activeTab : {}),
-            };
+            const { $active = {}, ...base } = componentStyleSet.value.$tab ?? {};
+            return isSelected(index) ? objectUtil.assign(base, $active) : base;
         }
 
         onMounted(() => {

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.vue
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.vue
@@ -1,7 +1,7 @@
 <template>
     <vs-responsive
         :class="['vs-tabs', colorSchemeClass, classObj]"
-        :style="{ ...styleSetVariables, ...componentStyleSet.$component }"
+        :style="{ ...styleSetVariables, ...componentInlineStyle }"
         :width
         :grid
     >
@@ -137,13 +137,11 @@ export default defineComponent({
 
         const additionalStyleSet: ComputedRef<Partial<VsTabsStyleSet>> = computed(() => {
             return objectUtil.shake({
-                $component: {
-                    height: height.value === undefined ? undefined : stringUtil.toStringSize(height.value),
-                },
+                height: height.value === undefined ? undefined : stringUtil.toStringSize(height.value),
             });
         });
 
-        const { componentStyleSet, styleSetVariables } = useStyleSet<VsTabsStyleSet>(
+        const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet<VsTabsStyleSet>(
             componentName,
             styleSet,
             baseStyleSet,
@@ -296,6 +294,7 @@ export default defineComponent({
             colorSchemeClass,
             componentStyleSet,
             styleSetVariables,
+            componentInlineStyle,
             classObj,
             getTabStyleSet,
 

--- a/packages/vlossom/src/components/vs-tabs/__stories__/vs-tabs.stories.ts
+++ b/packages/vlossom/src/components/vs-tabs/__stories__/vs-tabs.stories.ts
@@ -483,7 +483,7 @@ export const StyleSet: Story = {
             description: {
                 story:
                     '인라인 스타일 객체를 사용한 커스텀 탭입니다.' +
-                    'styleSet prop에 $gap, $divider, $tab, $activeTab, $control을 전달하여 세밀한 커스터마이징이 가능합니다.',
+                    'styleSet prop에 $gap, $divider, $tab($active 포함), $control을 전달하여 세밀한 커스터마이징이 가능합니다.',
             },
         },
     },
@@ -493,8 +493,10 @@ export const StyleSet: Story = {
         styleSet: {
             $gap: '1rem',
             $divider: '2px solid #b968c7',
-            $tab: { fontWeight: '600' },
-            $activeTab: { backgroundColor: '#f0e6f5' },
+            $tab: {
+                fontWeight: '600',
+                $active: { backgroundColor: '#f0e6f5' },
+            },
             $control: {
                 backgroundColor: '#b968c7',
                 borderRadius: '8px',

--- a/packages/vlossom/src/components/vs-tabs/__stories__/vs-tabs.stories.ts
+++ b/packages/vlossom/src/components/vs-tabs/__stories__/vs-tabs.stories.ts
@@ -23,11 +23,9 @@ const meta: Meta<typeof VsTabs> = {
             const preDefinedStyleSet: VsTabsStyleSet = {
                 $gap: '0.5rem',
                 $control: {
-                    $component: {
-                        backgroundColor: '#1565c0',
-                        borderRadius: '4px',
-                        padding: '0.4rem',
-                    },
+                    backgroundColor: '#1565c0',
+                    borderRadius: '4px',
+                    padding: '0.4rem',
                 },
             } as const;
 
@@ -498,11 +496,9 @@ export const StyleSet: Story = {
             $tab: { fontWeight: '600' },
             $activeTab: { backgroundColor: '#f0e6f5' },
             $control: {
-                $component: {
-                    backgroundColor: '#b968c7',
-                    borderRadius: '8px',
-                    padding: '0.4rem',
-                },
+                backgroundColor: '#b968c7',
+                borderRadius: '8px',
+                padding: '0.4rem',
             },
         },
     },

--- a/packages/vlossom/src/components/vs-tabs/types.ts
+++ b/packages/vlossom/src/components/vs-tabs/types.ts
@@ -20,7 +20,8 @@ export interface VsTabsStyleSet extends CSSProperties {
     $divider?: CSSProperties['border'] & {};
 
     $tabs?: CSSProperties;
-    $tab?: CSSProperties;
-    $activeTab?: CSSProperties;
+    $tab?: CSSProperties & {
+        $active?: CSSProperties;
+    };
     $control?: Omit<VsButtonStyleSet, '$loading'>;
 }

--- a/packages/vlossom/src/components/vs-tabs/types.ts
+++ b/packages/vlossom/src/components/vs-tabs/types.ts
@@ -15,11 +15,10 @@ export interface VsTabsRef extends ComponentPublicInstance<typeof VsTabs> {
     goNext: () => void;
 }
 
-export interface VsTabsStyleSet {
+export interface VsTabsStyleSet extends CSSProperties {
     $gap?: string;
     $divider?: CSSProperties['border'] & {};
 
-    $component?: CSSProperties;
     $tabs?: CSSProperties;
     $tab?: CSSProperties;
     $activeTab?: CSSProperties;

--- a/packages/vlossom/src/components/vs-text-wrap/README.ko.md
+++ b/packages/vlossom/src/components/vs-text-wrap/README.ko.md
@@ -69,8 +69,7 @@
 ## 타입
 
 ```typescript
-interface VsTextWrapStyleSet {
-    $component?: CSSProperties;
+interface VsTextWrapStyleSet extends CSSProperties {
     $copyIcon?: CSSProperties;
     $linkIcon?: CSSProperties;
 }
@@ -83,7 +82,7 @@ interface VsTextWrapStyleSet {
     <vs-text-wrap
         copy
         :style-set="{
-            $component: { backgroundColor: '#f5f5f5', borderRadius: '0.5rem', padding: '1rem' },
+            backgroundColor: '#f5f5f5', borderRadius: '0.5rem', padding: '1rem',
             $copyIcon: { color: '#1976d2', fontSize: '1.2rem' },
             $linkIcon: { color: '#4caf50' },
         }"

--- a/packages/vlossom/src/components/vs-text-wrap/README.md
+++ b/packages/vlossom/src/components/vs-text-wrap/README.md
@@ -69,8 +69,7 @@ A container component that wraps text content and provides copy-to-clipboard and
 ## Types
 
 ```typescript
-interface VsTextWrapStyleSet {
-    $component?: CSSProperties;
+interface VsTextWrapStyleSet extends CSSProperties {
     $copyIcon?: CSSProperties;
     $linkIcon?: CSSProperties;
 }
@@ -83,7 +82,7 @@ interface VsTextWrapStyleSet {
     <vs-text-wrap
         copy
         :style-set="{
-            $component: { backgroundColor: '#f5f5f5', borderRadius: '0.5rem', padding: '1rem' },
+            backgroundColor: '#f5f5f5', borderRadius: '0.5rem', padding: '1rem',
             $copyIcon: { color: '#1976d2', fontSize: '1.2rem' },
             $linkIcon: { color: '#4caf50' },
         }"

--- a/packages/vlossom/src/components/vs-text-wrap/VsTextWrap.vue
+++ b/packages/vlossom/src/components/vs-text-wrap/VsTextWrap.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="vs-text-wrap" :style="componentStyleSet.$component">
+    <div class="vs-text-wrap" :style="componentInlineStyle">
         <div ref="contentsRef" class="vs-text-wrap-contents">
             <slot />
         </div>
@@ -62,16 +62,14 @@ export default defineComponent({
 
         const additionalStyleSet: ComputedRef<Partial<VsTextWrapStyleSet>> = computed(() => {
             return objectUtil.shake({
-                $component: objectUtil.shake({
-                    width:
-                        !width.value || objectUtil.isObject(width.value)
-                            ? undefined
-                            : stringUtil.toStringSize(width.value as string | number),
-                }),
+                width:
+                    !width.value || objectUtil.isObject(width.value)
+                        ? undefined
+                        : stringUtil.toStringSize(width.value as string | number),
             });
         });
 
-        const { componentStyleSet } = useStyleSet<VsTextWrapStyleSet>(
+        const { componentStyleSet, componentInlineStyle } = useStyleSet<VsTextWrapStyleSet>(
             componentName,
             styleSet,
             baseStyleSet,
@@ -131,6 +129,7 @@ export default defineComponent({
 
         return {
             componentStyleSet,
+            componentInlineStyle,
             contentText,
             contentsRef,
             copyInnerText,

--- a/packages/vlossom/src/components/vs-text-wrap/__tests__/vs-text-wrap.test.ts
+++ b/packages/vlossom/src/components/vs-text-wrap/__tests__/vs-text-wrap.test.ts
@@ -43,7 +43,7 @@ describe('VsTextWrap', () => {
             });
 
             // then
-            expect(wrapper.vm.componentStyleSet.$component?.width).toBe('200px');
+            expect(wrapper.vm.componentStyleSet.width).toBe('200px');
         });
     });
 

--- a/packages/vlossom/src/components/vs-text-wrap/types.ts
+++ b/packages/vlossom/src/components/vs-text-wrap/types.ts
@@ -11,8 +11,7 @@ export type { VsTextWrap };
 
 export interface VsTextWrapRef extends ComponentPublicInstance<typeof VsTextWrap> {}
 
-export interface VsTextWrapStyleSet {
-    $component?: CSSProperties;
+export interface VsTextWrapStyleSet extends CSSProperties {
     $copyIcon?: CSSProperties;
     $linkIcon?: CSSProperties;
 }

--- a/packages/vlossom/src/components/vs-theme-button/README.ko.md
+++ b/packages/vlossom/src/components/vs-theme-button/README.ko.md
@@ -30,7 +30,7 @@
         :style-set="{
             $iconSize: '1.5rem',
             $iconColor: '#ff9800',
-            $component: { width: '3rem', height: '3rem' },
+            width: '3rem', height: '3rem',
         }"
     />
 </template>
@@ -70,7 +70,7 @@ interface VsThemeButtonStyleSet extends VsToggleStyleSet {
 ```
 
 > [!NOTE]
-> [`VsToggleStyleSet`](../vs-toggle/README.ko.md)의 모든 속성(`$component`, `$content`, `$loading`)을 상속합니다.
+> [`VsToggleStyleSet`](../vs-toggle/README.ko.md)의 모든 속성(`$content`, `$loading`)과 `CSSProperties`를 상속합니다.
 
 ### StyleSet 예시
 
@@ -80,7 +80,7 @@ interface VsThemeButtonStyleSet extends VsToggleStyleSet {
         :style-set="{
             $iconSize: '1.25rem',
             $iconColor: '#ff9800',
-            $component: { width: '2.5rem', height: '2.5rem' },
+            width: '2.5rem', height: '2.5rem',
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-theme-button/README.md
+++ b/packages/vlossom/src/components/vs-theme-button/README.md
@@ -30,7 +30,7 @@ A toggle button that switches the application between light and dark themes.
         :style-set="{
             $iconSize: '1.5rem',
             $iconColor: '#ff9800',
-            $component: { width: '3rem', height: '3rem' },
+            width: '3rem', height: '3rem',
         }"
     />
 </template>
@@ -70,7 +70,7 @@ interface VsThemeButtonStyleSet extends VsToggleStyleSet {
 ```
 
 > [!NOTE]
-> Inherits all properties from [`VsToggleStyleSet`](../vs-toggle/README.md) (`$component`, `$content`, `$loading`).
+> Inherits all properties from [`VsToggleStyleSet`](../vs-toggle/README.md) (`$content`, `$loading`) and `CSSProperties`.
 
 ### StyleSet Example
 
@@ -80,7 +80,7 @@ interface VsThemeButtonStyleSet extends VsToggleStyleSet {
         :style-set="{
             $iconSize: '1.25rem',
             $iconColor: '#ff9800',
-            $component: { width: '2.5rem', height: '2.5rem' },
+            width: '2.5rem', height: '2.5rem',
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-theme-button/__stories__/vs-theme-button.stories.ts
+++ b/packages/vlossom/src/components/vs-theme-button/__stories__/vs-theme-button.stories.ts
@@ -48,11 +48,9 @@ export const StyleSet: Story = {
     args: {
         styleSet: {
             $iconColor: '#B95C50',
-            $component: {
-                width: '3rem',
-                backgroundColor: '#DEB3AD',
-                borderRadius: '1rem',
-            },
+            width: '3rem',
+            backgroundColor: '#DEB3AD',
+            borderRadius: '1rem',
         },
     },
 };

--- a/packages/vlossom/src/components/vs-toast/README.ko.md
+++ b/packages/vlossom/src/components/vs-toast/README.ko.md
@@ -69,9 +69,8 @@
 ## 타입
 
 ```typescript
-interface VsToastStyleSet {
+interface VsToastStyleSet extends CSSProperties {
     $closeButton?: Omit<VsButtonStyleSet, '$loading'>;
-    $component?: CSSProperties;
 }
 ```
 
@@ -84,14 +83,12 @@ interface VsToastStyleSet {
 <template>
     <vs-toast
         :style-set="{
-            $component: {
-                backgroundColor: '#323232',
-                color: '#ffffff',
-                borderRadius: '0.5rem',
-                padding: '0.75rem 1rem',
-            },
+            backgroundColor: '#323232',
+            color: '#ffffff',
+            borderRadius: '0.5rem',
+            padding: '0.75rem 1rem',
             $closeButton: {
-                $component: { color: '#ffffff' },
+                color: '#ffffff',
             },
         }"
     >

--- a/packages/vlossom/src/components/vs-toast/README.md
+++ b/packages/vlossom/src/components/vs-toast/README.md
@@ -69,9 +69,8 @@ Toasts are typically triggered via the `$vs.toast` plugin API.
 ## Types
 
 ```typescript
-interface VsToastStyleSet {
+interface VsToastStyleSet extends CSSProperties {
     $closeButton?: Omit<VsButtonStyleSet, '$loading'>;
-    $component?: CSSProperties;
 }
 ```
 
@@ -84,14 +83,12 @@ interface VsToastStyleSet {
 <template>
     <vs-toast
         :style-set="{
-            $component: {
-                backgroundColor: '#323232',
-                color: '#ffffff',
-                borderRadius: '0.5rem',
-                padding: '0.75rem 1rem',
-            },
+            backgroundColor: '#323232',
+            color: '#ffffff',
+            borderRadius: '0.5rem',
+            padding: '0.75rem 1rem',
             $closeButton: {
-                $component: { color: '#ffffff' },
+                color: '#ffffff',
             },
         }"
     >

--- a/packages/vlossom/src/components/vs-toast/VsToast.vue
+++ b/packages/vlossom/src/components/vs-toast/VsToast.vue
@@ -1,7 +1,7 @@
 <template>
     <div
         :class="['vs-toast', colorSchemeClass, { 'vs-toast-primary': primary }]"
-        :style="componentStyleSet.$component"
+        :style="componentInlineStyle"
         @mouseenter="onMouseEnter"
         @mouseleave="onMouseLeave"
     >
@@ -50,14 +50,16 @@ export default defineComponent({
         const baseStyleSet: ComputedRef<VsToastStyleSet> = computed(() => {
             return {
                 $closeButton: {
-                    $component: {
-                        padding: '0',
-                    },
+                    padding: '0',
                 },
             };
         });
 
-        const { componentStyleSet } = useStyleSet<VsToastStyleSet>(componentName, styleSet, baseStyleSet);
+        const { componentStyleSet, componentInlineStyle } = useStyleSet<VsToastStyleSet>(
+            componentName,
+            styleSet,
+            baseStyleSet,
+        );
 
         const holdToClose = ref(false);
         let timer: any = null;
@@ -96,6 +98,7 @@ export default defineComponent({
             computedColorScheme,
             colorSchemeClass,
             componentStyleSet,
+            componentInlineStyle,
             onMouseEnter,
             onMouseLeave,
             holdToClose,

--- a/packages/vlossom/src/components/vs-toast/__stories__/vs-toast.stories.ts
+++ b/packages/vlossom/src/components/vs-toast/__stories__/vs-toast.stories.ts
@@ -22,18 +22,14 @@ const meta: Meta<typeof VsToast> = {
         setup() {
             const preDefinedStyleSet: VsToastStyleSet = {
                 $closeButton: {
-                    $component: {
-                        color: '#fff',
-                    },
-                },
-                $component: {
-                    borderRadius: '8px',
-                    padding: '1rem 1.5rem',
-                    height: 'auto',
-                    backgroundColor: '#1e88e5',
-                    border: '2px solid #1e88e5',
                     color: '#fff',
                 },
+                borderRadius: '8px',
+                padding: '1rem 1.5rem',
+                height: 'auto',
+                backgroundColor: '#1e88e5',
+                border: '2px solid #1e88e5',
+                color: '#fff',
             } as const;
 
             useVlossom().styleSet = {
@@ -169,18 +165,14 @@ export const StyleSet: Story = {
     args: {
         styleSet: {
             $closeButton: {
-                $component: {
-                    color: '#fff',
-                },
-            },
-            $component: {
-                borderRadius: '12px',
-                padding: '1.5rem 2rem',
-                height: 'auto',
-                backgroundColor: '#e188e5',
-                border: '2px solid #e188e5',
                 color: '#fff',
             },
+            borderRadius: '12px',
+            padding: '1.5rem 2rem',
+            height: 'auto',
+            backgroundColor: '#e188e5',
+            border: '2px solid #e188e5',
+            color: '#fff',
         },
     },
     render: (args: any) => ({

--- a/packages/vlossom/src/components/vs-toast/types.ts
+++ b/packages/vlossom/src/components/vs-toast/types.ts
@@ -16,7 +16,6 @@ export interface VsToastRef extends ComponentPublicInstance<typeof VsToast> {}
 
 export interface VsToastViewRef extends ComponentPublicInstance<typeof VsToastView> {}
 
-export interface VsToastStyleSet {
-    $component?: CSSProperties;
+export interface VsToastStyleSet extends CSSProperties {
     $closeButton?: Omit<VsButtonStyleSet, '$loading'>;
 }

--- a/packages/vlossom/src/components/vs-toggle/README.ko.md
+++ b/packages/vlossom/src/components/vs-toggle/README.ko.md
@@ -81,11 +81,9 @@ interface VsToggleStyleSet extends VsButtonStyleSet {}
     <vs-toggle
         v-model="isActive"
         :style-set="{
-            $component: {
-                borderRadius: '0.25rem',
-                minWidth: '6rem',
-                padding: '0.5rem 1.5rem',
-            },
+            borderRadius: '0.25rem',
+            minWidth: '6rem',
+            padding: '0.5rem 1.5rem',
         }"
     >
         토글

--- a/packages/vlossom/src/components/vs-toggle/README.md
+++ b/packages/vlossom/src/components/vs-toggle/README.md
@@ -81,11 +81,9 @@ interface VsToggleStyleSet extends VsButtonStyleSet {}
     <vs-toggle
         v-model="isActive"
         :style-set="{
-            $component: {
-                borderRadius: '0.25rem',
-                minWidth: '6rem',
-                padding: '0.5rem 1.5rem',
-            },
+            borderRadius: '0.25rem',
+            minWidth: '6rem',
+            padding: '0.5rem 1.5rem',
         }"
     >
         Toggle

--- a/packages/vlossom/src/components/vs-toggle/__stories__/vs-toggle.stories.ts
+++ b/packages/vlossom/src/components/vs-toggle/__stories__/vs-toggle.stories.ts
@@ -20,12 +20,10 @@ const meta: Meta<typeof VsToggle> = {
         components: { VsToggle },
         setup() {
             const preDefinedStyleSet: VsToggleStyleSet = {
-                $component: {
-                    backgroundColor: '#1e88e5',
-                    height: '3rem',
-                    width: 'auto',
-                    padding: '0 1.5rem',
-                },
+                backgroundColor: '#1e88e5',
+                height: '3rem',
+                width: 'auto',
+                padding: '0 1.5rem',
             } as const;
 
             useVlossom().styleSet = {
@@ -155,13 +153,11 @@ export const ToggleExample1: Story = {
             });
 
             const menuButtonStyleSet: VsToggleStyleSet = {
-                $component: {
-                    width: size.value,
-                    height: size.value,
-                    borderRadius: '8px',
-                    backgroundColor: 'transparent',
-                    border: '1px solid #ddd',
-                },
+                width: size.value,
+                height: size.value,
+                borderRadius: '8px',
+                backgroundColor: 'transparent',
+                border: '1px solid #ddd',
             };
 
             const onToggle = (value: boolean) => {

--- a/packages/vlossom/src/composables/style-set/README.ko.md
+++ b/packages/vlossom/src/composables/style-set/README.ko.md
@@ -4,15 +4,32 @@
 
 **Available Version**: 2.0.0+
 
-컴포넌트의 style-set을 타입이 있는 `componentStyleSet` 객체와 평탄화된 `styleSetVariables` CSS 커스텀 속성 맵으로 해석, 병합, 변환합니다.
+컴포넌트의 style-set을 해석/병합한 뒤 세 가지 파생 뷰를 제공합니다: 병합된 객체(`componentStyleSet`), CSS 커스텀 속성 맵(`styleSetVariables`), 그리고 inline `:style` 바인딩용 CSSProperties 객체(`componentInlineStyle`).
+
+## Style-Set 컨벤션
+
+`VsXxxStyleSet` 인터페이스는 `CSSProperties`를 상속(extends)합니다. 키는 prefix로 구분됩니다.
+
+- **non-`$` 키** — 표준 CSS 속성으로, 컴포넌트 루트 요소에 inline style로 적용됩니다 (`componentInlineStyle` 통해).
+- **`$X` (primitive)** — `--{component-kebab}-X` 형태의 CSS 변수로 emit됩니다 (`styleSetVariables` 통해).
+- **`$X` (object)** — 슬롯/요소 단위 CSSProperties 혹은 하위 StyleSet으로, `componentStyleSet.$X`로 접근합니다.
+
+```ts
+import type { CSSProperties } from 'vue';
+
+export interface VsButtonStyleSet extends CSSProperties {
+    $content?: CSSProperties;        // 슬롯
+    $loading?: VsLoadingStyleSet;    // 하위 컴포넌트
+}
+```
 
 ## Feature
 
 - 문자열 `styleSet` prop을 `useOptionsStore`를 통해 등록된 전역 style-set으로 해석합니다
 - 우선순위 순서로 세 레이어를 병합합니다: `baseStyleSet` < `styleSet` (prop) < `additionalStyleSet`
-- `variables` 항목을 `:style` 바인딩에 사용할 CSS 커스텀 속성 이름(`--{component-kebab}-{key}`)으로 변환합니다
-- 중첩 변수 객체 한 레벨(`variables.group.property`)을 지원합니다 — `--{component}-{group}-{property}`를 생성합니다
-- 요소의 직접 CSSProperties 바인딩과 하위 컴포넌트 `:style-set` prop을 위해 `componentStyleSet`을 반환합니다
+- 루트 레벨의 `$X` primitive 항목을 CSS 커스텀 속성(`--{component-kebab}-X`)으로 변환합니다
+- 루트 레벨의 CSS 속성을 spread 가능한 `componentInlineStyle` 객체로 반환합니다
+- `$X` 슬롯과 하위 컴포넌트 style-set 접근을 위해 `componentStyleSet`을 반환합니다
 
 ## Basic Usage
 
@@ -20,56 +37,54 @@
 <template>
     <button
         :class="['vs-button', colorSchemeClass]"
-        :style="{ ...styleSetVariables, ...componentStyleSet.component }"
+        :style="{ ...styleSetVariables, ...componentInlineStyle }"
     >
-        <vs-loading v-if="loading" :style-set="componentStyleSet.loading" />
-        <slot />
+        <vs-loading v-if="loading" :style-set="componentStyleSet.$loading" />
+        <div class="vs-button-content" :style="componentStyleSet.$content">
+            <slot />
+        </div>
     </button>
 </template>
 
 <script setup>
-import { ref, toRefs } from 'vue';
+import { toRefs } from 'vue';
 import { useStyleSet } from '@/composables';
 
 const props = defineProps({ styleSet: [String, Object] });
 const { styleSet } = toRefs(props);
 
-const { componentStyleSet, styleSetVariables } = useStyleSet('VsButton', styleSet);
+const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet('VsButton', styleSet);
 </script>
 ```
 
 ## Args
 
-| 인자                 | 타입                            | 기본값     | 필수 | 설명                                                                              |
-| -------------------- | ------------------------------- | ---------- | ---- | --------------------------------------------------------------------------------- |
-| `component`          | `VsComponent \| string`         | —          | Yes  | CSS 변수 접두사와 전역 style-set 조회에 사용되는 컴포넌트 이름.                   |
-| `styleSet`           | `Ref<string \| T \| undefined>` | —          | Yes  | `styleSet` prop 값. 문자열은 명명된 전역 style-set으로 해석됩니다.               |
-| `baseStyleSet`       | `Ref<Partial<T>>`               | `ref({})` | No   | 사용자 prop 이전에 적용되는 기본 style-set (가장 낮은 우선순위).                 |
-| `additionalStyleSet` | `Ref<Partial<T>>`               | `ref({})` | No   | 다른 컴포넌트 prop에서 파생된 동적 오버라이드 (가장 높은 우선순위).              |
+| 인자                 | 타입                            | 기본값    | 필수 | 설명                                                                  |
+| -------------------- | ------------------------------- | --------- | ---- | --------------------------------------------------------------------- |
+| `component`          | `VsComponent \| string`         | —         | Yes  | CSS 변수 접두사와 전역 style-set 조회에 사용되는 컴포넌트 이름.       |
+| `styleSet`           | `Ref<string \| T \| undefined>` | —         | Yes  | `styleSet` prop 값. 문자열은 명명된 전역 style-set으로 해석됩니다.    |
+| `baseStyleSet`       | `Ref<Partial<T>>`               | `ref({})` | No   | 사용자 prop 이전에 적용되는 기본 style-set (가장 낮은 우선순위).      |
+| `additionalStyleSet` | `Ref<Partial<T>>`               | `ref({})` | No   | 다른 컴포넌트 prop에서 파생된 동적 오버라이드 (가장 높은 우선순위).   |
 
 ## Types
 
 ```typescript
 // 제네릭 T는 { [key: string]: any }를 확장해야 합니다
-// 일반적인 StyleSet 구조:
-interface ExampleStyleSet {
-    variables?: {
-        propertyName?: string;
-        groupName?: {
-            nestedProperty?: string;
-        };
-    };
-    component?: CSSProperties;
-    childComponent?: ChildStyleSet;
+// 일반적인 StyleSet 구조 (루트에서 CSSProperties 상속):
+interface ExampleStyleSet extends CSSProperties {
+    $primitiveVar?: string;         // --vs-example-primitiveVar로 변환
+    $element?: CSSProperties;       // 슬롯/요소 스타일
+    $childComponent?: ChildStyleSet; // 하위 컴포넌트 style-set
 }
 ```
 
 ## Return Refs
 
-| RefType              | 타입                                  | 설명                                                                               |
-| -------------------- | ------------------------------------- | ---------------------------------------------------------------------------------- |
-| `componentStyleSet`  | `ComputedRef<Partial<T>>`             | 병합된 style-set 객체. `.component`, `.variables` 또는 하위 컴포넌트 키에 접근하세요. |
-| `styleSetVariables`  | `ComputedRef<Record<string, string>>` | `componentStyleSet.value.variables`에서 파생된 CSS 커스텀 속성의 평탄화된 맵.     |
+| RefType                | 타입                                  | 설명                                                                                            |
+| ---------------------- | ------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `componentStyleSet`    | `ComputedRef<Partial<T>>`             | 완전히 병합된 style-set 객체. `$X` 슬롯 키와 하위 style-set 접근에 사용합니다.                 |
+| `styleSetVariables`    | `ComputedRef<Record<string, string>>` | 루트 레벨의 `$X` primitive 항목에서 파생된 CSS 커스텀 속성 맵.                                 |
+| `componentInlineStyle` | `ComputedRef<CSSProperties>`          | 루트 레벨의 non-`$` 키에서 파생된 inline CSSProperties. 루트 요소의 `:style`에 spread하세요. |
 
 ## Return Methods
 
@@ -83,6 +98,7 @@ interface ExampleStyleSet {
 
 ## Cautions
 
-- style-set의 `variables` 키만 CSS 커스텀 속성으로 변환됩니다. 다른 키(예: `component`, `loading`)는 `:style` / `:style-set`에 직접 spread하거나 전달해야 합니다.
-- 두 레벨 이상의 깊이 중첩된 `variables` 객체는 CSS 속성으로 변환되지 않습니다.
+- **루트 레벨**의 `$X` primitive 키만 CSS 커스텀 속성으로 변환됩니다. `$X` object 값은 `componentStyleSet`을 통해 노출되며 직접 `:style` / `:style-set`로 바인딩해야 합니다.
+- `componentInlineStyle`은 **루트 레벨**의 non-`$` 키만 모읍니다. 중첩된 CSSProperties (예: `componentStyleSet.$content`)는 해당 요소/슬롯에 직접 바인딩해야 합니다.
 - `objectUtil.shake`는 병합 전 `baseStyleSet`과 `additionalStyleSet`에 적용되어 `undefined` 및 빈 값을 제거합니다.
+- 이미 병합된 style-set을 자식 컴포넌트로 전달하는 경우(예: `VsSelectTrigger`가 `VsSelect`로부터 `componentStyleSet`을 받는 경우), 그 prop에 대해 `useStyleSet`을 다시 호출해 `componentInlineStyle`을 재추출하세요. 별도 헬퍼는 필요 없습니다.

--- a/packages/vlossom/src/composables/style-set/README.md
+++ b/packages/vlossom/src/composables/style-set/README.md
@@ -4,15 +4,32 @@
 
 **Available Version**: 2.0.0+
 
-Resolves, merges, and transforms a component's style-set into both a typed `componentStyleSet` object and a flat `styleSetVariables` CSS custom property map.
+Resolves and merges a component's style-set, then exposes three derived views: the merged object (`componentStyleSet`), a flat CSS custom property map (`styleSetVariables`), and a CSSProperties object for inline `:style` binding (`componentInlineStyle`).
+
+## Style-Set Convention
+
+A `VsXxxStyleSet` interface extends `CSSProperties`. Keys are split by prefix:
+
+- **non-`$` keys** — standard CSS properties, applied to the component's root element (via `componentInlineStyle`).
+- **`$X` (primitive)** — CSS variables emitted as `--{component-kebab}-X` (via `styleSetVariables`).
+- **`$X` (object)** — slot-/element-level CSSProperties or a nested child StyleSet, accessed via `componentStyleSet.$X`.
+
+```ts
+import type { CSSProperties } from 'vue';
+
+export interface VsButtonStyleSet extends CSSProperties {
+    $content?: CSSProperties;        // element slot
+    $loading?: VsLoadingStyleSet;    // child component
+}
+```
 
 ## Feature
 
 - Resolves a string `styleSet` prop to a registered global style-set via `useOptionsStore`
 - Merges three layers in priority order: `baseStyleSet` < `styleSet` (prop) < `additionalStyleSet`
-- Converts `variables` entries into CSS custom property names (`--{component-kebab}-{key}`) for use in `:style` bindings
-- Supports one level of nested variable objects (`variables.group.property`) — generates `--{component}-{group}-{property}`
-- Returns `componentStyleSet` for direct CSSProperties binding on elements and sub-component `:style-set` props
+- Converts root-level `$X` primitive entries into CSS custom properties (`--{component-kebab}-X`)
+- Returns root-level CSS properties as a ready-to-spread `componentInlineStyle` object
+- Returns `componentStyleSet` for direct access to `$X` slots and nested child style-sets
 
 ## Basic Usage
 
@@ -20,56 +37,54 @@ Resolves, merges, and transforms a component's style-set into both a typed `comp
 <template>
     <button
         :class="['vs-button', colorSchemeClass]"
-        :style="{ ...styleSetVariables, ...componentStyleSet.component }"
+        :style="{ ...styleSetVariables, ...componentInlineStyle }"
     >
-        <vs-loading v-if="loading" :style-set="componentStyleSet.loading" />
-        <slot />
+        <vs-loading v-if="loading" :style-set="componentStyleSet.$loading" />
+        <div class="vs-button-content" :style="componentStyleSet.$content">
+            <slot />
+        </div>
     </button>
 </template>
 
 <script setup>
-import { ref, toRefs } from 'vue';
+import { toRefs } from 'vue';
 import { useStyleSet } from '@/composables';
 
 const props = defineProps({ styleSet: [String, Object] });
 const { styleSet } = toRefs(props);
 
-const { componentStyleSet, styleSetVariables } = useStyleSet('VsButton', styleSet);
+const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet('VsButton', styleSet);
 </script>
 ```
 
 ## Args
 
-| Arg                 | Type                                    | Default   | Required | Description                                                                             |
-| ------------------- | --------------------------------------- | --------- | -------- | --------------------------------------------------------------------------------------- |
-| `component`         | `VsComponent \| string`                 | —         | Yes      | Component name used for CSS variable prefix and global style-set lookup.                |
-| `styleSet`          | `Ref<string \| T \| undefined>`         | —         | Yes      | The `styleSet` prop value. A string resolves to a named global style-set.               |
-| `baseStyleSet`      | `Ref<Partial<T>>`                       | `ref({})` | No       | Default style-set applied before the user prop (lowest priority).                       |
-| `additionalStyleSet`| `Ref<Partial<T>>`                       | `ref({})` | No       | Dynamic overrides derived from other component props (highest priority).                |
+| Arg                  | Type                                    | Default   | Required | Description                                                                             |
+| -------------------- | --------------------------------------- | --------- | -------- | --------------------------------------------------------------------------------------- |
+| `component`          | `VsComponent \| string`                 | —         | Yes      | Component name used for CSS variable prefix and global style-set lookup.                |
+| `styleSet`           | `Ref<string \| T \| undefined>`         | —         | Yes      | The `styleSet` prop value. A string resolves to a named global style-set.               |
+| `baseStyleSet`       | `Ref<Partial<T>>`                       | `ref({})` | No       | Default style-set applied before the user prop (lowest priority).                       |
+| `additionalStyleSet` | `Ref<Partial<T>>`                       | `ref({})` | No       | Dynamic overrides derived from other component props (highest priority).                |
 
 ## Types
 
 ```typescript
 // The generic T must extend { [key: string]: any }
-// Common StyleSet structure:
-interface ExampleStyleSet {
-    variables?: {
-        propertyName?: string;
-        groupName?: {
-            nestedProperty?: string;
-        };
-    };
-    component?: CSSProperties;
-    childComponent?: ChildStyleSet;
+// Common StyleSet structure (extends CSSProperties at root):
+interface ExampleStyleSet extends CSSProperties {
+    $primitiveVar?: string;         // becomes --vs-example-primitiveVar
+    $element?: CSSProperties;       // slot/element style
+    $childComponent?: ChildStyleSet; // nested child style-set
 }
 ```
 
 ## Return Refs
 
-| RefType              | Type                              | Description                                                                          |
-| -------------------- | --------------------------------- | ------------------------------------------------------------------------------------ |
-| `componentStyleSet`  | `ComputedRef<Partial<T>>`         | Merged style-set object. Access `.component`, `.variables`, or sub-component keys.   |
-| `styleSetVariables`  | `ComputedRef<Record<string, string>>` | Flat map of CSS custom properties derived from `componentStyleSet.value.variables`.  |
+| RefType                | Type                                  | Description                                                                                                |
+| ---------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `componentStyleSet`    | `ComputedRef<Partial<T>>`             | Fully merged style-set object. Use it to access `$X` slot keys or nested child style-sets.                 |
+| `styleSetVariables`    | `ComputedRef<Record<string, string>>` | Flat map of CSS custom properties derived from root-level `$X` primitive entries.                          |
+| `componentInlineStyle` | `ComputedRef<CSSProperties>`          | Inline CSSProperties derived from non-`$` root-level keys. Spread into the root element's `:style` prop.   |
 
 ## Return Methods
 
@@ -83,6 +98,7 @@ interface ExampleStyleSet {
 
 ## Cautions
 
-- Only the `variables` key of the style-set is transformed into CSS custom properties. Other keys (e.g. `component`, `loading`) must be spread or passed directly as `:style` / `:style-set`.
-- Deeply nested `variables` objects (more than one level) are not converted to CSS properties.
+- Only **root-level** `$X` primitive keys are converted to CSS custom properties. `$X` object values are exposed via `componentStyleSet` for direct binding (`:style` / `:style-set`).
+- `componentInlineStyle` only collects **root-level** non-`$` keys. Nested CSSProperties (e.g. `componentStyleSet.$content`) must be bound on the corresponding element/slot manually.
 - `objectUtil.shake` is applied to `baseStyleSet` and `additionalStyleSet` before merging, removing `undefined` and empty values.
+- When forwarding an already-merged style-set to a child component (e.g. `VsSelectTrigger` receiving `componentStyleSet` from `VsSelect`), call `useStyleSet` again on that prop to re-derive `componentInlineStyle` — no extra helper is needed.

--- a/packages/vlossom/src/composables/style-set/__tests__/style-set-composable.test.ts
+++ b/packages/vlossom/src/composables/style-set/__tests__/style-set-composable.test.ts
@@ -294,7 +294,6 @@ describe('useStyleSet', () => {
             const styles = {
                 $height: '2.5rem',
                 $focused: { border: '1px solid red', backgroundColor: 'gray' },
-                $component: { fontSize: '1rem' },
                 $wrapper: { variables: { width: '100%' } },
             };
             const styleSet = ref(styles);
@@ -319,6 +318,87 @@ describe('useStyleSet', () => {
 
             // then
             expect(styleSetVariables.value).toEqual({});
+        });
+    });
+
+    describe('componentInlineStyle', () => {
+        it('빈 스타일셋에 대해 빈 객체를 반환해야 한다', () => {
+            // given
+            const component = VsComponent.VsButton;
+            const styleSet = ref(undefined);
+
+            // when
+            const { componentInlineStyle } = useStyleSet(component, styleSet);
+
+            // then
+            expect(componentInlineStyle.value).toEqual({});
+        });
+
+        it('$ prefix가 없는 CSSProperties를 inline style로 반환해야 한다', () => {
+            // given
+            const component = VsComponent.VsButton;
+            const styles = { color: 'red', fontSize: '14px', padding: '0.5rem' };
+            const styleSet = ref(styles);
+
+            // when
+            const { componentInlineStyle } = useStyleSet(component, styleSet);
+
+            // then
+            expect(componentInlineStyle.value).toEqual({
+                color: 'red',
+                fontSize: '14px',
+                padding: '0.5rem',
+            });
+        });
+
+        it('$ prefix가 붙은 키는 inline style에서 제외되어야 한다', () => {
+            // given
+            const component = VsComponent.VsSelect;
+            const styles = {
+                color: 'red',
+                $height: '2.5rem',
+                $focused: { border: '1px solid red' },
+                $wrapper: { $label: { fontSize: '14px' } },
+            };
+            const styleSet = ref(styles);
+
+            // when
+            const { componentInlineStyle } = useStyleSet<any>(component, styleSet);
+
+            // then
+            expect(componentInlineStyle.value).toEqual({ color: 'red' });
+        });
+
+        it('baseStyleSet, styleSet, additionalStyleSet의 CSSProperties가 모두 병합되어야 한다', () => {
+            // given
+            const component = VsComponent.VsButton;
+            const baseStyleSet = ref({ color: 'blue', padding: '5px' });
+            const styleSet = ref({ color: 'red', fontSize: '14px' });
+            const additionalStyleSet = ref({ color: 'green', fontWeight: 'bold' });
+
+            // when
+            const { componentInlineStyle } = useStyleSet(component, styleSet, baseStyleSet, additionalStyleSet);
+
+            // then
+            expect(componentInlineStyle.value).toEqual({
+                color: 'green',
+                padding: '5px',
+                fontSize: '14px',
+                fontWeight: 'bold',
+            });
+        });
+
+        it('값이 undefined나 null이면 inline style에서 제외되어야 한다', () => {
+            // given
+            const component = VsComponent.VsButton;
+            const styles = { color: 'red', padding: undefined, margin: null };
+            const styleSet: any = ref(styles);
+
+            // when
+            const { componentInlineStyle } = useStyleSet<any>(component, styleSet);
+
+            // then
+            expect(componentInlineStyle.value).toEqual({ color: 'red' });
         });
     });
 });

--- a/packages/vlossom/src/composables/style-set/style-set-composable.ts
+++ b/packages/vlossom/src/composables/style-set/style-set-composable.ts
@@ -3,26 +3,6 @@ import type { VsComponent } from '@/declaration';
 import { useOptionsStore } from '@/stores';
 import { objectUtil, stringUtil } from '@/utils';
 
-export function extractInlineStyle(styleSet: { [key: string]: any } | undefined | null): CSSProperties {
-    const result: CSSProperties = {};
-
-    if (!styleSet) {
-        return result;
-    }
-
-    for (const [key, value] of Object.entries(styleSet)) {
-        if (key.startsWith('$')) {
-            continue;
-        }
-        if (value === undefined || value === null) {
-            continue;
-        }
-        (result as Record<string, unknown>)[key] = value;
-    }
-
-    return result;
-}
-
 export function useStyleSet<T extends { [key: string]: any }>(
     component: VsComponent | string,
     styleSet: Ref<string | T | undefined>,
@@ -64,9 +44,21 @@ export function useStyleSet<T extends { [key: string]: any }>(
         return result;
     });
 
-    const componentInlineStyle: ComputedRef<CSSProperties> = computed(() =>
-        extractInlineStyle(componentStyleSet.value),
-    );
+    const componentInlineStyle: ComputedRef<CSSProperties> = computed(() => {
+        const result: CSSProperties = {};
+
+        for (const [key, value] of Object.entries(componentStyleSet.value)) {
+            if (key.startsWith('$')) {
+                continue;
+            }
+            if (value === undefined || value === null) {
+                continue;
+            }
+            (result as Record<string, unknown>)[key] = value;
+        }
+
+        return result;
+    });
 
     return {
         componentStyleSet,

--- a/packages/vlossom/src/composables/style-set/style-set-composable.ts
+++ b/packages/vlossom/src/composables/style-set/style-set-composable.ts
@@ -1,7 +1,27 @@
-import { computed, ref, type ComputedRef, type Ref } from 'vue';
+import { computed, ref, type ComputedRef, type CSSProperties, type Ref } from 'vue';
 import type { VsComponent } from '@/declaration';
 import { useOptionsStore } from '@/stores';
 import { objectUtil, stringUtil } from '@/utils';
+
+export function extractInlineStyle(styleSet: { [key: string]: any } | undefined | null): CSSProperties {
+    const result: CSSProperties = {};
+
+    if (!styleSet) {
+        return result;
+    }
+
+    for (const [key, value] of Object.entries(styleSet)) {
+        if (key.startsWith('$')) {
+            continue;
+        }
+        if (value === undefined || value === null) {
+            continue;
+        }
+        (result as Record<string, unknown>)[key] = value;
+    }
+
+    return result;
+}
 
 export function useStyleSet<T extends { [key: string]: any }>(
     component: VsComponent | string,
@@ -44,8 +64,13 @@ export function useStyleSet<T extends { [key: string]: any }>(
         return result;
     });
 
+    const componentInlineStyle: ComputedRef<CSSProperties> = computed(() =>
+        extractInlineStyle(componentStyleSet.value),
+    );
+
     return {
         componentStyleSet,
         styleSetVariables,
+        componentInlineStyle,
     };
 }


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

 ## 요약

  `VsXxxStyleSet`에서 `$component?: CSSProperties` 래퍼를 제거하고, 인터페이스가 `CSSProperties`를 직접
  상속(extends)하도록 평탄화합니다. 사용자는 `:style-set="{ $component: { padding: '1rem' } }"` 대신 `:style-set="{
  padding: '1rem' }"`로 더 자연스럽게 작성할 수 있습니다.

  ## 동기

  - `$component` 래퍼는 인지적 마찰을 만들었음 — 왜 root CSS는 `$component` 안에 넣어야 하는지 직관적이지 않았음.
  - `$` prefix 컨벤션이 이미 슬롯/CSS 변수와 표준 CSS의 분리 역할을 충분히 해주므로, 별도 래퍼 키는 불필요.
  - 단순 케이스(VsBar, VsDimmed 등)에서는 보일러플레이트 한 단계가 그대로 사라짐.

  ## 주요 변경

  ### 1. 컨벤션 변경

  | 키 형태 | 처리 |
  | --- | --- |
  | non-`$` (root) | 표준 CSS — 컴포넌트 root 요소에 inline style |
  | `$X` (primitive) | CSS 변수 (`--vs-{kebab-component}-X`) |
  | `$X` (object) | 슬롯/요소 스타일 또는 하위 StyleSet |

  ### 2. Interface (Before / After)

  ```ts
  // Before
  interface VsButtonStyleSet {
      $component?: CSSProperties;
      $content?: CSSProperties;
      $loading?: VsLoadingStyleSet;
  }

  // After
  interface VsButtonStyleSet extends CSSProperties {
      $content?: CSSProperties;
      $loading?: VsLoadingStyleSet;
  }
```
  ### 3. Composable

  useStyleSet에 componentInlineStyle: ComputedRef<CSSProperties> 추가 — non-$ 키들을 모아 :style에 그대로 spread할 수
  있는 객체로 반환.
``` ts
  const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet(...);

  :style="{ ...styleSetVariables, ...componentInlineStyle }"
```
###  4. 사용 예시 (Before / After)
```html
  <!-- Before -->
  <vs-button :style-set="{
      $component: { backgroundColor: 'red', padding: '1rem' },
      $loading: { $color: 'white' },
  }" />

  <!-- After -->
  <vs-button :style-set="{
      backgroundColor: 'red',
      padding: '1rem',
      $loading: { $color: 'white' },
  }" />
```

  변경 범위

  - types.ts 30개: VsXxxStyleSet { $component?: CSSProperties; ... } → extends CSSProperties { ... }
  - Vue 컴포넌트 39개: 템플릿/스크립트의 componentStyleSet.$component 및 $component: 래퍼 모두 평탄화
  - VsSelectTrigger: 부모로부터 받은 머지된 styleSet에 다시 useStyleSet을 호출해 componentInlineStyle 추출
  - 테스트/스토리/README/playground: 새 컨벤션으로 일괄 갱신
  - 문서: composables/style-set/README.md(.ko.md), .claude/skills/style-set-create/SKILL.md sync

  Breaking Change

  styleSet prop을 외부에서 직접 사용하는 코드는 다음과 같이 마이그레이션이 필요합니다:
```
  // Before
  { $component: { padding: '1rem' } }

  // After
  { padding: '1rem' }
```
  전역 styleSet 등록(VlossomOptions.styleSet)에서도 동일하게 적용됩니다.
