### PR TITLE
feat(style-set): nested-state pattern for stateful style-sets

### DIFF
--- a/.claude/skills/style-set-create/SKILL.md
+++ b/.claude/skills/style-set-create/SKILL.md
@@ -258,7 +258,7 @@ export default defineComponent({
 - [ ] 타입 안전한 CSS 속성 타입을 사용했는가? (`CSSProperties['objectFit'] & {}` 등)
 
 #### 네이밍
-- [ ] 상태 수식어가 prefix 패턴인가? (`$activeStep` ✅, `$stepActive` ❌)
+- [ ] 상태 수식어가 nested-state 패턴인가? (`$step.$active` ✅, `$activeStep` ❌)
 - [ ] 속성명이 내용을 반영하는가? (`$content` ✅, `$expand` ❌ — 동작이 아닌 내용 기반)
 - [ ] import가 같은 모듈에서 통합되었는가?
 
@@ -405,10 +405,21 @@ export interface VsCardStyleSet extends CSSProperties {
 
 ### 네이밍 규칙
 
-**상태 수식어는 prefix 패턴 사용:**
+**상태 수식어는 nested-state 패턴 사용:**
+
+상태(`$active`, `$selected`, `$focused` 등)는 별도의 top-level 키로 분리하지 말고, 해당 요소의 styleset 안에 중첩한다.
+컴포넌트의 .vue 파일에서 상태에 따라 `computed`로 base 스타일과 상태 스타일을 머지해 적용한다.
 
 ```typescript
-// ✅ CORRECT: prefix 패턴
+// ✅ CORRECT: nested-state 패턴
+$step?: CSSProperties & {
+    $active?: CSSProperties;
+};
+$label?: CSSProperties & {
+    $active?: CSSProperties;
+};
+
+// ❌ WRONG: prefix 패턴 (별도 top-level 키)
 $step?: CSSProperties;
 $activeStep?: CSSProperties;
 $label?: CSSProperties;

--- a/packages/vlossom/eslint.config.ts
+++ b/packages/vlossom/eslint.config.ts
@@ -86,7 +86,7 @@ export default defineConfigWithVueTs(
             'no-shadow': 'off',
             'no-prototype-builtins': 'off',
             'no-unused-vars': 'off',
-            '@typescript-eslint/no-unused-vars': 'error',
+            '@typescript-eslint/no-unused-vars': ['error', { ignoreRestSiblings: true }],
             '@typescript-eslint/no-shadow': 'error',
             '@typescript-eslint/no-explicit-any': 'off',
             '@typescript-eslint/explicit-module-boundary-types': 'off',

--- a/packages/vlossom/src/components/vs-accordion/VsAccordion.vue
+++ b/packages/vlossom/src/components/vs-accordion/VsAccordion.vue
@@ -3,7 +3,7 @@
         :class="['vs-accordion', colorSchemeClass, classObj, { 'vs-accordion-open': isOpen }]"
         :width
         :grid
-        :style="[styleSetVariables, componentInlineStyle]"
+        :style="{ ...styleSetVariables, ...componentInlineStyle }"
         :tabindex="disabled ? -1 : 0"
         @keydown.enter.prevent.stop="toggle"
         @keydown.space.prevent.stop="toggle"

--- a/packages/vlossom/src/components/vs-avatar/README.ko.md
+++ b/packages/vlossom/src/components/vs-avatar/README.ko.md
@@ -9,7 +9,6 @@
 ## Feature
 
 - 기본 슬롯을 통해 이미지, 텍스트 이니셜, 아이콘 콘텐츠 수용
-- `objectFit` CSS 변수를 통한 이미지 object-fit 커스터마이징 지원
 - 배경 및 테두리 스타일링을 위한 색상 테마 지원
 - 기본 크기(3.6rem × 3.6rem) 고정이며 `component` CSSProperties로 완전 재정의 가능
 
@@ -43,16 +42,16 @@
 
 ## Props
 
-| Prop | Type | Default | Required | Description |
-| ---- | ---- | ------- | -------- | ----------- |
-| `colorScheme` | `ColorScheme` | | | 컴포넌트 색상 테마 |
-| `styleSet` | `string \| VsAvatarStyleSet` | | | 커스텀 스타일 세트 |
+| Prop          | Type                         | Default | Required | Description        |
+| ------------- | ---------------------------- | ------- | -------- | ------------------ |
+| `colorScheme` | `ColorScheme`                |         |          | 컴포넌트 색상 테마 |
+| `styleSet`    | `string \| VsAvatarStyleSet` |         |          | 커스텀 스타일 세트 |
 
 ## Types
 
 ```typescript
 interface VsAvatarStyleSet extends CSSProperties {
-    $objectFit?: CSSProperties['objectFit'] & {};
+    $imageObjectFit?: CSSProperties['objectFit'] & {};
 }
 ```
 
@@ -62,7 +61,7 @@ interface VsAvatarStyleSet extends CSSProperties {
 <template>
     <vs-avatar
         :style-set="{
-            $objectFit: 'cover',
+            $imageObjectFit: 'cover',
             width: '5rem',
             height: '5rem',
             borderRadius: '50%',
@@ -80,8 +79,8 @@ interface VsAvatarStyleSet extends CSSProperties {
 
 ## Slots
 
-| Slot | Description |
-| ---- | ----------- |
+| Slot      | Description                            |
+| --------- | -------------------------------------- |
 | `default` | 아바타 콘텐츠 — 이미지, 이니셜, 아이콘 |
 
 ## Methods

--- a/packages/vlossom/src/components/vs-avatar/README.md
+++ b/packages/vlossom/src/components/vs-avatar/README.md
@@ -9,7 +9,6 @@ A circular or rounded display element for showing user profile images, initials,
 ## Feature
 
 - Accepts image elements, text initials, or icon content via the default slot
-- Supports `object-fit` customization for images via the `objectFit` CSS variable
 - Color scheme support for background and border styling
 - Fixed default size (3.6rem × 3.6rem) with full override via `component` CSSProperties
 
@@ -43,16 +42,16 @@ A circular or rounded display element for showing user profile images, initials,
 
 ## Props
 
-| Prop | Type | Default | Required | Description |
-| ---- | ---- | ------- | -------- | ----------- |
-| `colorScheme` | `ColorScheme` | | | Color scheme for the component |
-| `styleSet` | `string \| VsAvatarStyleSet` | | | Custom style set |
+| Prop          | Type                         | Default | Required | Description                    |
+| ------------- | ---------------------------- | ------- | -------- | ------------------------------ |
+| `colorScheme` | `ColorScheme`                |         |          | Color scheme for the component |
+| `styleSet`    | `string \| VsAvatarStyleSet` |         |          | Custom style set               |
 
 ## Types
 
 ```typescript
 interface VsAvatarStyleSet extends CSSProperties {
-    $objectFit?: CSSProperties['objectFit'] & {};
+    $imageObjectFit?: CSSProperties['objectFit'] & {};
 }
 ```
 
@@ -62,7 +61,7 @@ interface VsAvatarStyleSet extends CSSProperties {
 <template>
     <vs-avatar
         :style-set="{
-            $objectFit: 'cover',
+            $imageObjectFit: 'cover',
             width: '5rem',
             height: '5rem',
             borderRadius: '50%',
@@ -80,8 +79,8 @@ interface VsAvatarStyleSet extends CSSProperties {
 
 ## Slots
 
-| Slot | Description |
-| ---- | ----------- |
+| Slot      | Description                               |
+| --------- | ----------------------------------------- |
 | `default` | Avatar content — image, initials, or icon |
 
 ## Methods

--- a/packages/vlossom/src/components/vs-avatar/VsAvatar.vue
+++ b/packages/vlossom/src/components/vs-avatar/VsAvatar.vue
@@ -23,14 +23,10 @@ export default defineComponent({
 
         const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet<VsAvatarStyleSet>(
-            componentName,
-            styleSet,
-        );
+        const { styleSetVariables, componentInlineStyle } = useStyleSet<VsAvatarStyleSet>(componentName, styleSet);
 
         return {
             colorSchemeClass,
-            componentStyleSet,
             styleSetVariables,
             componentInlineStyle,
         };

--- a/packages/vlossom/src/components/vs-bar/VsBar.vue
+++ b/packages/vlossom/src/components/vs-bar/VsBar.vue
@@ -1,9 +1,5 @@
 <template>
-    <component
-        :is="tag"
-        :class="['vs-bar', colorSchemeClass, classObj]"
-        :style="componentInlineStyle"
-    >
+    <component :is="tag" :class="['vs-bar', colorSchemeClass, classObj]" :style="componentInlineStyle">
         <slot />
     </component>
 </template>
@@ -36,7 +32,7 @@ export default defineComponent({
                 position: position.value || undefined,
             });
         });
-        const { componentStyleSet, componentInlineStyle } = useStyleSet<VsBarStyleSet>(
+        const { componentInlineStyle } = useStyleSet<VsBarStyleSet>(
             componentName,
             styleSet,
             baseStyleSet,
@@ -47,7 +43,7 @@ export default defineComponent({
             'vs-primary': primary.value,
         }));
 
-        return { colorSchemeClass, componentStyleSet, componentInlineStyle, classObj };
+        return { colorSchemeClass, componentInlineStyle, classObj };
     },
 });
 </script>

--- a/packages/vlossom/src/components/vs-dimmed/VsDimmed.vue
+++ b/packages/vlossom/src/components/vs-dimmed/VsDimmed.vue
@@ -1,11 +1,6 @@
 <template>
     <Transition name="dimmed">
-        <div
-            v-if="isShow"
-            class="vs-dimmed"
-            :style="componentInlineStyle"
-            aria-hidden="true"
-        />
+        <div v-if="isShow" class="vs-dimmed" :style="componentInlineStyle" aria-hidden="true" />
     </Transition>
 </template>
 
@@ -33,7 +28,7 @@ export default defineComponent({
 
         const isShow = ref(modelValue.value);
 
-        const { componentStyleSet, componentInlineStyle } = useStyleSet<VsDimmedStyleSet>(componentName, styleSet);
+        const { componentInlineStyle } = useStyleSet<VsDimmedStyleSet>(componentName, styleSet);
 
         function show() {
             isShow.value = true;
@@ -53,7 +48,6 @@ export default defineComponent({
 
         return {
             isShow,
-            componentStyleSet,
             componentInlineStyle,
             show,
             hide,

--- a/packages/vlossom/src/components/vs-divider/VsDivider.vue
+++ b/packages/vlossom/src/components/vs-divider/VsDivider.vue
@@ -27,10 +27,7 @@ export default defineComponent({
 
         const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet<VsDividerStyleSet>(
-            componentName,
-            styleSet,
-        );
+        const { styleSetVariables, componentInlineStyle } = useStyleSet<VsDividerStyleSet>(componentName, styleSet);
 
         const classObj = computed(() => ({
             'vs-vertical': vertical.value,
@@ -39,7 +36,6 @@ export default defineComponent({
 
         return {
             colorSchemeClass,
-            componentStyleSet,
             styleSetVariables,
             componentInlineStyle,
             classObj,

--- a/packages/vlossom/src/components/vs-expandable/VsExpandable.vue
+++ b/packages/vlossom/src/components/vs-expandable/VsExpandable.vue
@@ -26,7 +26,7 @@ export default defineComponent({
     setup(props) {
         const { styleSet } = toRefs(props);
 
-        const { componentStyleSet, componentInlineStyle } = useStyleSet<VsExpandableStyleSet>(componentName, styleSet);
+        const { componentInlineStyle } = useStyleSet<VsExpandableStyleSet>(componentName, styleSet);
 
         function beforeEnter(el: Element) {
             const element = el as HTMLElement;
@@ -84,7 +84,6 @@ export default defineComponent({
         }
 
         return {
-            componentStyleSet,
             componentInlineStyle,
             beforeEnter,
             enter,

--- a/packages/vlossom/src/components/vs-grid/VsGrid.vue
+++ b/packages/vlossom/src/components/vs-grid/VsGrid.vue
@@ -1,5 +1,5 @@
 <template>
-    <component :is="tag" class="vs-grid" :style="[componentInlineStyle, styleSetVariables]">
+    <component :is="tag" class="vs-grid" :style="{ ...styleSetVariables, ...componentInlineStyle }">
         <slot />
     </component>
 </template>
@@ -36,7 +36,7 @@ export default defineComponent({
             });
         });
 
-        const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet<VsGridStyleSet>(
+        const { styleSetVariables, componentInlineStyle } = useStyleSet<VsGridStyleSet>(
             componentName,
             styleSet,
             baseStyleSet,
@@ -44,7 +44,6 @@ export default defineComponent({
         );
 
         return {
-            componentStyleSet,
             styleSetVariables,
             componentInlineStyle,
         };

--- a/packages/vlossom/src/components/vs-grid/__tests__/vs-grid.test.ts
+++ b/packages/vlossom/src/components/vs-grid/__tests__/vs-grid.test.ts
@@ -27,7 +27,7 @@ describe('VsGrid', () => {
             });
 
             // then
-            expect(wrapper.vm.componentStyleSet).toMatchObject({
+            expect(wrapper.vm.componentInlineStyle).toMatchObject({
                 width: '600px',
                 height: '500px',
             });
@@ -47,7 +47,7 @@ describe('VsGrid', () => {
             });
         });
 
-        it('columnGap, rowGap이 주어지면 componentStyleSet에 적용되어야 한다', () => {
+        it('columnGap, rowGap이 주어지면 componentInlineStyle에 적용되어야 한다', () => {
             // given, when
             const wrapper = mount(VsGrid, {
                 props: {
@@ -57,7 +57,7 @@ describe('VsGrid', () => {
             });
 
             // then
-            expect(wrapper.vm.componentStyleSet).toMatchObject({
+            expect(wrapper.vm.componentInlineStyle).toMatchObject({
                 columnGap: '20px',
                 rowGap: '25px',
             });

--- a/packages/vlossom/src/components/vs-loading/VsLoading.vue
+++ b/packages/vlossom/src/components/vs-loading/VsLoading.vue
@@ -38,14 +38,14 @@ export default defineComponent({
             });
         });
 
-        const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet<VsLoadingStyleSet>(
+        const { styleSetVariables, componentInlineStyle } = useStyleSet<VsLoadingStyleSet>(
             componentName,
             styleSet,
             baseStyleSet,
             additionalStyleSet,
         );
 
-        return { colorSchemeClass, componentStyleSet, styleSetVariables, componentInlineStyle };
+        return { colorSchemeClass, styleSetVariables, componentInlineStyle };
     },
 });
 </script>

--- a/packages/vlossom/src/components/vs-loading/__tests__/vs-loading.test.ts
+++ b/packages/vlossom/src/components/vs-loading/__tests__/vs-loading.test.ts
@@ -41,7 +41,7 @@ describe('VsLoading', () => {
             });
 
             // then
-            expect(wrapper.vm.componentStyleSet).toMatchObject({
+            expect(wrapper.vm.componentInlineStyle).toMatchObject({
                 width: '200px',
                 height: '150px',
             });
@@ -61,7 +61,7 @@ describe('VsLoading', () => {
             });
 
             // then
-            expect(wrapper.vm.componentStyleSet).toMatchObject({
+            expect(wrapper.vm.componentInlineStyle).toMatchObject({
                 width: '300px',
                 height: '250px',
             });

--- a/packages/vlossom/src/components/vs-message/VsMessage.vue
+++ b/packages/vlossom/src/components/vs-message/VsMessage.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="['vs-message', colorClass]" :style="{ ...componentInlineStyle, ...styleSetVariables }">
+    <div :class="['vs-message', colorClass]" :style="{ ...styleSetVariables, ...componentInlineStyle }">
         <i class="vs-message-icon">
             <vs-render :content="icon" />
         </i>
@@ -47,13 +47,13 @@ export default defineComponent({
             }
         });
 
-        const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet(componentName, styleSet);
+        const { styleSetVariables, componentInlineStyle } = useStyleSet(componentName, styleSet);
 
         const icon = computed(() => {
             return messageIcons[state.value];
         });
 
-        return { colorClass, icon, componentStyleSet, styleSetVariables, componentInlineStyle };
+        return { colorClass, icon, styleSetVariables, componentInlineStyle };
     },
 });
 </script>

--- a/packages/vlossom/src/components/vs-pagination/README.ko.md
+++ b/packages/vlossom/src/components/vs-pagination/README.ko.md
@@ -62,15 +62,15 @@ const page = ref(0);
 
 ```typescript
 interface VsPaginationStyleSet extends CSSProperties {
-    $selectedButtonBackgroundColor?: string;
-    $selectedButtonFontColor?: string;
-    $pageButton?: Omit<VsButtonStyleSet, '$loading'>;
+    $pageButton?: Omit<VsButtonStyleSet, '$loading'> & {
+        $selected?: Omit<VsButtonStyleSet, '$loading'>;
+    };
     $controlButton?: Omit<VsButtonStyleSet, '$loading'>;
 }
 ```
 
 > [!NOTE]
-> `$pageButton`과 `$controlButton`은 [VsButtonStyleSet](../vs-button/README.md#types)(`$loading` 제외)을 사용합니다.
+> `$pageButton`과 `$controlButton`은 [VsButtonStyleSet](../vs-button/README.md#types)(`$loading` 제외)을 사용합니다. `$pageButton.$selected`는 현재 선택된 페이지 버튼에 적용됩니다.
 
 ### StyleSet 사용 예시
 
@@ -80,9 +80,13 @@ interface VsPaginationStyleSet extends CSSProperties {
         v-model="page"
         :length="10"
         :style-set="{
-            $selectedButtonBackgroundColor: '#4f46e5',
-            $selectedButtonFontColor: '#ffffff',
             gap: '0.25rem',
+            $pageButton: {
+                $selected: {
+                    backgroundColor: '#4f46e5',
+                    color: '#ffffff',
+                },
+            },
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-pagination/README.md
+++ b/packages/vlossom/src/components/vs-pagination/README.md
@@ -62,15 +62,15 @@ const page = ref(0);
 
 ```typescript
 interface VsPaginationStyleSet extends CSSProperties {
-    $selectedButtonBackgroundColor?: string;
-    $selectedButtonFontColor?: string;
-    $pageButton?: Omit<VsButtonStyleSet, '$loading'>;
+    $pageButton?: Omit<VsButtonStyleSet, '$loading'> & {
+        $selected?: Omit<VsButtonStyleSet, '$loading'>;
+    };
     $controlButton?: Omit<VsButtonStyleSet, '$loading'>;
 }
 ```
 
 > [!NOTE]
-> `$pageButton` and `$controlButton` use [VsButtonStyleSet](../vs-button/README.md#types) (excluding `$loading`).
+> `$pageButton` and `$controlButton` use [VsButtonStyleSet](../vs-button/README.md#types) (excluding `$loading`). The `$pageButton.$selected` style is applied to the currently selected page button.
 
 ### StyleSet Example
 
@@ -80,9 +80,13 @@ interface VsPaginationStyleSet extends CSSProperties {
         v-model="page"
         :length="10"
         :style-set="{
-            $selectedButtonBackgroundColor: '#4f46e5',
-            $selectedButtonFontColor: '#ffffff',
             gap: '0.25rem',
+            $pageButton: {
+                $selected: {
+                    backgroundColor: '#4f46e5',
+                    color: '#ffffff',
+                },
+            },
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-pagination/VsPagination.css
+++ b/packages/vlossom/src/components/vs-pagination/VsPagination.css
@@ -1,9 +1,6 @@
 @reference 'tailwindcss';
 
 .vs-pagination {
-    --vs-pagination-selectedButtonBackgroundColor: initial;
-    --vs-pagination-selectedButtonFontColor: initial;
-
     @apply relative flex items-center justify-center;
 
     gap: 0.5rem;
@@ -18,13 +15,6 @@
         .vs-page-button {
             min-width: 2rem;
             min-height: 2rem;
-        }
-
-        .vs-page-button {
-            &.vs-primary {
-                background-color: var(--vs-pagination-selectedButtonBackgroundColor, var(--vs-cs-bg-primary));
-                color: var(--vs-pagination-selectedButtonFontColor, var(--vs-cs-font-primary));
-            }
         }
     }
 

--- a/packages/vlossom/src/components/vs-pagination/VsPagination.vue
+++ b/packages/vlossom/src/components/vs-pagination/VsPagination.vue
@@ -16,7 +16,7 @@
             @click.prevent.stop="goFirst()"
         >
             <slot name="first">
-                <vs-render :content="paginationIcons.goFirst" />
+                <vs-render class="size-4" :content="paginationIcons.goFirst" />
             </slot>
         </vs-button>
         <vs-button
@@ -31,7 +31,7 @@
             @click.prevent.stop="goPrev()"
         >
             <slot name="prev">
-                <vs-render :content="paginationIcons.goPrev" />
+                <vs-render class="size-4" :content="paginationIcons.goPrev" />
             </slot>
         </vs-button>
         <div class="vs-page-buttons">
@@ -66,7 +66,7 @@
             @click.prevent.stop="goNext()"
         >
             <slot name="next">
-                <vs-render :content="paginationIcons.goNext" />
+                <vs-render class="size-4" :content="paginationIcons.goNext" />
             </slot>
         </vs-button>
         <vs-button
@@ -82,7 +82,7 @@
             @click.prevent.stop="goLast()"
         >
             <slot name="last">
-                <vs-render :content="paginationIcons.goLast" />
+                <vs-render class="size-4" :content="paginationIcons.goLast" />
             </slot>
         </vs-button>
     </div>
@@ -144,9 +144,7 @@ export default defineComponent({
         const { colorScheme, styleSet, disabled, modelValue, length, showingLength } = toRefs(props);
         const { computedColorScheme, colorSchemeClass } = useColorScheme(componentName, colorScheme);
         const baseStyleSet: ComputedRef<VsPaginationStyleSet> = computed(() => ({
-            $controlButton: {
-                padding: '0.4rem',
-            },
+            $controlButton: { $content: { padding: '0' } },
         }));
 
         const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet<VsPaginationStyleSet>(

--- a/packages/vlossom/src/components/vs-pagination/VsPagination.vue
+++ b/packages/vlossom/src/components/vs-pagination/VsPagination.vue
@@ -93,7 +93,7 @@ import { type ComputedRef, computed, defineComponent, toRefs, watch } from 'vue'
 import { VsComponent } from '@/declaration';
 import { useColorScheme, useStyleSet, useIndexSelector } from '@/composables';
 import { getColorSchemeProps, getStyleSetProps } from '@/props';
-import { logUtil } from '@/utils';
+import { logUtil, objectUtil } from '@/utils';
 import type { VsPaginationStyleSet } from './types';
 import { paginationIcons } from './icons';
 
@@ -191,9 +191,9 @@ export default defineComponent({
         });
 
         function getPageButtonStyleSet(page: number) {
-            const { $selected, ...base } = componentStyleSet.value.$pageButton ?? {};
+            const { $selected = {}, ...base } = componentStyleSet.value.$pageButton ?? {};
             if (page === selectedIndex.value + 1) {
-                return { ...base, ...$selected };
+                return objectUtil.assign(base, $selected);
             }
             return base;
         }

--- a/packages/vlossom/src/components/vs-pagination/VsPagination.vue
+++ b/packages/vlossom/src/components/vs-pagination/VsPagination.vue
@@ -40,7 +40,7 @@
                 :key="page"
                 class="vs-page-button"
                 :color-scheme="computedColorScheme"
-                :style-set="componentStyleSet.$pageButton"
+                :style-set="getPageButtonStyleSet(page)"
                 :primary="page === selectedIndex + 1"
                 :disabled
                 :ghost
@@ -192,6 +192,14 @@ export default defineComponent({
             return pageArr;
         });
 
+        function getPageButtonStyleSet(page: number) {
+            const { $selected, ...base } = componentStyleSet.value.$pageButton ?? {};
+            if (page === selectedIndex.value + 1) {
+                return { ...base, ...$selected };
+            }
+            return base;
+        }
+
         function setPage(page: number) {
             selectIndex(page);
         }
@@ -239,6 +247,7 @@ export default defineComponent({
             paginationIcons,
             selectedIndex,
             pages,
+            getPageButtonStyleSet,
             goFirst,
             goLast,
             goPrev,

--- a/packages/vlossom/src/components/vs-pagination/types.ts
+++ b/packages/vlossom/src/components/vs-pagination/types.ts
@@ -19,11 +19,8 @@ export interface VsPaginationRef extends ComponentPublicInstance<typeof VsPagina
 }
 
 export interface VsPaginationStyleSet extends CSSProperties {
-    // TODO: VsStateStyleSet 처리 필요
-    $selectedButtonBackgroundColor?: string;
-    $selectedButtonFontColor?: string;
-    // TODO: VsStateStyleSet 처리 필요 (이렇게 하면 되지 않을까?)
-    // $pageButton?: Omit<VsButtonStyleSet, '$loading'> & { $selected?: CSSProperties; };
-    $pageButton?: Omit<VsButtonStyleSet, '$loading'>;
+    $pageButton?: Omit<VsButtonStyleSet, '$loading'> & {
+        $selected?: Omit<VsButtonStyleSet, '$loading'>;
+    };
     $controlButton?: Omit<VsButtonStyleSet, '$loading'>;
 }

--- a/packages/vlossom/src/components/vs-progress/VsProgress.vue
+++ b/packages/vlossom/src/components/vs-progress/VsProgress.vue
@@ -44,10 +44,7 @@ export default defineComponent({
 
         const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
-        const { componentStyleSet, styleSetVariables, componentInlineStyle } = useStyleSet<VsProgressStyleSet>(
-            componentName,
-            styleSet,
-        );
+        const { styleSetVariables, componentInlineStyle } = useStyleSet<VsProgressStyleSet>(componentName, styleSet);
 
         const { value, max } = toRefs(props);
 
@@ -74,7 +71,6 @@ export default defineComponent({
 
         return {
             colorSchemeClass,
-            componentStyleSet,
             styleSetVariables,
             componentInlineStyle,
             computedValue,

--- a/packages/vlossom/src/components/vs-select/README.ko.md
+++ b/packages/vlossom/src/components/vs-select/README.ko.md
@@ -112,22 +112,19 @@ const options = [
 ```typescript
 interface VsSelectStyleSet extends CSSProperties {
     $height?: string;
-    $focused?: {
-        border?: string;
-        borderRadius?: string;
-        backgroundColor?: string;
-    };
     $wrapper?: VsInputWrapperStyleSet;
     $chip?: VsChipStyleSet;
     $selectAllCheckbox?: VsCheckboxStyleSet;
     $options?: VsGroupedListStyleSet;
-    $option?: CSSProperties;
-    $selectedOption?: CSSProperties;
+    $option?: CSSProperties & {
+        $focused?: CSSProperties;
+        $selected?: CSSProperties;
+    };
 }
 ```
 
 > [!NOTE]
-> `$wrapper`는 [VsInputWrapperStyleSet](../vs-input-wrapper/README.md#types), `$chip`은 [VsChipStyleSet](../vs-chip/README.md#types), `$selectAllCheckbox`는 [VsCheckboxStyleSet](../vs-checkbox/README.md#types), `$options`는 [VsGroupedListStyleSet](../vs-grouped-list/README.md#types)을 사용합니다.
+> `$wrapper`는 [VsInputWrapperStyleSet](../vs-input-wrapper/README.md#types), `$chip`은 [VsChipStyleSet](../vs-chip/README.md#types), `$selectAllCheckbox`는 [VsCheckboxStyleSet](../vs-checkbox/README.md#types), `$options`는 [VsGroupedListStyleSet](../vs-grouped-list/README.md#types)을 사용합니다. `$option.$focused`는 키보드로 포커스된 옵션에 적용되고, `$option.$selected`는 선택된 옵션에 적용됩니다.
 
 ### StyleSet 사용 예시
 
@@ -138,9 +135,11 @@ interface VsSelectStyleSet extends CSSProperties {
         :options="options"
         :style-set="{
             $height: '2.5rem',
-            $focused: { border: '2px solid #6366f1' },
-            $option: { padding: '0.5rem 1rem' },
-            $selectedOption: { backgroundColor: '#ede9fe', fontWeight: 'bold' },
+            $option: {
+                padding: '0.5rem 1rem',
+                $focused: { backgroundColor: '#eef2ff' },
+                $selected: { backgroundColor: '#ede9fe', fontWeight: 'bold' },
+            },
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-select/README.md
+++ b/packages/vlossom/src/components/vs-select/README.md
@@ -112,22 +112,19 @@ const options = [
 ```typescript
 interface VsSelectStyleSet extends CSSProperties {
     $height?: string;
-    $focused?: {
-        border?: string;
-        borderRadius?: string;
-        backgroundColor?: string;
-    };
     $wrapper?: VsInputWrapperStyleSet;
     $chip?: VsChipStyleSet;
     $selectAllCheckbox?: VsCheckboxStyleSet;
     $options?: VsGroupedListStyleSet;
-    $option?: CSSProperties;
-    $selectedOption?: CSSProperties;
+    $option?: CSSProperties & {
+        $focused?: CSSProperties;
+        $selected?: CSSProperties;
+    };
 }
 ```
 
 > [!NOTE]
-> `$wrapper` uses [VsInputWrapperStyleSet](../vs-input-wrapper/README.md#types), `$chip` uses [VsChipStyleSet](../vs-chip/README.md#types), `$selectAllCheckbox` uses [VsCheckboxStyleSet](../vs-checkbox/README.md#types), and `$options` uses [VsGroupedListStyleSet](../vs-grouped-list/README.md#types).
+> `$wrapper` uses [VsInputWrapperStyleSet](../vs-input-wrapper/README.md#types), `$chip` uses [VsChipStyleSet](../vs-chip/README.md#types), `$selectAllCheckbox` uses [VsCheckboxStyleSet](../vs-checkbox/README.md#types), and `$options` uses [VsGroupedListStyleSet](../vs-grouped-list/README.md#types). The `$option.$focused` style is applied to the keyboard-focused option, and `$option.$selected` is applied to selected options.
 
 ### StyleSet Example
 
@@ -138,9 +135,11 @@ interface VsSelectStyleSet extends CSSProperties {
         :options="options"
         :style-set="{
             $height: '2.5rem',
-            $focused: { border: '2px solid #6366f1' },
-            $option: { padding: '0.5rem 1rem' },
-            $selectedOption: { backgroundColor: '#ede9fe', fontWeight: 'bold' },
+            $option: {
+                padding: '0.5rem 1rem',
+                $focused: { backgroundColor: '#eef2ff' },
+                $selected: { backgroundColor: '#ede9fe', fontWeight: 'bold' },
+            },
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-select/VsSelect.css
+++ b/packages/vlossom/src/components/vs-select/VsSelect.css
@@ -57,10 +57,6 @@
 }
 
 .vs-select-options {
-    --vs-select-focused-border: initial;
-    --vs-select-focused-borderRadius: initial;
-    --vs-select-focused-backgroundColor: initial;
-
     @apply overflow-hidden;
 
     border: 1px solid var(--vs-cs-line);
@@ -72,7 +68,7 @@
 
         &.vs-focusable-active {
             @apply box-content;
-            background-color: var(--vs-select-focused-backgroundColor, var(--vs-cs-bg-colored)) !important;
+            background-color: var(--vs-cs-bg-colored);
         }
     }
 

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -86,12 +86,12 @@
                                 'vs-select-focusable',
                                 { selected: isSelected(itemSlotProps.id) },
                             ]"
-                            :style="componentStyleSet.$option"
+                            :style="getOptionStyleSet(itemSlotProps.id)"
                             :data-id="itemSlotProps.id"
                             :data-focusable="itemSlotProps.disabled ? undefined : true"
                         >
                             <slot name="option" v-bind="{ ...itemSlotProps, selected: isSelected(itemSlotProps.id) }">
-                                <div class="vs-select-option" :style="getOptionStyleSet(itemSlotProps.id)">
+                                <div class="vs-select-option">
                                     {{ itemSlotProps.label }}
                                 </div>
                             </slot>
@@ -455,9 +455,12 @@ export default defineComponent({
         }
 
         function getOptionStyleSet(optionId: string): CSSProperties {
+            const { $focused, $selected, ...base } = componentStyleSet.value.$option ?? {};
+            const isOptionFocused = currentFocusableElement.value?.dataset?.['id'] === optionId;
             return {
-                ...componentStyleSet.value.$option,
-                ...(isSelected(optionId) ? componentStyleSet.value.$selectedOption : {}),
+                ...base,
+                ...(isSelected(optionId) ? $selected : {}),
+                ...(isOptionFocused ? $focused : {}),
             };
         }
 

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -455,13 +455,15 @@ export default defineComponent({
         }
 
         function getOptionStyleSet(optionId: string): CSSProperties {
-            const { $focused, $selected, ...base } = componentStyleSet.value.$option ?? {};
+            const { $focused = {}, $selected = {}, ...base } = componentStyleSet.value.$option ?? {};
             const isOptionFocused = currentFocusableElement.value?.dataset?.['id'] === optionId;
-            return {
-                ...base,
-                ...(isSelected(optionId) ? $selected : {}),
-                ...(isOptionFocused ? $focused : {}),
-            };
+            if (isSelected(optionId)) {
+                return objectUtil.assign(base, $selected);
+            }
+            if (isOptionFocused) {
+                return objectUtil.assign(base, $focused);
+            }
+            return base;
         }
 
         function closeOptions() {

--- a/packages/vlossom/src/components/vs-select/__stories__/vs-select.stories.ts
+++ b/packages/vlossom/src/components/vs-select/__stories__/vs-select.stories.ts
@@ -227,10 +227,10 @@ export const StyleSet: Story = {
         placeholder: 'Select an option',
         styleSet: {
             $height: '3rem',
-            $focused: {
-                border: '2px solid #2196f3',
-                borderRadius: '12px',
-                backgroundColor: '#f5f5f5',
+            $option: {
+                $focused: {
+                    backgroundColor: '#f5f5f5',
+                },
             },
             fontSize: '1rem',
         },

--- a/packages/vlossom/src/components/vs-select/types.ts
+++ b/packages/vlossom/src/components/vs-select/types.ts
@@ -21,16 +21,12 @@ export interface VsSelectTriggerRef extends ComponentPublicInstance<typeof VsSel
 
 export interface VsSelectStyleSet extends CSSProperties {
     $height?: string;
-    // TODO: VsStateStyleSet 처리 필요
-    $focused?: {
-        border?: string;
-        borderRadius?: string;
-        backgroundColor?: string;
-    };
     $wrapper?: VsInputWrapperStyleSet;
     $chip?: VsChipStyleSet;
     $selectAllCheckbox?: VsCheckboxStyleSet;
     $options?: VsGroupedListStyleSet;
-    $option?: CSSProperties;
-    $selectedOption?: CSSProperties;
+    $option?: CSSProperties & {
+        $focused?: CSSProperties;
+        $selected?: CSSProperties;
+    };
 }

--- a/packages/vlossom/src/components/vs-steps/README.ko.md
+++ b/packages/vlossom/src/components/vs-steps/README.ko.md
@@ -79,14 +79,22 @@ interface VsStepsStyleSet extends CSSProperties {
     $stepSize?: string;
 
     $steps?: CSSProperties;
-    $step?: CSSProperties;
-    $activeStep?: CSSProperties;
-    $label?: CSSProperties;
-    $activeLabel?: CSSProperties;
-    $progress?: CSSProperties;
-    $activeProgress?: CSSProperties;
+    $step?: CSSProperties & {
+        $completed?: CSSProperties;
+        $active?: CSSProperties;
+    };
+    $label?: CSSProperties & {
+        $completed?: CSSProperties;
+        $active?: CSSProperties;
+    };
+    $progress?: CSSProperties & {
+        $active?: CSSProperties;
+    };
 }
 ```
+
+> [!NOTE]
+> `$completed`는 이미 완료된 단계에, `$active`는 현재 단계에 적용됩니다. `$progress`는 progress 트랙(빈 경로), `$progress.$active`는 채워진 부분 스타일입니다.
 
 ### StyleSet 사용 예시
 
@@ -97,10 +105,15 @@ interface VsStepsStyleSet extends CSSProperties {
         :steps="steps"
         :style-set="{
             $stepSize: '2rem',
-            $step: { border: '2px solid #d1d5db' },
-            $activeStep: { backgroundColor: '#6366f1', borderColor: '#6366f1', color: '#fff' },
-            $progress: { backgroundColor: '#a5b4fc' },
-            $activeProgress: { backgroundColor: '#6366f1' },
+            $step: {
+                border: '2px solid #d1d5db',
+                $completed: { backgroundColor: '#a5b4fc', borderColor: '#a5b4fc', color: '#fff' },
+                $active: { backgroundColor: '#6366f1', borderColor: '#6366f1', color: '#fff' },
+            },
+            $progress: {
+                backgroundColor: '#e5e7eb',
+                $active: { backgroundColor: '#6366f1' },
+            },
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-steps/README.md
+++ b/packages/vlossom/src/components/vs-steps/README.md
@@ -79,14 +79,22 @@ interface VsStepsStyleSet extends CSSProperties {
     $stepSize?: string;
 
     $steps?: CSSProperties;
-    $step?: CSSProperties;
-    $activeStep?: CSSProperties;
-    $label?: CSSProperties;
-    $activeLabel?: CSSProperties;
-    $progress?: CSSProperties;
-    $activeProgress?: CSSProperties;
+    $step?: CSSProperties & {
+        $completed?: CSSProperties;
+        $active?: CSSProperties;
+    };
+    $label?: CSSProperties & {
+        $completed?: CSSProperties;
+        $active?: CSSProperties;
+    };
+    $progress?: CSSProperties & {
+        $active?: CSSProperties;
+    };
 }
 ```
+
+> [!NOTE]
+> `$completed` applies to completed steps (passed) and `$active` applies to the current step. `$progress` styles the progress track (empty path) and `$progress.$active` styles the filled portion.
 
 ### StyleSet Example
 
@@ -97,10 +105,15 @@ interface VsStepsStyleSet extends CSSProperties {
         :steps="steps"
         :style-set="{
             $stepSize: '2rem',
-            $step: { border: '2px solid #d1d5db' },
-            $activeStep: { backgroundColor: '#6366f1', borderColor: '#6366f1', color: '#fff' },
-            $progress: { backgroundColor: '#a5b4fc' },
-            $activeProgress: { backgroundColor: '#6366f1' },
+            $step: {
+                border: '2px solid #d1d5db',
+                $completed: { backgroundColor: '#a5b4fc', borderColor: '#a5b4fc', color: '#fff' },
+                $active: { backgroundColor: '#6366f1', borderColor: '#6366f1', color: '#fff' },
+            },
+            $progress: {
+                backgroundColor: '#e5e7eb',
+                $active: { backgroundColor: '#6366f1' },
+            },
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-steps/VsSteps.vue
+++ b/packages/vlossom/src/components/vs-steps/VsSteps.vue
@@ -5,7 +5,7 @@
         :width
         :grid
     >
-        <div class="vs-step-line">
+        <div class="vs-step-line" :style="trackStyleSet">
             <div class="vs-step-progress" :style="progressStyleSet" />
         </div>
         <ul
@@ -135,6 +135,11 @@ export default defineComponent({
             handleKeydown,
         } = useIndexSelector(steps, disabled);
 
+        const trackStyleSet: ComputedRef<CSSProperties> = computed(() => {
+            const { $active, ...base } = componentStyleSet.value.$progress ?? {};
+            return base;
+        });
+
         const progressStyleSet: ComputedRef<CSSProperties> = computed(() => {
             const dimensionKey = vertical.value ? 'height' : 'width';
             if (gapCount.value === 0) {
@@ -143,23 +148,26 @@ export default defineComponent({
 
             const percentage = selectedIndex.value === NOT_SELECTED ? 0 : (selectedIndex.value / gapCount.value) * 100;
             return {
-                ...componentStyleSet.value.$progress,
-                ...(isSelected(selectedIndex.value) ? componentStyleSet.value.$activeProgress : {}),
+                ...componentStyleSet.value.$progress?.$active,
                 [dimensionKey]: `${percentage}%`,
             };
         });
 
         function getStepStyleSet(index: number): CSSProperties {
+            const { $completed, $active, ...base } = componentStyleSet.value.$step ?? {};
             return {
-                ...componentStyleSet.value.$step,
-                ...(isPrevious(index) || isSelected(index) ? componentStyleSet.value.$activeStep : {}),
+                ...base,
+                ...(isPrevious(index) ? $completed : {}),
+                ...(isSelected(index) ? $active : {}),
             };
         }
 
         function getLabelStyleSet(index: number): CSSProperties {
+            const { $completed, $active, ...base } = componentStyleSet.value.$label ?? {};
             return {
-                ...componentStyleSet.value.$label,
-                ...(isPrevious(index) || isSelected(index) ? componentStyleSet.value.$activeLabel : {}),
+                ...base,
+                ...(isPrevious(index) ? $completed : {}),
+                ...(isSelected(index) ? $active : {}),
             };
         }
 
@@ -185,6 +193,7 @@ export default defineComponent({
             componentStyleSet,
             styleSetVariables,
             componentInlineStyle,
+            trackStyleSet,
             progressStyleSet,
             getStepStyleSet,
             getLabelStyleSet,

--- a/packages/vlossom/src/components/vs-steps/VsSteps.vue
+++ b/packages/vlossom/src/components/vs-steps/VsSteps.vue
@@ -75,9 +75,9 @@ import {
 import { useColorScheme, useStyleSet, useIndexSelector } from '@/composables';
 import { getResponsiveProps, getColorSchemeProps, getStyleSetProps } from '@/props';
 import { NOT_SELECTED, VsComponent } from '@/declaration';
+import { objectUtil, stringUtil } from '@/utils';
 import VsResponsive from '@/components/vs-responsive/VsResponsive.vue';
 import type { VsStepsStyleSet } from './types';
-import { objectUtil, stringUtil } from '@/utils';
 
 const componentName = VsComponent.VsSteps;
 export default defineComponent({
@@ -154,21 +154,25 @@ export default defineComponent({
         });
 
         function getStepStyleSet(index: number): CSSProperties {
-            const { $completed, $active, ...base } = componentStyleSet.value.$step ?? {};
-            return {
-                ...base,
-                ...(isPrevious(index) ? $completed : {}),
-                ...(isSelected(index) ? $active : {}),
-            };
+            const { $completed = {}, $active = {}, ...base } = componentStyleSet.value.$step ?? {};
+            if (isPrevious(index)) {
+                return objectUtil.assign(base, $completed);
+            }
+            if (isSelected(index)) {
+                return objectUtil.assign(base, $active);
+            }
+            return base;
         }
 
         function getLabelStyleSet(index: number): CSSProperties {
-            const { $completed, $active, ...base } = componentStyleSet.value.$label ?? {};
-            return {
-                ...base,
-                ...(isPrevious(index) ? $completed : {}),
-                ...(isSelected(index) ? $active : {}),
-            };
+            const { $completed = {}, $active = {}, ...base } = componentStyleSet.value.$label ?? {};
+            if (isPrevious(index)) {
+                return objectUtil.assign(base, $completed);
+            }
+            if (isSelected(index)) {
+                return objectUtil.assign(base, $active);
+            }
+            return base;
         }
 
         onMounted(() => {

--- a/packages/vlossom/src/components/vs-steps/__stories__/vs-steps.stories.ts
+++ b/packages/vlossom/src/components/vs-steps/__stories__/vs-steps.stories.ts
@@ -29,17 +29,24 @@ const meta: Meta<typeof VsSteps> = {
                     padding: '0.5rem',
                     width: '2.5rem',
                     height: '2.5rem',
-                },
-                $activeStep: {
-                    backgroundColor: '#1e88e5',
-                    border: '2px solid #1565c0',
+                    $completed: {
+                        backgroundColor: '#90caf9',
+                        border: '2px solid #64b5f6',
+                    },
+                    $active: {
+                        backgroundColor: '#1e88e5',
+                        border: '2px solid #1565c0',
+                    },
                 },
                 $label: {
                     color: '#666',
-                },
-                $activeLabel: {
-                    color: '#1e88e5',
-                    fontWeight: '700',
+                    $completed: {
+                        color: '#64b5f6',
+                    },
+                    $active: {
+                        color: '#1e88e5',
+                        fontWeight: '700',
+                    },
                 },
             } as const;
 
@@ -484,26 +491,32 @@ export const StyleSet: Story = {
                 borderRadius: '8px',
                 width: '3rem',
                 height: '3rem',
-            },
-            $activeStep: {
-                backgroundColor: '#e91e63',
-                border: '3px solid #c2185b',
-                borderRadius: '50%',
+                $completed: {
+                    backgroundColor: '#f48fb1',
+                    border: '3px solid #f06292',
+                    borderRadius: '50%',
+                },
+                $active: {
+                    backgroundColor: '#e91e63',
+                    border: '3px solid #c2185b',
+                    borderRadius: '50%',
+                },
             },
             $label: {
                 fontSize: '0.875rem',
                 color: '#999',
-            },
-            $activeLabel: {
-                fontSize: '1rem',
-                color: '#e91e63',
-                fontWeight: 'bold',
+                $completed: {
+                    color: '#f06292',
+                },
+                $active: {
+                    fontSize: '1rem',
+                    color: '#e91e63',
+                    fontWeight: 'bold',
+                },
             },
             $progress: {
                 backgroundColor: '#e0e0e0',
-            },
-            $activeProgress: {
-                backgroundColor: '#e91e63',
+                $active: { backgroundColor: '#e91e63' },
             },
         },
         modelValue: 1,

--- a/packages/vlossom/src/components/vs-steps/types.ts
+++ b/packages/vlossom/src/components/vs-steps/types.ts
@@ -15,10 +15,15 @@ export interface VsStepsStyleSet extends CSSProperties {
     $stepSize?: string;
 
     $steps?: CSSProperties;
-    $step?: CSSProperties;
-    $activeStep?: CSSProperties;
-    $label?: CSSProperties;
-    $activeLabel?: CSSProperties;
-    $progress?: CSSProperties;
-    $activeProgress?: CSSProperties;
+    $step?: CSSProperties & {
+        $completed?: CSSProperties;
+        $active?: CSSProperties;
+    };
+    $label?: CSSProperties & {
+        $completed?: CSSProperties;
+        $active?: CSSProperties;
+    };
+    $progress?: CSSProperties & {
+        $active?: CSSProperties;
+    };
 }

--- a/packages/vlossom/src/components/vs-switch/README.ko.md
+++ b/packages/vlossom/src/components/vs-switch/README.ko.md
@@ -94,14 +94,15 @@ async function confirmChange(from, to) {
 interface VsSwitchStyleSet extends CSSProperties {
     $handleColor?: string;
     $handleSize?: string;
-    $switchButton?: CSSProperties;
-    $activeSwitchButton?: CSSProperties;
+    $switchButton?: CSSProperties & {
+        $active?: CSSProperties;
+    };
     $wrapper?: VsInputWrapperStyleSet;
 }
 ```
 
 > [!NOTE]
-> `$wrapper`는 [`VsInputWrapperStyleSet`](../vs-input-wrapper/README.ko.md)을 사용합니다.
+> `$wrapper`는 [`VsInputWrapperStyleSet`](../vs-input-wrapper/README.ko.md)을 사용합니다. `$switchButton.$active`는 스위치가 ON 상태일 때 적용됩니다.
 
 ### StyleSet 예시
 
@@ -112,8 +113,10 @@ interface VsSwitchStyleSet extends CSSProperties {
         :style-set="{
             $handleColor: '#ffffff',
             $handleSize: '1.4rem',
-            $switchButton: { borderRadius: '0.25rem' },
-            $activeSwitchButton: { backgroundColor: '#4caf50' },
+            $switchButton: {
+                borderRadius: '0.25rem',
+                $active: { backgroundColor: '#4caf50' },
+            },
             minHeight: '2.5rem',
         }"
     />

--- a/packages/vlossom/src/components/vs-switch/README.md
+++ b/packages/vlossom/src/components/vs-switch/README.md
@@ -94,14 +94,15 @@ async function confirmChange(from, to) {
 interface VsSwitchStyleSet extends CSSProperties {
     $handleColor?: string;
     $handleSize?: string;
-    $switchButton?: CSSProperties;
-    $activeSwitchButton?: CSSProperties;
+    $switchButton?: CSSProperties & {
+        $active?: CSSProperties;
+    };
     $wrapper?: VsInputWrapperStyleSet;
 }
 ```
 
 > [!NOTE]
-> `$wrapper` uses [`VsInputWrapperStyleSet`](../vs-input-wrapper/README.md).
+> `$wrapper` uses [`VsInputWrapperStyleSet`](../vs-input-wrapper/README.md). The `$switchButton.$active` style is applied when the switch is ON.
 
 ### StyleSet Example
 
@@ -112,8 +113,10 @@ interface VsSwitchStyleSet extends CSSProperties {
         :style-set="{
             $handleColor: '#ffffff',
             $handleSize: '1.4rem',
-            $switchButton: { borderRadius: '0.25rem' },
-            $activeSwitchButton: { backgroundColor: '#4caf50' },
+            $switchButton: {
+                borderRadius: '0.25rem',
+                $active: { backgroundColor: '#4caf50' },
+            },
             minHeight: '2.5rem',
         }"
     />

--- a/packages/vlossom/src/components/vs-switch/VsSwitch.vue
+++ b/packages/vlossom/src/components/vs-switch/VsSwitch.vue
@@ -229,9 +229,10 @@ export default defineComponent({
         }
 
         function getSwitchButtonStyle(): CSSProperties {
+            const { $active, ...base } = componentStyleSet.value.$switchButton ?? {};
             return {
-                ...componentStyleSet.value.$switchButton,
-                ...(isChecked.value ? componentStyleSet.value.$activeSwitchButton : {}),
+                ...base,
+                ...(isChecked.value ? $active : {}),
             };
         }
 

--- a/packages/vlossom/src/components/vs-switch/VsSwitch.vue
+++ b/packages/vlossom/src/components/vs-switch/VsSwitch.vue
@@ -65,6 +65,7 @@ import {
     type TemplateRef,
 } from 'vue';
 import { VsComponent } from '@/declaration';
+import { objectUtil } from '@/utils';
 import { getColorSchemeProps, getInputProps, getResponsiveProps, getStyleSetProps } from '@/props';
 import { useColorScheme, useInput, useStateClass, useStyleSet, useValueMatcher } from '@/composables';
 import type { VsSwitchStyleSet } from './types';
@@ -229,11 +230,8 @@ export default defineComponent({
         }
 
         function getSwitchButtonStyle(): CSSProperties {
-            const { $active, ...base } = componentStyleSet.value.$switchButton ?? {};
-            return {
-                ...base,
-                ...(isChecked.value ? $active : {}),
-            };
+            const { $active = {}, ...base } = componentStyleSet.value.$switchButton ?? {};
+            return objectUtil.assign(base, isChecked.value ? $active : {});
         }
 
         return {

--- a/packages/vlossom/src/components/vs-switch/types.ts
+++ b/packages/vlossom/src/components/vs-switch/types.ts
@@ -16,7 +16,8 @@ export interface VsSwitchRef extends ComponentPublicInstance<typeof VsSwitch>, F
 export interface VsSwitchStyleSet extends CSSProperties {
     $handleColor?: string;
     $handleSize?: string;
-    $switchButton?: CSSProperties;
-    $activeSwitchButton?: CSSProperties;
+    $switchButton?: CSSProperties & {
+        $active?: CSSProperties;
+    };
     $wrapper?: VsInputWrapperStyleSet;
 }

--- a/packages/vlossom/src/components/vs-table/README.ko.md
+++ b/packages/vlossom/src/components/vs-table/README.ko.md
@@ -138,8 +138,9 @@ interface VsTableStyleSet extends CSSProperties {
     $toolbar?: CSSProperties;
     $search?: VsSearchInputStyleSet;
     $header?: CSSProperties;
-    $row?: CSSProperties;
-    $selectedRow?: CSSProperties;
+    $row?: CSSProperties & {
+        $selected?: CSSProperties;
+    };
     $cell?: CSSProperties;
 }
 
@@ -178,8 +179,10 @@ interface VsTablePaginationOptions {
         :style-set="{
             borderRadius: '0.5rem', overflow: 'hidden',
             $header: { fontSize: '0.875rem', fontWeight: 700 },
-            $row: { height: '3rem' },
-            $selectedRow: { backgroundColor: '#e3f2fd' },
+            $row: {
+                height: '3rem',
+                $selected: { backgroundColor: '#e3f2fd' },
+            },
             $cell: { padding: '0.5rem 1rem' },
         }"
     />

--- a/packages/vlossom/src/components/vs-table/README.md
+++ b/packages/vlossom/src/components/vs-table/README.md
@@ -138,8 +138,9 @@ interface VsTableStyleSet extends CSSProperties {
     $toolbar?: CSSProperties;
     $search?: VsSearchInputStyleSet;
     $header?: CSSProperties;
-    $row?: CSSProperties;
-    $selectedRow?: CSSProperties;
+    $row?: CSSProperties & {
+        $selected?: CSSProperties;
+    };
     $cell?: CSSProperties;
 }
 
@@ -178,8 +179,10 @@ interface VsTablePaginationOptions {
         :style-set="{
             borderRadius: '0.5rem', overflow: 'hidden',
             $header: { fontSize: '0.875rem', fontWeight: 700 },
-            $row: { height: '3rem' },
-            $selectedRow: { backgroundColor: '#e3f2fd' },
+            $row: {
+                height: '3rem',
+                $selected: { backgroundColor: '#e3f2fd' },
+            },
             $cell: { padding: '0.5rem 1rem' },
         }"
     />

--- a/packages/vlossom/src/components/vs-table/VsTableBodyRow.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableBodyRow.vue
@@ -137,15 +137,16 @@ export default defineComponent({
             };
         });
         const rowStyle = computed<CSSProperties | undefined>(() => {
+            const { $selected, ...baseRow } = tableStyleSet?.value?.$row ?? {};
             if (isSelected.value) {
                 return {
-                    ...tableStyleSet?.value?.$row,
-                    ...tableStyleSet?.value?.$selectedRow,
+                    ...baseRow,
+                    ...$selected,
                     ...gridStyle.value,
                 };
             }
             return {
-                ...tableStyleSet?.value?.$row,
+                ...baseRow,
                 ...gridStyle.value,
             };
         });

--- a/packages/vlossom/src/components/vs-table/VsTableBodyRow.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableBodyRow.vue
@@ -43,7 +43,7 @@
 
 <script lang="ts">
 import { defineComponent, inject, computed, type ComputedRef, type PropType, toRefs, type CSSProperties } from 'vue';
-import { stringUtil } from '@/utils';
+import { objectUtil, stringUtil } from '@/utils';
 import { useStateClass } from '@/composables';
 import type { ColorScheme, UIState } from '@/declaration';
 import type { VsSkeletonStyleSet } from './../vs-skeleton/types';
@@ -137,18 +137,9 @@ export default defineComponent({
             };
         });
         const rowStyle = computed<CSSProperties | undefined>(() => {
-            const { $selected, ...baseRow } = tableStyleSet?.value?.$row ?? {};
-            if (isSelected.value) {
-                return {
-                    ...baseRow,
-                    ...$selected,
-                    ...gridStyle.value,
-                };
-            }
-            return {
-                ...baseRow,
-                ...gridStyle.value,
-            };
+            const { $selected = {}, ...baseRow } = tableStyleSet?.value?.$row ?? {};
+            const statedRowStyle = isSelected.value ? objectUtil.assign(baseRow, $selected) : baseRow;
+            return objectUtil.assign(statedRowStyle, gridStyle.value ?? {});
         });
         const skeletonStyleSet = computed<VsSkeletonStyleSet>(() => ({
             height: '100%',

--- a/packages/vlossom/src/components/vs-table/VsTableHeader.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableHeader.vue
@@ -42,7 +42,7 @@
 
 <script lang="ts">
 import { defineComponent, inject, computed, type ComputedRef, type CSSProperties } from 'vue';
-import { stringUtil } from '@/utils';
+import { objectUtil, stringUtil } from '@/utils';
 import {
     VsTableSortType,
     TABLE_STYLE_SET_TOKEN,
@@ -94,11 +94,8 @@ export default defineComponent({
         });
         const headerStyle = computed<CSSProperties | undefined>(() => {
             const { $selected, ...baseRow } = tableStyleSet?.value?.$row ?? {};
-            return {
-                ...baseRow,
-                ...tableStyleSet?.value?.$header,
-                ...gridStyle.value,
-            };
+            const baseRowStyle = objectUtil.assign(baseRow, tableStyleSet?.value?.$header ?? {});
+            return objectUtil.assign(baseRowStyle, gridStyle.value ?? {});
         });
 
         function getGridColumnWidth(column?: VsTableColumnDef): string {

--- a/packages/vlossom/src/components/vs-table/VsTableHeader.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableHeader.vue
@@ -92,11 +92,14 @@ export default defineComponent({
                 gridTemplateColumns: cols.join(' '),
             };
         });
-        const headerStyle = computed<CSSProperties | undefined>(() => ({
-            ...tableStyleSet?.value?.$row,
-            ...tableStyleSet?.value?.$header,
-            ...gridStyle.value,
-        }));
+        const headerStyle = computed<CSSProperties | undefined>(() => {
+            const { $selected, ...baseRow } = tableStyleSet?.value?.$row ?? {};
+            return {
+                ...baseRow,
+                ...tableStyleSet?.value?.$header,
+                ...gridStyle.value,
+            };
+        });
 
         function getGridColumnWidth(column?: VsTableColumnDef): string {
             if (!column) {

--- a/packages/vlossom/src/components/vs-table/types.ts
+++ b/packages/vlossom/src/components/vs-table/types.ts
@@ -16,8 +16,9 @@ export interface VsTableStyleSet extends CSSProperties {
     $toolbar?: CSSProperties;
     $search?: VsSearchInputStyleSet;
     $header?: CSSProperties;
-    $row?: CSSProperties;
-    $selectedRow?: CSSProperties;
+    $row?: CSSProperties & {
+        $selected?: CSSProperties;
+    };
     $cell?: CSSProperties;
 }
 

--- a/packages/vlossom/src/components/vs-tabs/README.ko.md
+++ b/packages/vlossom/src/components/vs-tabs/README.ko.md
@@ -82,14 +82,15 @@ interface VsTabsStyleSet extends CSSProperties {
     $divider?: CSSProperties['border'] & {};
 
     $tabs?: CSSProperties;
-    $tab?: CSSProperties;
-    $activeTab?: CSSProperties;
+    $tab?: CSSProperties & {
+        $active?: CSSProperties;
+    };
     $control?: Omit<VsButtonStyleSet, '$loading'>;
 }
 ```
 
 > [!NOTE]
-> `$control`은 [`VsButtonStyleSet`](../vs-button/README.ko.md)을 사용합니다(`$loading` 제외).
+> `$control`은 [`VsButtonStyleSet`](../vs-button/README.ko.md)을 사용합니다(`$loading` 제외). `$tab.$active`는 현재 선택된 탭에 적용됩니다.
 
 ### StyleSet 예시
 
@@ -101,8 +102,11 @@ interface VsTabsStyleSet extends CSSProperties {
         :style-set="{
             $gap: '0.5rem',
             $divider: '2px solid #e0e0e0',
-            $tab: { borderRadius: '0.25rem', padding: '0.5rem 1.25rem' },
-            $activeTab: { backgroundColor: '#1976d2', color: '#ffffff' },
+            $tab: {
+                borderRadius: '0.25rem',
+                padding: '0.5rem 1.25rem',
+                $active: { backgroundColor: '#1976d2', color: '#ffffff' },
+            },
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-tabs/README.md
+++ b/packages/vlossom/src/components/vs-tabs/README.md
@@ -82,14 +82,15 @@ interface VsTabsStyleSet extends CSSProperties {
     $divider?: CSSProperties['border'] & {};
 
     $tabs?: CSSProperties;
-    $tab?: CSSProperties;
-    $activeTab?: CSSProperties;
+    $tab?: CSSProperties & {
+        $active?: CSSProperties;
+    };
     $control?: Omit<VsButtonStyleSet, '$loading'>;
 }
 ```
 
 > [!NOTE]
-> `$control` uses [`VsButtonStyleSet`](../vs-button/README.md) (excluding `$loading`).
+> `$control` uses [`VsButtonStyleSet`](../vs-button/README.md) (excluding `$loading`). The `$tab.$active` style is applied to the currently selected tab.
 
 ### StyleSet Example
 
@@ -101,8 +102,11 @@ interface VsTabsStyleSet extends CSSProperties {
         :style-set="{
             $gap: '0.5rem',
             $divider: '2px solid #e0e0e0',
-            $tab: { borderRadius: '0.25rem', padding: '0.5rem 1.25rem' },
-            $activeTab: { backgroundColor: '#1976d2', color: '#ffffff' },
+            $tab: {
+                borderRadius: '0.25rem',
+                padding: '0.5rem 1.25rem',
+                $active: { backgroundColor: '#1976d2', color: '#ffffff' },
+            },
         }"
     />
 </template>

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.vue
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.vue
@@ -243,11 +243,8 @@ export default defineComponent({
         let resizeObserver: ResizeObserver | null = null;
 
         function getTabStyleSet(index: number): CSSProperties {
-            const { $active, ...base } = componentStyleSet.value.$tab ?? {};
-            return {
-                ...base,
-                ...(isSelected(index) ? $active : {}),
-            };
+            const { $active = {}, ...base } = componentStyleSet.value.$tab ?? {};
+            return isSelected(index) ? objectUtil.assign(base, $active) : base;
         }
 
         onMounted(() => {

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.vue
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.vue
@@ -20,12 +20,7 @@
 
         <div ref="tabsRef" class="vs-tabs-wrap">
             <ul role="tablist" class="vs-tab-list" :style="componentStyleSet.$tabs">
-                <li
-                    v-if="indicatorStyle"
-                    class="vs-tab-indicator"
-                    :style="{ ...indicatorStyle, ...componentStyleSet.$activeTab }"
-                    aria-hidden="true"
-                />
+                <li v-if="indicatorStyle" class="vs-tab-indicator" :style="indicatorStyle" aria-hidden="true" />
                 <li
                     v-for="(tab, index) in tabs"
                     :key="tab"
@@ -248,9 +243,10 @@ export default defineComponent({
         let resizeObserver: ResizeObserver | null = null;
 
         function getTabStyleSet(index: number): CSSProperties {
+            const { $active, ...base } = componentStyleSet.value.$tab ?? {};
             return {
-                ...componentStyleSet.value.$tab,
-                ...(isSelected(index) ? componentStyleSet.value.$activeTab : {}),
+                ...base,
+                ...(isSelected(index) ? $active : {}),
             };
         }
 

--- a/packages/vlossom/src/components/vs-tabs/__stories__/vs-tabs.stories.ts
+++ b/packages/vlossom/src/components/vs-tabs/__stories__/vs-tabs.stories.ts
@@ -483,7 +483,7 @@ export const StyleSet: Story = {
             description: {
                 story:
                     '인라인 스타일 객체를 사용한 커스텀 탭입니다.' +
-                    'styleSet prop에 $gap, $divider, $tab, $activeTab, $control을 전달하여 세밀한 커스터마이징이 가능합니다.',
+                    'styleSet prop에 $gap, $divider, $tab($active 포함), $control을 전달하여 세밀한 커스터마이징이 가능합니다.',
             },
         },
     },
@@ -493,8 +493,10 @@ export const StyleSet: Story = {
         styleSet: {
             $gap: '1rem',
             $divider: '2px solid #b968c7',
-            $tab: { fontWeight: '600' },
-            $activeTab: { backgroundColor: '#f0e6f5' },
+            $tab: {
+                fontWeight: '600',
+                $active: { backgroundColor: '#f0e6f5' },
+            },
             $control: {
                 backgroundColor: '#b968c7',
                 borderRadius: '8px',

--- a/packages/vlossom/src/components/vs-tabs/types.ts
+++ b/packages/vlossom/src/components/vs-tabs/types.ts
@@ -20,7 +20,8 @@ export interface VsTabsStyleSet extends CSSProperties {
     $divider?: CSSProperties['border'] & {};
 
     $tabs?: CSSProperties;
-    $tab?: CSSProperties;
-    $activeTab?: CSSProperties;
+    $tab?: CSSProperties & {
+        $active?: CSSProperties;
+    };
     $control?: Omit<VsButtonStyleSet, '$loading'>;
 }


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary
상태별 스타일($selected, $active, $focused, $completed)을 별도의 top-level 키 대신 해당 요소의 StyleSet 안에
   중첩한다. 각 컴포넌트의 .vue 파일에서 destructure 후 computed로 런타임 상태에 따라 병합한다.

## Description
  - VsPagination: $pageButton.$selected ($selectedButton* CSS 변수 제거)
  - VsSelect: $option.$focused, $option.$selected (top-level $focused, $selectedOption 제거)
  - VsSteps: $step.$completed/$active, $label.$completed/$active, $progress.$active
    - $progress는 트랙(.vs-step-line)에, $progress.$active는 fill에 매핑
  - VsSwitch: $switchButton.$active
  - VsTable: $row.$selected
  - VsTabs: $tab.$active (indicator에서 active 스타일을 이중 적용하지 않음)

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
