### PR TITLE
feat(VsSwitch): update switch button layout and visibility

### DIFF
--- a/packages/vlossom/src/components/vs-switch/VsSwitch.css
+++ b/packages/vlossom/src/components/vs-switch/VsSwitch.css
@@ -8,7 +8,7 @@
     min-height: var(--vs-comp-height-md);
 
     .vs-switch-button {
-        @apply relative inline-grid cursor-pointer items-center px-2.5 transition-all duration-300 select-none;
+        @apply relative inline-grid min-w-14 cursor-pointer items-center px-2.5 transition-all duration-300 select-none;
         border: 1px solid var(--vs-cs-line);
         border-radius: 1.5rem;
         background-color: var(--vs-cs-bg-area);

--- a/packages/vlossom/src/components/vs-switch/VsSwitch.css
+++ b/packages/vlossom/src/components/vs-switch/VsSwitch.css
@@ -8,7 +8,7 @@
     min-height: var(--vs-comp-height-md);
 
     .vs-switch-button {
-        @apply relative flex cursor-pointer items-center px-2.5 transition-all duration-300 select-none;
+        @apply relative inline-grid cursor-pointer items-center px-2.5 transition-all duration-300 select-none;
         border: 1px solid var(--vs-cs-line);
         border-radius: 1.5rem;
         background-color: var(--vs-cs-bg-area);
@@ -19,8 +19,16 @@
         font-size: var(--vs-font-size-sm);
 
         .vs-status-label {
-            @apply ml-1.5 block w-full pr-0 text-center break-all whitespace-nowrap select-none;
-            padding-left: calc(var(--vs-switch-handleSize, 1.2rem));
+            @apply block w-full pr-0 text-center break-all whitespace-nowrap select-none;
+            grid-row: 1;
+            grid-column: 1;
+            padding-left: calc(var(--vs-switch-handleSize, 1.5rem));
+        }
+        .vs-status-label[data-value='true'] {
+            @apply invisible;
+        }
+        .vs-status-label[data-value='false'] {
+            @apply visible;
         }
 
         &::before {
@@ -49,7 +57,13 @@
 
             .vs-status-label {
                 @apply pl-0;
-                padding-right: calc(var(--vs-switch-handleSize, 1.3rem));
+                padding-right: calc(var(--vs-switch-handleSize, 1.5rem));
+            }
+            .vs-status-label[data-value='false'] {
+                @apply invisible;
+            }
+            .vs-status-label[data-value='true'] {
+                @apply visible;
             }
         }
     }

--- a/packages/vlossom/src/components/vs-switch/VsSwitch.vue
+++ b/packages/vlossom/src/components/vs-switch/VsSwitch.vue
@@ -37,11 +37,11 @@
                 />
 
                 <div :class="['vs-switch-button', stateBoxClasses]" :style="getSwitchButtonStyle()">
-                    <span class="vs-status-label" data-value="true" v-show="isChecked">
+                    <span class="vs-status-label" data-value="true">
                         <slot name="true-label"> {{ trueLabel }} </slot>
                     </span>
 
-                    <span class="vs-status-label" data-value="false" v-show="!isChecked">
+                    <span class="vs-status-label" data-value="false">
                         <slot name="false-label"> {{ falseLabel }} </slot>
                     </span>
                 </div>

--- a/packages/vlossom/src/components/vs-switch/VsSwitch.vue
+++ b/packages/vlossom/src/components/vs-switch/VsSwitch.vue
@@ -87,9 +87,9 @@ export default defineComponent({
         },
         checked: { type: Boolean, default: false },
         multiple: { type: Boolean, default: false },
-        falseLabel: { type: String, default: 'OFF' },
+        falseLabel: { type: String, default: '' },
         falseValue: { type: null, default: false },
-        trueLabel: { type: String, default: 'ON' },
+        trueLabel: { type: String, default: '' },
         trueValue: { type: null, default: true },
         // v-model
         modelValue: { type: null, default: false },


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary

1. `VsSwitch` 컴퍼넌트의 true/false 라벨에 따라 길이 고정
2. `VsSwitch` 라벨이 없는 경우 최소 길이 보장

## Screenshots or Recordings 

<img width="227" height="128" alt="switch" src="https://github.com/user-attachments/assets/1552282f-af0c-4dd1-bd94-b67064b3d810" />

<img width="172" height="250" alt="image" src="https://github.com/user-attachments/assets/6a1e0b11-6bef-4708-bdcf-eebd635a8f2a" />


## Related Tickets & Documents

- Closes #452 #349 

