### PR TITLE
feat(vite.config): add Prettier formatting for .d.ts files

### DIFF
--- a/packages/vlossom/vite.config.ts
+++ b/packages/vlossom/vite.config.ts
@@ -4,7 +4,29 @@ import { fileURLToPath, URL } from 'node:url';
 import { writeFileSync } from 'node:fs';
 import { visualizer } from 'rollup-plugin-visualizer';
 import dts from 'vite-plugin-dts';
+import prettier from 'prettier';
 import { commonConfig } from './vite.config.common';
+
+/**
+ * @description format .d.ts files with Prettier before vite write .d.ts to disk
+ * @see {@link https://github.com/vlossom-ui/vlossom/issues/357|Issue #357}
+ */
+async function beforeWriteFile(
+    filePath: string,
+    content: string,
+): Promise<{ filePath: string; content: string } | void> {
+    if (!filePath.endsWith('.d.ts')) {
+        return;
+    }
+
+    const prettierConfig = await prettier.resolveConfig(filePath);
+    const formatted = await prettier.format(content, {
+        ...prettierConfig,
+        parser: 'typescript',
+    });
+
+    return { filePath, content: formatted };
+}
 
 export default defineConfig({
     ...commonConfig,
@@ -14,6 +36,7 @@ export default defineConfig({
             tsconfigPath: './tsconfig.app.json',
             rollupTypes: true,
             insertTypesEntry: true,
+            beforeWriteFile,
         }),
         visualizer({
             filename: 'visualizer-vlossom.html',


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary

1. `*.d.ts` 파일이 포맷팅되지 않습니다.
2. 라이브러리 사용자는 타입 정의로 이동할 때 읽기에 어려움이 있습니다. 
3. `*.d.ts` 파일이 포맷팅 되도록 수정하여 개선합니다.

## How To Test

1. use cl `pnpm build-only`

## Related Tickets & Documents
- Closes #357

