### PR TITLE
fix(vs-input): improve autofill and clear button focus styles

### DIFF
--- a/packages/vlossom/src/components/vs-input/VsInput.css
+++ b/packages/vlossom/src/components/vs-input/VsInput.css
@@ -54,7 +54,7 @@
     }
 }
 
-/* clears the 'X' */
+/* Hide browser-provided search input controls to apply clear button. */
 input[type='search']::-ms-clear,
 input[type='search']::-ms-reveal,
 input[type='search']::-webkit-search-decoration,
@@ -62,4 +62,24 @@ input[type='search']::-webkit-search-cancel-button,
 input[type='search']::-webkit-search-results-button,
 input[type='search']::-webkit-search-results-decoration {
     @apply hidden;
+}
+
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+input:-webkit-autofill:active {
+    -webkit-box-shadow: 0 0 0 1000px var(--vs-cs-bg-area) inset;
+    -webkit-text-fill-color: var(--vs-cs-font);
+    box-shadow: 0 0 0 1000px var(--vs-cs-bg-area) inset;
+    caret-color: var(--vs-cs-font);
+}
+
+input:autofill,
+input:autofill:hover,
+input:autofill:focus,
+input:autofill:active {
+    -webkit-box-shadow: 0 0 0 1000px var(--vs-cs-bg-area) inset;
+    -webkit-text-fill-color: var(--vs-cs-font);
+    box-shadow: 0 0 0 1000px var(--vs-cs-bg-area) inset;
+    caret-color: var(--vs-cs-font);
 }

--- a/packages/vlossom/src/components/vs-input/VsInput.css
+++ b/packages/vlossom/src/components/vs-input/VsInput.css
@@ -31,7 +31,8 @@
     }
 
     .vs-clear-button {
-        @apply mr-2.5 flex items-center justify-center rounded border-none opacity-0 focus-visible:outline-1;
+        @apply mr-2.5 flex items-center justify-center rounded border-none opacity-0;
+
         transition: opacity 0.4s;
 
         background: none;
@@ -39,6 +40,10 @@
 
         &:focus {
             @apply cursor-pointer opacity-100;
+        }
+
+        &:focus-visible {
+            outline: 2px solid var(--vs-cs-font);
         }
     }
 

--- a/packages/vlossom/src/components/vs-input/VsInput.css
+++ b/packages/vlossom/src/components/vs-input/VsInput.css
@@ -68,9 +68,9 @@ input:-webkit-autofill,
 input:-webkit-autofill:hover,
 input:-webkit-autofill:focus,
 input:-webkit-autofill:active {
-    -webkit-box-shadow: 0 0 0 1000px var(--vs-cs-bg-area) inset;
+    -webkit-box-shadow: 0 0 0 1000px var(--vs-no-color) inset;
     -webkit-text-fill-color: var(--vs-cs-font);
-    box-shadow: 0 0 0 1000px var(--vs-cs-bg-area) inset;
+    box-shadow: 0 0 0 1000px var(--vs-no-color) inset;
     caret-color: var(--vs-cs-font);
 }
 
@@ -78,8 +78,8 @@ input:autofill,
 input:autofill:hover,
 input:autofill:focus,
 input:autofill:active {
-    -webkit-box-shadow: 0 0 0 1000px var(--vs-cs-bg-area) inset;
+    -webkit-box-shadow: 0 0 0 1000px var(--vs-no-color) inset;
     -webkit-text-fill-color: var(--vs-cs-font);
-    box-shadow: 0 0 0 1000px var(--vs-cs-bg-area) inset;
+    box-shadow: 0 0 0 1000px var(--vs-no-color) inset;
     caret-color: var(--vs-cs-font);
 }


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Fix Bug (fix)
- [x] Style (style)

## Summary

<img width="507" height="295" alt="vs-input-color-fixed" src="https://github.com/user-attachments/assets/5364ee07-60ff-4d70-be54-f2e6bd7679ca" />

<img width="783" height="187" alt="image" src="https://github.com/user-attachments/assets/29c06619-91bb-42bd-a75c-048b7d97ac79" />

VsInput의 autofill 상태와 clear button 포커스 스타일을 color scheme 기준에 맞게 개선합니다.

## Description

- 브라우저 autofill 적용 시 기본 배경색이 노출되지 않도록 autofill 배경을 `var(--vs-no-color)`로 덮어씁니다.
- autofill 상태에서도 입력 텍스트와 입력 커서 색상이 현재 color scheme에 맞게 표시됩니다.
- clear button의 `focus-visible` outline을 명시해 키보드 포커스 상태를 더 잘 인지할 수 있도록 개선합니다.
- search input의 기본 브라우저 컨트롤을 숨기는 주석의 내용을 보강합니다.

**특이사항**

<img width="437" height="295" alt="vs-input-color" src="https://github.com/user-attachments/assets/9bdca504-f2ce-4c83-a9d2-0f7c68b75cf2" />

위와 같이 자동 완성을 적용할 경우 **간헐적으로** input 내의 텍스트 폰트의 색상이 검은색으로 바뀌는 이슈가 있습니다. 색상 변경이 개발자 도구 상에서도 감지되지 않아, 브라우저 자체의 문제인 것으로 추측됩니다. 따라서 문제 해결에 어려움이 있어 해당 이슈는 known-issue로 둘 예정입니다.

## Related Tickets & Documents

- Related Issue #332
- Closes #332