### PR TITLE
feat(list-index-selector): change index select spec

### DIFF
--- a/packages/vlossom/.gitignore
+++ b/packages/vlossom/.gitignore
@@ -31,3 +31,4 @@ coverage
 visualizer*
 *storybook.log
 storybook-static
+.playwright-mcp

--- a/packages/vlossom/playground/Sandbox.vue
+++ b/packages/vlossom/playground/Sandbox.vue
@@ -1,147 +1,18 @@
 <template>
     <vs-page class="mb-8" :style-set="{ padding: '0' }">
-        <div class="sandbox flex flex-col gap-8 p-6">
-            <h1 class="text-2xl font-bold">useIndexSelector behavior matrix</h1>
-            <p class="text-sm text-gray-500">
-                Out-of-range → selectedIndex가 -1 (선택 없음). Disabled → 현재 선택은 유지되고 새 선택은 무시됨 (no-op).
-            </p>
-
-            <!-- VsPagination -->
-            <section class="flex flex-col gap-3">
-                <h2 class="text-xl font-semibold">VsPagination</h2>
-
-                <div class="flex flex-col gap-1">
-                    <h3 class="font-medium">1. 정상</h3>
-                    <vs-pagination v-model="pagPage" :length="5" />
-                    <div class="text-sm text-gray-600">v-model page: {{ pagPage }}</div>
-                </div>
-
-                <div class="flex flex-col gap-1">
-                    <h3 class="font-medium">2. Out-of-range (length=5, modelValue=10)</h3>
-                    <vs-pagination v-model="pagOorPage" :length="5" />
-                    <div class="text-sm text-gray-600">v-model page: {{ pagOorPage }} (→ -1 = 선택 없음)</div>
-                </div>
-
-                <div class="flex flex-col gap-1">
-                    <h3 class="font-medium">3. Disabled=true (page=2 유지, 클릭 no-op)</h3>
-                    <vs-pagination v-model="pagDisabledPage" :length="5" disabled />
-                    <div class="text-sm text-gray-600">v-model page: {{ pagDisabledPage }} (클릭해도 변경 안 됨)</div>
-                </div>
-            </section>
-
-            <!-- VsTabs -->
-            <section class="flex flex-col gap-3">
-                <h2 class="text-xl font-semibold">VsTabs</h2>
-
-                <div class="flex flex-col gap-1">
-                    <h3 class="font-medium">1. 정상</h3>
-                    <vs-tabs v-model="tabsIndex" :tabs="tabs" />
-                    <div class="text-sm text-gray-600">v-model index: {{ tabsIndex }}</div>
-                </div>
-
-                <div class="flex flex-col gap-1">
-                    <h3 class="font-medium">2. Out-of-range (3 tabs, modelValue=10)</h3>
-                    <vs-tabs v-model="tabsOorIndex" :tabs="tabs" />
-                    <div class="text-sm text-gray-600">v-model index: {{ tabsOorIndex }} (→ -1 = 선택 없음)</div>
-                </div>
-
-                <div class="flex flex-col gap-1">
-                    <h3 class="font-medium">3. Per-item disabled (Tab 2 비활성, 클릭 no-op)</h3>
-                    <vs-tabs v-model="tabsPerDisabledIndex" :tabs="tabs" :disabled="disableSecond" />
-                    <div class="text-sm text-gray-600">
-                        v-model index: {{ tabsPerDisabledIndex }} (Tab 2 클릭 시 현재 선택 유지)
-                    </div>
-                </div>
-
-                <div class="flex flex-col gap-1">
-                    <h3 class="font-medium">4. Disabled=true (전체 비활성, modelValue=1 유지)</h3>
-                    <vs-tabs v-model="tabsAllDisabledIndex" :tabs="tabs" disabled />
-                    <div class="text-sm text-gray-600">
-                        v-model index: {{ tabsAllDisabledIndex }} (Tab 2 선택 유지, 클릭 no-op)
-                    </div>
-                </div>
-            </section>
-
-            <!-- VsSteps -->
-            <section class="flex flex-col gap-3">
-                <h2 class="text-xl font-semibold">VsSteps</h2>
-
-                <div class="flex flex-col gap-1">
-                    <h3 class="font-medium">1. 정상</h3>
-                    <vs-steps v-model="stepsIndex" :steps="steps" />
-                    <div class="text-sm text-gray-600">v-model index: {{ stepsIndex }}</div>
-                </div>
-
-                <div class="flex flex-col gap-1">
-                    <h3 class="font-medium">2. Out-of-range (3 steps, modelValue=10)</h3>
-                    <vs-steps v-model="stepsOorIndex" :steps="steps" />
-                    <div class="text-sm text-gray-600">v-model index: {{ stepsOorIndex }} (→ -1 = 선택 없음)</div>
-                </div>
-
-                <div class="flex flex-col gap-1">
-                    <h3 class="font-medium">3. Per-item disabled (Step 2 비활성, 클릭 no-op)</h3>
-                    <vs-steps v-model="stepsPerDisabledIndex" :steps="steps" :disabled="disableSecond" />
-                    <div class="text-sm text-gray-600">
-                        v-model index: {{ stepsPerDisabledIndex }} (Step 2 클릭 시 현재 선택 유지)
-                    </div>
-                </div>
-
-                <div class="flex flex-col gap-1">
-                    <h3 class="font-medium">4. Disabled=true (전체 비활성, modelValue=1 유지)</h3>
-                    <vs-steps v-model="stepsAllDisabledIndex" :steps="steps" disabled />
-                    <div class="text-sm text-gray-600">
-                        v-model index: {{ stepsAllDisabledIndex }} (Step 2 선택 유지, 클릭 no-op)
-                    </div>
-                </div>
-            </section>
+        <div class="sandbox">
+            <h1>Sandbox</h1>
         </div>
     </vs-page>
 </template>
 
 <script lang="ts">
-import { defineComponent, ref } from 'vue';
+import { defineComponent } from 'vue';
 
 export default defineComponent({
     name: 'Sandbox',
     setup() {
-        const tabs = ['Tab 1', 'Tab 2', 'Tab 3'];
-        const steps = ['Step 1', 'Step 2', 'Step 3'];
-
-        // VsPagination
-        const pagPage = ref(2);
-        const pagOorPage = ref(10);
-        const pagDisabledPage = ref(2);
-
-        // VsTabs
-        const tabsIndex = ref(0);
-        const tabsOorIndex = ref(10);
-        const tabsPerDisabledIndex = ref(0);
-        const tabsAllDisabledIndex = ref(1);
-
-        // VsSteps
-        const stepsIndex = ref(0);
-        const stepsOorIndex = ref(10);
-        const stepsPerDisabledIndex = ref(0);
-        const stepsAllDisabledIndex = ref(1);
-
-        const disableSecond = (_item: string, index: number) => index === 1;
-
-        return {
-            tabs,
-            steps,
-            pagPage,
-            pagOorPage,
-            pagDisabledPage,
-            tabsIndex,
-            tabsOorIndex,
-            tabsPerDisabledIndex,
-            tabsAllDisabledIndex,
-            stepsIndex,
-            stepsOorIndex,
-            stepsPerDisabledIndex,
-            stepsAllDisabledIndex,
-            disableSecond,
-        };
+        return {};
     },
 });
 </script>

--- a/packages/vlossom/playground/Sandbox.vue
+++ b/packages/vlossom/playground/Sandbox.vue
@@ -1,18 +1,147 @@
 <template>
     <vs-page class="mb-8" :style-set="{ padding: '0' }">
-        <div class="sandbox">
-            <h1>Sandbox</h1>
+        <div class="sandbox flex flex-col gap-8 p-6">
+            <h1 class="text-2xl font-bold">useIndexSelector behavior matrix</h1>
+            <p class="text-sm text-gray-500">
+                Out-of-range → selectedIndex가 -1 (선택 없음). Disabled → 현재 선택은 유지되고 새 선택은 무시됨 (no-op).
+            </p>
+
+            <!-- VsPagination -->
+            <section class="flex flex-col gap-3">
+                <h2 class="text-xl font-semibold">VsPagination</h2>
+
+                <div class="flex flex-col gap-1">
+                    <h3 class="font-medium">1. 정상</h3>
+                    <vs-pagination v-model="pagPage" :length="5" />
+                    <div class="text-sm text-gray-600">v-model page: {{ pagPage }}</div>
+                </div>
+
+                <div class="flex flex-col gap-1">
+                    <h3 class="font-medium">2. Out-of-range (length=5, modelValue=10)</h3>
+                    <vs-pagination v-model="pagOorPage" :length="5" />
+                    <div class="text-sm text-gray-600">v-model page: {{ pagOorPage }} (→ -1 = 선택 없음)</div>
+                </div>
+
+                <div class="flex flex-col gap-1">
+                    <h3 class="font-medium">3. Disabled=true (page=2 유지, 클릭 no-op)</h3>
+                    <vs-pagination v-model="pagDisabledPage" :length="5" disabled />
+                    <div class="text-sm text-gray-600">v-model page: {{ pagDisabledPage }} (클릭해도 변경 안 됨)</div>
+                </div>
+            </section>
+
+            <!-- VsTabs -->
+            <section class="flex flex-col gap-3">
+                <h2 class="text-xl font-semibold">VsTabs</h2>
+
+                <div class="flex flex-col gap-1">
+                    <h3 class="font-medium">1. 정상</h3>
+                    <vs-tabs v-model="tabsIndex" :tabs="tabs" />
+                    <div class="text-sm text-gray-600">v-model index: {{ tabsIndex }}</div>
+                </div>
+
+                <div class="flex flex-col gap-1">
+                    <h3 class="font-medium">2. Out-of-range (3 tabs, modelValue=10)</h3>
+                    <vs-tabs v-model="tabsOorIndex" :tabs="tabs" />
+                    <div class="text-sm text-gray-600">v-model index: {{ tabsOorIndex }} (→ -1 = 선택 없음)</div>
+                </div>
+
+                <div class="flex flex-col gap-1">
+                    <h3 class="font-medium">3. Per-item disabled (Tab 2 비활성, 클릭 no-op)</h3>
+                    <vs-tabs v-model="tabsPerDisabledIndex" :tabs="tabs" :disabled="disableSecond" />
+                    <div class="text-sm text-gray-600">
+                        v-model index: {{ tabsPerDisabledIndex }} (Tab 2 클릭 시 현재 선택 유지)
+                    </div>
+                </div>
+
+                <div class="flex flex-col gap-1">
+                    <h3 class="font-medium">4. Disabled=true (전체 비활성, modelValue=1 유지)</h3>
+                    <vs-tabs v-model="tabsAllDisabledIndex" :tabs="tabs" disabled />
+                    <div class="text-sm text-gray-600">
+                        v-model index: {{ tabsAllDisabledIndex }} (Tab 2 선택 유지, 클릭 no-op)
+                    </div>
+                </div>
+            </section>
+
+            <!-- VsSteps -->
+            <section class="flex flex-col gap-3">
+                <h2 class="text-xl font-semibold">VsSteps</h2>
+
+                <div class="flex flex-col gap-1">
+                    <h3 class="font-medium">1. 정상</h3>
+                    <vs-steps v-model="stepsIndex" :steps="steps" />
+                    <div class="text-sm text-gray-600">v-model index: {{ stepsIndex }}</div>
+                </div>
+
+                <div class="flex flex-col gap-1">
+                    <h3 class="font-medium">2. Out-of-range (3 steps, modelValue=10)</h3>
+                    <vs-steps v-model="stepsOorIndex" :steps="steps" />
+                    <div class="text-sm text-gray-600">v-model index: {{ stepsOorIndex }} (→ -1 = 선택 없음)</div>
+                </div>
+
+                <div class="flex flex-col gap-1">
+                    <h3 class="font-medium">3. Per-item disabled (Step 2 비활성, 클릭 no-op)</h3>
+                    <vs-steps v-model="stepsPerDisabledIndex" :steps="steps" :disabled="disableSecond" />
+                    <div class="text-sm text-gray-600">
+                        v-model index: {{ stepsPerDisabledIndex }} (Step 2 클릭 시 현재 선택 유지)
+                    </div>
+                </div>
+
+                <div class="flex flex-col gap-1">
+                    <h3 class="font-medium">4. Disabled=true (전체 비활성, modelValue=1 유지)</h3>
+                    <vs-steps v-model="stepsAllDisabledIndex" :steps="steps" disabled />
+                    <div class="text-sm text-gray-600">
+                        v-model index: {{ stepsAllDisabledIndex }} (Step 2 선택 유지, 클릭 no-op)
+                    </div>
+                </div>
+            </section>
         </div>
     </vs-page>
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { defineComponent, ref } from 'vue';
 
 export default defineComponent({
     name: 'Sandbox',
     setup() {
-        return {};
+        const tabs = ['Tab 1', 'Tab 2', 'Tab 3'];
+        const steps = ['Step 1', 'Step 2', 'Step 3'];
+
+        // VsPagination
+        const pagPage = ref(2);
+        const pagOorPage = ref(10);
+        const pagDisabledPage = ref(2);
+
+        // VsTabs
+        const tabsIndex = ref(0);
+        const tabsOorIndex = ref(10);
+        const tabsPerDisabledIndex = ref(0);
+        const tabsAllDisabledIndex = ref(1);
+
+        // VsSteps
+        const stepsIndex = ref(0);
+        const stepsOorIndex = ref(10);
+        const stepsPerDisabledIndex = ref(0);
+        const stepsAllDisabledIndex = ref(1);
+
+        const disableSecond = (_item: string, index: number) => index === 1;
+
+        return {
+            tabs,
+            steps,
+            pagPage,
+            pagOorPage,
+            pagDisabledPage,
+            tabsIndex,
+            tabsOorIndex,
+            tabsPerDisabledIndex,
+            tabsAllDisabledIndex,
+            stepsIndex,
+            stepsOorIndex,
+            stepsPerDisabledIndex,
+            stepsAllDisabledIndex,
+            disableSecond,
+        };
     },
 });
 </script>

--- a/packages/vlossom/src/components/vs-pagination/VsPagination.vue
+++ b/packages/vlossom/src/components/vs-pagination/VsPagination.vue
@@ -90,7 +90,7 @@
 
 <script lang="ts">
 import { type ComputedRef, computed, defineComponent, toRefs, watch } from 'vue';
-import { NOT_SELECTED, VsComponent } from '@/declaration';
+import { VsComponent } from '@/declaration';
 import { useColorScheme, useStyleSet, useIndexSelector } from '@/composables';
 import { getColorSchemeProps, getStyleSetProps } from '@/props';
 import { logUtil, objectUtil } from '@/utils';
@@ -155,7 +155,10 @@ export default defineComponent({
 
         const pageIndexList = computed(() => Array.from({ length: length.value }, (_, i) => i));
 
-        const { selectedIndex, selectIndex, isFirstEdge, isLastEdge } = useIndexSelector(pageIndexList, disabled);
+        const { selectedIndex, selectIndex, syncIndex, isFirstEdge, isLastEdge } = useIndexSelector(
+            pageIndexList,
+            disabled,
+        );
 
         const pages: ComputedRef<number[]> = computed(() => {
             const pageArr: number[] = [];
@@ -218,26 +221,11 @@ export default defineComponent({
             selectIndex(selectedIndex.value + 1);
         }
 
-        watch(
-            modelValue,
-            (value) => {
-                if (value < 0 || value >= length.value) {
-                    selectedIndex.value = NOT_SELECTED;
-                } else {
-                    selectedIndex.value = value;
-                }
-            },
-            { immediate: true },
-        );
+        watch(modelValue, syncIndex, { immediate: true });
 
         watch(selectedIndex, (index: number) => {
             emit('update:modelValue', index);
             emit('change', index);
-        });
-
-        watch(length, () => {
-            const currentIndex = selectedIndex.value;
-            selectIndex(currentIndex);
         });
 
         return {

--- a/packages/vlossom/src/components/vs-pagination/VsPagination.vue
+++ b/packages/vlossom/src/components/vs-pagination/VsPagination.vue
@@ -90,7 +90,7 @@
 
 <script lang="ts">
 import { type ComputedRef, computed, defineComponent, toRefs, watch } from 'vue';
-import { VsComponent } from '@/declaration';
+import { NOT_SELECTED, VsComponent } from '@/declaration';
 import { useColorScheme, useStyleSet, useIndexSelector } from '@/composables';
 import { getColorSchemeProps, getStyleSetProps } from '@/props';
 import { logUtil, objectUtil } from '@/utils';
@@ -221,7 +221,11 @@ export default defineComponent({
         watch(
             modelValue,
             (value) => {
-                selectIndex(value);
+                if (value < 0 || value >= length.value) {
+                    selectedIndex.value = NOT_SELECTED;
+                } else {
+                    selectedIndex.value = value;
+                }
             },
             { immediate: true },
         );

--- a/packages/vlossom/src/components/vs-pagination/__tests__/vs-pagination.test.ts
+++ b/packages/vlossom/src/components/vs-pagination/__tests__/vs-pagination.test.ts
@@ -175,6 +175,27 @@ describe('VsPagination', () => {
                 expect(btn.attributes('disabled')).toBeDefined();
             });
         });
+
+        it('페이지 변경 직후 disabled가 true로 토글돼도 modelValue를 NOT_SELECTED로 재emit하지 않아야 한다', async () => {
+            // given
+            const wrapper = mount(VsPagination, {
+                props: {
+                    length: 5,
+                    modelValue: 0,
+                    disabled: false,
+                },
+            });
+
+            // when: 페이지 변경 → 부모가 modelValue=2 반영, 동시에 disabled=true로 토글 (로딩 시작 시나리오)
+            await wrapper.findAll('.vs-page-button')[2].trigger('click');
+            await wrapper.setProps({ modelValue: 2, disabled: true });
+
+            // then: change 이벤트는 정상 paginate(2) 한 번만 발생해야 한다 (NOT_SELECTED=-1 재emit 없음)
+            const changeEvents = wrapper.emitted('change') as number[][] | undefined;
+            expect(changeEvents).toBeTruthy();
+            expect(changeEvents!.every(([index]) => index >= 0)).toBe(true);
+            expect(changeEvents![changeEvents!.length - 1]).toEqual([2]);
+        });
     });
 
     describe('페이지 변경', () => {

--- a/packages/vlossom/src/components/vs-pagination/__tests__/vs-pagination.test.ts
+++ b/packages/vlossom/src/components/vs-pagination/__tests__/vs-pagination.test.ts
@@ -176,7 +176,7 @@ describe('VsPagination', () => {
             });
         });
 
-        it('페이지 변경 직후 disabled가 true로 토글돼도 modelValue를 NOT_SELECTED로 재emit하지 않아야 한다', async () => {
+        it('페이지 변경 직후 disabled 상태가 되더라도 modelValue를 NOT_SELECTED로 재emit하지 않아야 한다 (index 유지)', async () => {
             // given
             const wrapper = mount(VsPagination, {
                 props: {
@@ -195,6 +195,8 @@ describe('VsPagination', () => {
             expect(changeEvents).toBeTruthy();
             expect(changeEvents!.every(([index]) => index >= 0)).toBe(true);
             expect(changeEvents![changeEvents!.length - 1]).toEqual([2]);
+
+            expect(wrapper.vm.selectedIndex).toBe(2);
         });
     });
 

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -149,9 +149,7 @@ import {
 import { objectUtil } from '@/utils';
 import type { VsSelectStyleSet, VsSelectTriggerRef } from './types';
 import { useSelectRules } from './vs-select-rules';
-import { useSelectValue } from './composables/select-value-composable';
-import { useSelectSearch } from './composables/select-search-composable';
-import { useSelectKeyboard } from './composables/select-keyboard-composable';
+import { useSelectValue, useSelectSearch, useSelectKeyboard } from './composables';
 
 import type { VsSearchInputRef } from '@/components/vs-search-input/types';
 import type { VsGroupedListRef } from '@/components/vs-grouped-list/types';

--- a/packages/vlossom/src/components/vs-select/composables/index.ts
+++ b/packages/vlossom/src/components/vs-select/composables/index.ts
@@ -1,0 +1,3 @@
+export * from './select-keyboard-composable';
+export * from './select-search-composable';
+export * from './select-value-composable';

--- a/packages/vlossom/src/components/vs-steps/VsSteps.vue
+++ b/packages/vlossom/src/components/vs-steps/VsSteps.vue
@@ -129,8 +129,8 @@ export default defineComponent({
             isSelected,
             isDisabled,
             isPrevious,
-            findActiveIndexForwardFrom,
             selectIndex: selectStep,
+            syncIndex,
             handleKeydown,
         } = useIndexSelector(steps, disabled);
 
@@ -174,27 +174,13 @@ export default defineComponent({
             return base;
         }
 
-        watch(steps, () => {
-            selectedIndex.value = steps.value.length > 0 ? 0 : NOT_SELECTED;
-        });
-
         watch(selectedIndex, (index: number) => {
             stepRefs.value[index]?.focus();
             emit('update:modelValue', index);
             emit('change', index);
         });
 
-        watch(
-            modelValue,
-            (value) => {
-                if (value < 0 || value >= steps.value.length) {
-                    selectedIndex.value = NOT_SELECTED;
-                } else {
-                    selectedIndex.value = value;
-                }
-            },
-            { immediate: true },
-        );
+        watch(modelValue, syncIndex, { immediate: true });
 
         return {
             // Style

--- a/packages/vlossom/src/components/vs-steps/VsSteps.vue
+++ b/packages/vlossom/src/components/vs-steps/VsSteps.vue
@@ -66,7 +66,6 @@ import {
     toRefs,
     ref,
     watch,
-    onMounted,
     type Ref,
     type PropType,
     type ComputedRef,
@@ -175,12 +174,8 @@ export default defineComponent({
             return base;
         }
 
-        onMounted(() => {
-            selectedIndex.value = findActiveIndexForwardFrom(modelValue.value);
-        });
-
         watch(steps, () => {
-            selectStep(findActiveIndexForwardFrom(0));
+            selectedIndex.value = steps.value.length > 0 ? 0 : NOT_SELECTED;
         });
 
         watch(selectedIndex, (index: number) => {
@@ -189,7 +184,17 @@ export default defineComponent({
             emit('change', index);
         });
 
-        watch(modelValue, selectStep);
+        watch(
+            modelValue,
+            (value) => {
+                if (value < 0 || value >= steps.value.length) {
+                    selectedIndex.value = NOT_SELECTED;
+                } else {
+                    selectedIndex.value = value;
+                }
+            },
+            { immediate: true },
+        );
 
         return {
             // Style

--- a/packages/vlossom/src/components/vs-steps/__tests__/vs-steps.test.ts
+++ b/packages/vlossom/src/components/vs-steps/__tests__/vs-steps.test.ts
@@ -279,7 +279,7 @@ describe('VsSteps', () => {
             expect(wrapper.emitted('change')).toBeFalsy();
         });
 
-        it('전체 비활성화된 상태로 마운트되어도 modelValue가 유지되고 클릭으로 변경되지 않아야 한다', async () => {
+        it('전체 비활성화된 상태로 마운트되어도 modelValue가 유지된다', async () => {
             // given
             const wrapper = mount(VsSteps, {
                 props: {
@@ -290,17 +290,9 @@ describe('VsSteps', () => {
             });
             await nextTick();
 
-            // then: 마운트 시 modelValue(=1)가 보존되어 -1로 자동 변경되지 않는다
-            const initialEmits = (wrapper.emitted('update:modelValue') ?? []).map((e) => e[0]);
-            expect(initialEmits).not.toContain(-1);
-
-            // when
-            const stepItems = wrapper.findAll('.vs-step-item');
-            await stepItems[0].trigger('click');
-
-            // then: 클릭으로 인한 추가 emit이 없어야 한다
-            const finalEmits = (wrapper.emitted('update:modelValue') ?? []).map((e) => e[0]);
-            expect(finalEmits.length).toBe(initialEmits.length);
+            // then
+            expect(wrapper.vm.selectedIndex).toBe(1);
+            expect(wrapper.vm.selectedIndex).not.toBe(-1);
         });
     });
 
@@ -346,8 +338,8 @@ describe('VsSteps', () => {
                     disabled: (step: string, index: number) => index === 3,
                 },
                 slots: {
-                    step: `<span class="custom-step" 
-                        :data-selected="isSelected" 
+                    step: `<span class="custom-step"
+                        :data-selected="isSelected"
                         :data-previous="isPrevious"
                         :data-disabled="isDisabled">
                         {{ index }}
@@ -381,7 +373,7 @@ describe('VsSteps', () => {
                     disabled: (step: string, index: number) => index === 2,
                 },
                 slots: {
-                    label: `<span class="custom-label" 
+                    label: `<span class="custom-label"
                         :data-selected="isSelected"
                         :data-previous="isPrevious"
                         :data-disabled="isDisabled">

--- a/packages/vlossom/src/components/vs-steps/__tests__/vs-steps.test.ts
+++ b/packages/vlossom/src/components/vs-steps/__tests__/vs-steps.test.ts
@@ -261,7 +261,7 @@ describe('VsSteps', () => {
             expect(wrapper.emitted('change')?.[0]).toEqual([2]);
         });
 
-        it('함수를 통해 비활성화된 스텝을 클릭하면 NOT_SELECTED(-1)로 이벤트가 발생해야 한다', async () => {
+        it('함수를 통해 비활성화된 스텝을 클릭하면 이벤트가 발생하지 않고 현재 선택이 유지되어야 한다', async () => {
             // given
             const wrapper = mount(VsSteps, {
                 props: {
@@ -275,30 +275,32 @@ describe('VsSteps', () => {
             await stepItems[1].trigger('click');
 
             // then
-            expect(wrapper.emitted('update:modelValue')).toBeTruthy();
-            expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([-1]);
-            expect(wrapper.emitted('change')).toBeTruthy();
-            expect(wrapper.emitted('change')?.[0]).toEqual([-1]);
+            expect(wrapper.emitted('update:modelValue')).toBeFalsy();
+            expect(wrapper.emitted('change')).toBeFalsy();
         });
 
-        it('전체 비활성화된 스텝을 클릭하면 NOT_SELECTED(-1)로 이벤트가 발생해야 한다', async () => {
+        it('전체 비활성화된 상태로 마운트되어도 modelValue가 유지되고 클릭으로 변경되지 않아야 한다', async () => {
             // given
             const wrapper = mount(VsSteps, {
                 props: {
                     steps: ['Step 1', 'Step 2', 'Step 3'],
+                    modelValue: 1,
                     disabled: true,
                 },
             });
+            await nextTick();
+
+            // then: 마운트 시 modelValue(=1)가 보존되어 -1로 자동 변경되지 않는다
+            const initialEmits = (wrapper.emitted('update:modelValue') ?? []).map((e) => e[0]);
+            expect(initialEmits).not.toContain(-1);
 
             // when
             const stepItems = wrapper.findAll('.vs-step-item');
             await stepItems[0].trigger('click');
 
-            // then
-            expect(wrapper.emitted('update:modelValue')).toBeTruthy();
-            expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([-1]);
-            expect(wrapper.emitted('change')).toBeTruthy();
-            expect(wrapper.emitted('change')?.[0]).toEqual([-1]);
+            // then: 클릭으로 인한 추가 emit이 없어야 한다
+            const finalEmits = (wrapper.emitted('update:modelValue') ?? []).map((e) => e[0]);
+            expect(finalEmits.length).toBe(initialEmits.length);
         });
     });
 

--- a/packages/vlossom/src/components/vs-steps/__tests__/vs-steps.test.ts
+++ b/packages/vlossom/src/components/vs-steps/__tests__/vs-steps.test.ts
@@ -432,7 +432,7 @@ describe('VsSteps', () => {
             expect(stepItems[3].classes()).not.toContain('vs-selected');
         });
 
-        it('steps 배열이 변경되면 첫 번째 활성 스텝으로 이동해야 한다', async () => {
+        it('steps 길이가 줄어서 현재 선택이 범위를 벗어나면 선택이 해제되어야 한다', async () => {
             // given
             const wrapper = mount(VsSteps, {
                 props: {
@@ -448,10 +448,31 @@ describe('VsSteps', () => {
             await nextTick();
 
             // then
-            expect(wrapper.emitted('update:modelValue')).toBeTruthy();
             const stepItems = wrapper.findAll('.vs-step-item');
             expect(stepItems).toHaveLength(2);
-            expect(stepItems[0].classes()).toContain('vs-selected');
+            expect(stepItems[0].classes()).not.toContain('vs-selected');
+            expect(stepItems[1].classes()).not.toContain('vs-selected');
+        });
+
+        it('steps 길이가 변해도 현재 선택이 여전히 유효 범위에 있으면 유지되어야 한다', async () => {
+            // given
+            const wrapper = mount(VsSteps, {
+                props: {
+                    steps: ['Step 1', 'Step 2', 'Step 3'],
+                    modelValue: 1,
+                },
+            });
+
+            await nextTick();
+
+            // when
+            await wrapper.setProps({ steps: ['New Step 1', 'New Step 2', 'New Step 3', 'New Step 4'] });
+            await nextTick();
+
+            // then
+            const stepItems = wrapper.findAll('.vs-step-item');
+            expect(stepItems).toHaveLength(4);
+            expect(stepItems[1].classes()).toContain('vs-selected');
         });
     });
 

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.vue
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.vue
@@ -151,6 +151,7 @@ export default defineComponent({
             findActiveIndexForwardFrom,
             findActiveIndexBackwardFrom,
             selectIndex: selectTab,
+            syncIndex,
             handleKeydown,
             isFirstEdge,
             isLastEdge,
@@ -261,16 +262,6 @@ export default defineComponent({
             }
         });
 
-        watch(
-            () => tabs.value.length,
-            (newLength) => {
-                const currentIndex = selectedIndex.value;
-                if (currentIndex < 0 || currentIndex >= newLength) {
-                    selectedIndex.value = NOT_SELECTED;
-                }
-            },
-        );
-
         watch(selectedIndex, (index: number) => {
             scrollTo(index);
             emit('update:modelValue', index);
@@ -280,17 +271,7 @@ export default defineComponent({
             });
         });
 
-        watch(
-            modelValue,
-            (value) => {
-                if (value < 0 || value >= tabs.value.length) {
-                    selectedIndex.value = NOT_SELECTED;
-                } else {
-                    selectedIndex.value = value;
-                }
-            },
-            { immediate: true },
-        );
+        watch(modelValue, syncIndex, { immediate: true });
 
         return {
             // Style

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.vue
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.vue
@@ -248,8 +248,6 @@ export default defineComponent({
         }
 
         onMounted(() => {
-            selectedIndex.value = findActiveIndexForwardFrom(modelValue.value);
-
             if (tabsRef.value) {
                 resizeObserver = new ResizeObserver(handleResize);
                 resizeObserver.observe(tabsRef.value);
@@ -265,9 +263,11 @@ export default defineComponent({
 
         watch(
             () => tabs.value.length,
-            () => {
+            (newLength) => {
                 const currentIndex = selectedIndex.value;
-                selectTab(findActiveIndexForwardFrom(currentIndex));
+                if (currentIndex < 0 || currentIndex >= newLength) {
+                    selectedIndex.value = NOT_SELECTED;
+                }
             },
         );
 
@@ -280,7 +280,17 @@ export default defineComponent({
             });
         });
 
-        watch(modelValue, selectTab);
+        watch(
+            modelValue,
+            (value) => {
+                if (value < 0 || value >= tabs.value.length) {
+                    selectedIndex.value = NOT_SELECTED;
+                } else {
+                    selectedIndex.value = value;
+                }
+            },
+            { immediate: true },
+        );
 
         return {
             // Style

--- a/packages/vlossom/src/components/vs-tabs/__tests__/vs-tabs.test.ts
+++ b/packages/vlossom/src/components/vs-tabs/__tests__/vs-tabs.test.ts
@@ -300,7 +300,7 @@ describe('VsTabs', () => {
             expect(wrapper.emitted('change')).toBeFalsy();
         });
 
-        it('전체 비활성화된 상태로 마운트되어도 modelValue가 유지되고 클릭으로 변경되지 않아야 한다', async () => {
+        it('전체 비활성화된 상태로 마운트되어도 modelValue가 유지된다', async () => {
             // given
             const wrapper = mount(VsTabs, {
                 props: {
@@ -311,18 +311,9 @@ describe('VsTabs', () => {
             });
             await nextTick();
 
-            // then: 마운트 시 modelValue(=1)가 보존되어 -1로 자동 변경되지 않는다
-            const tabItems = wrapper.findAll('.vs-tab-item');
-            expect(tabItems[1].attributes('aria-selected')).toBe('true');
-            const initialEmits = (wrapper.emitted('update:modelValue') ?? []).map((e) => e[0]);
-            expect(initialEmits).not.toContain(-1);
-
-            // when
-            await tabItems[0].trigger('click');
-
-            // then: 클릭으로 인한 추가 emit이 없어야 한다
-            const finalEmits = (wrapper.emitted('update:modelValue') ?? []).map((e) => e[0]);
-            expect(finalEmits.length).toBe(initialEmits.length);
+            // then
+            expect(wrapper.vm.selectedIndex).toBe(1);
+            expect(wrapper.vm.selectedIndex).not.toBe(-1);
         });
     });
 
@@ -411,6 +402,51 @@ describe('VsTabs', () => {
             // then
             const customTabs = wrapper.findAll('.custom-tab');
             expect(customTabs).toHaveLength(3);
+        });
+    });
+
+    describe('reactivity', () => {
+        it('tabs 길이가 줄어서 현재 선택이 범위를 벗어나면 선택이 해제되어야 한다', async () => {
+            // given
+            const wrapper = mount(VsTabs, {
+                props: {
+                    tabs: ['Tab 1', 'Tab 2', 'Tab 3'],
+                    modelValue: 2,
+                },
+            });
+
+            await nextTick();
+
+            // when
+            await wrapper.setProps({ tabs: ['New Tab 1', 'New Tab 2'] });
+            await nextTick();
+
+            // then
+            const tabItems = wrapper.findAll('.vs-tab-item');
+            expect(tabItems).toHaveLength(2);
+            expect(tabItems[0].classes()).not.toContain('vs-selected');
+            expect(tabItems[1].classes()).not.toContain('vs-selected');
+        });
+
+        it('tabs 길이가 변해도 현재 선택이 여전히 유효 범위에 있으면 유지되어야 한다', async () => {
+            // given
+            const wrapper = mount(VsTabs, {
+                props: {
+                    tabs: ['Tab 1', 'Tab 2', 'Tab 3'],
+                    modelValue: 1,
+                },
+            });
+
+            await nextTick();
+
+            // when
+            await wrapper.setProps({ tabs: ['New Tab 1', 'New Tab 2', 'New Tab 3', 'New Tab 4'] });
+            await nextTick();
+
+            // then
+            const tabItems = wrapper.findAll('.vs-tab-item');
+            expect(tabItems).toHaveLength(4);
+            expect(tabItems[1].classes()).toContain('vs-selected');
         });
     });
 });

--- a/packages/vlossom/src/components/vs-tabs/__tests__/vs-tabs.test.ts
+++ b/packages/vlossom/src/components/vs-tabs/__tests__/vs-tabs.test.ts
@@ -282,7 +282,7 @@ describe('VsTabs', () => {
             expect(wrapper.emitted('change')?.[0]).toEqual([2]);
         });
 
-        it('함수를 통해 비활성화된 탭을 클릭하면 NOT_SELECTED(-1)로 이벤트가 발생해야 한다', async () => {
+        it('함수를 통해 비활성화된 탭을 클릭하면 이벤트가 발생하지 않고 현재 선택이 유지되어야 한다', async () => {
             // given
             const wrapper = mount(VsTabs, {
                 props: {
@@ -296,30 +296,33 @@ describe('VsTabs', () => {
             await tabItems[1].trigger('click');
 
             // then
-            expect(wrapper.emitted('update:modelValue')).toBeTruthy();
-            expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([-1]);
-            expect(wrapper.emitted('change')).toBeTruthy();
-            expect(wrapper.emitted('change')?.[0]).toEqual([-1]);
+            expect(wrapper.emitted('update:modelValue')).toBeFalsy();
+            expect(wrapper.emitted('change')).toBeFalsy();
         });
 
-        it('전체 비활성화된 탭을 클릭하면 NOT_SELECTED(-1)로 이벤트가 발생해야 한다', async () => {
+        it('전체 비활성화된 상태로 마운트되어도 modelValue가 유지되고 클릭으로 변경되지 않아야 한다', async () => {
             // given
             const wrapper = mount(VsTabs, {
                 props: {
                     tabs: ['Tab 1', 'Tab 2', 'Tab 3'],
+                    modelValue: 1,
                     disabled: true,
                 },
             });
+            await nextTick();
+
+            // then: 마운트 시 modelValue(=1)가 보존되어 -1로 자동 변경되지 않는다
+            const tabItems = wrapper.findAll('.vs-tab-item');
+            expect(tabItems[1].attributes('aria-selected')).toBe('true');
+            const initialEmits = (wrapper.emitted('update:modelValue') ?? []).map((e) => e[0]);
+            expect(initialEmits).not.toContain(-1);
 
             // when
-            const tabItems = wrapper.findAll('.vs-tab-item');
             await tabItems[0].trigger('click');
 
-            // then
-            expect(wrapper.emitted('update:modelValue')).toBeTruthy();
-            expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([-1]);
-            expect(wrapper.emitted('change')).toBeTruthy();
-            expect(wrapper.emitted('change')?.[0]).toEqual([-1]);
+            // then: 클릭으로 인한 추가 emit이 없어야 한다
+            const finalEmits = (wrapper.emitted('update:modelValue') ?? []).map((e) => e[0]);
+            expect(finalEmits.length).toBe(initialEmits.length);
         });
     });
 

--- a/packages/vlossom/src/composables/list-index-selector/README.ko.md
+++ b/packages/vlossom/src/composables/list-index-selector/README.ko.md
@@ -69,7 +69,7 @@ const { selectedIndex, isSelected, isDisabled, selectIndex, handleKeydown } = us
 | `isPrevious`                  | `index: number`                           | `index`가 `selectedIndex`보다 앞에 있으면 `true`를 반환합니다.                         |
 | `findActiveIndexForwardFrom`  | `targetIndex: number`                     | `targetIndex`부터 앞쪽으로 첫 번째 비비활성화 인덱스를 찾습니다.                       |
 | `findActiveIndexBackwardFrom` | `targetIndex: number`                     | `targetIndex`부터 뒤쪽으로 첫 번째 비비활성화 인덱스를 찾습니다.                       |
-| `selectIndex`                 | `index: number`                           | `index`가 유효하고 비활성화되지 않은 경우 `selectedIndex`를 설정합니다; 아니면 `NOT_SELECTED`. |
+| `selectIndex`                 | `index: number`                           | `index`가 유효하고 비활성화되지 않은 경우 `selectedIndex`를 설정합니다. 범위를 벗어나면 `NOT_SELECTED`로 초기화하고, 비활성화된 경우에는 현재 선택을 유지(no-op)합니다. |
 | `handleKeydown`               | `e: KeyboardEvent, isVertical: boolean`   | 화살표, Home, End 키를 처리합니다. `isVertical`에 따라 수직/수평 키 매핑을 사용합니다. |
 
 ## Hooks
@@ -80,4 +80,4 @@ const { selectedIndex, isSelected, isDisabled, selectIndex, handleKeydown } = us
 ## Cautions
 
 - `selectedIndex`는 `NOT_SELECTED`가 아닌 `0`(첫 번째 항목)에서 시작합니다. 마운트 시 첫 번째 항목이 선택 가능한지 확인하거나, 필요한 경우 수동으로 초기화하세요.
-- 모든 항목이 비활성화된 경우 `selectIndex`는 항상 `NOT_SELECTED`를 설정합니다.
+- 모든 항목이 비활성화되었거나 대상 인덱스가 비활성화된 경우 `selectIndex`는 no-op으로, 현재 `selectedIndex`를 그대로 유지합니다.

--- a/packages/vlossom/src/composables/list-index-selector/README.md
+++ b/packages/vlossom/src/composables/list-index-selector/README.md
@@ -69,7 +69,7 @@ No additional exported types. Uses `NOT_SELECTED` constant (`-1`) for the unsele
 | `isPrevious`                   | `index: number`                           | Returns `true` if `index` is before `selectedIndex`.                             |
 | `findActiveIndexForwardFrom`   | `targetIndex: number`                     | Finds the first non-disabled index at or after `targetIndex`.                    |
 | `findActiveIndexBackwardFrom`  | `targetIndex: number`                     | Finds the first non-disabled index at or before `targetIndex`.                   |
-| `selectIndex`                  | `index: number`                           | Sets `selectedIndex` to `index` if valid and not disabled; otherwise sets `NOT_SELECTED`. |
+| `selectIndex`                  | `index: number`                           | Sets `selectedIndex` to `index` if valid and not disabled. Out-of-range clears to `NOT_SELECTED`; disabled is a no-op (current selection is preserved). |
 | `handleKeydown`                | `e: KeyboardEvent, isVertical: boolean`   | Handles Arrow, Home, and End keys. Uses vertical/horizontal key mapping based on `isVertical`. |
 
 ## Hooks
@@ -80,4 +80,4 @@ No additional exported types. Uses `NOT_SELECTED` constant (`-1`) for the unsele
 ## Cautions
 
 - `selectedIndex` starts at `0` (the first item), not `NOT_SELECTED`. Ensure the first item is selectable on mount, or reset manually if needed.
-- If all items are disabled, `selectIndex` always sets `NOT_SELECTED`.
+- If all items are disabled (or the target index is disabled), `selectIndex` is a no-op: the current `selectedIndex` is preserved rather than cleared.

--- a/packages/vlossom/src/composables/list-index-selector/__tests__/list-index-selector-composable.test.ts
+++ b/packages/vlossom/src/composables/list-index-selector/__tests__/list-index-selector-composable.test.ts
@@ -187,7 +187,7 @@ describe('list-index-selector-composable', () => {
             expect(selectedIndex.value).toBe(1);
         });
 
-        it('비활성화된 인덱스를 선택하면 NOT_SELECTED가 설정되어야 한다', () => {
+        it('비활성화된 인덱스를 선택하면 현재 선택이 유지되어야 한다', () => {
             // given
             const list = ref(['item1', 'item2', 'item3']);
             const disabled = ref((item: string, index: number) => index === 1);
@@ -198,7 +198,7 @@ describe('list-index-selector-composable', () => {
             selectIndex(1);
 
             // then
-            expect(selectedIndex.value).toBe(-1);
+            expect(selectedIndex.value).toBe(0);
         });
 
         it('범위를 벗어난 인덱스를 선택하면 NOT_SELECTED가 설정되어야 한다', () => {
@@ -221,7 +221,7 @@ describe('list-index-selector-composable', () => {
             expect(selectedIndex.value).toBe(-1);
         });
 
-        it('모든 항목이 비활성화된 경우 NOT_SELECTED가 설정되어야 한다', () => {
+        it('모든 항목이 비활성화된 경우 현재 선택이 유지되어야 한다', () => {
             // given
             const list = ref(['item1', 'item2', 'item3']);
             const disabled = ref(true);
@@ -232,7 +232,7 @@ describe('list-index-selector-composable', () => {
             selectIndex(1);
 
             // then
-            expect(selectedIndex.value).toBe(-1);
+            expect(selectedIndex.value).toBe(0);
         });
     });
 

--- a/packages/vlossom/src/composables/list-index-selector/list-index-selector-composable.ts
+++ b/packages/vlossom/src/composables/list-index-selector/list-index-selector-composable.ts
@@ -1,4 +1,4 @@
-import { computed, ref, type Ref } from 'vue';
+import { computed, ref, watch, type Ref } from 'vue';
 import { NOT_SELECTED } from '@/declaration';
 
 export function useIndexSelector(
@@ -89,6 +89,14 @@ export function useIndexSelector(
         selectedIndex.value = index;
     }
 
+    function syncIndex(index: number) {
+        if (isOutOfRange(index)) {
+            selectedIndex.value = NOT_SELECTED;
+        } else {
+            selectedIndex.value = index;
+        }
+    }
+
     const isFirstEdge = computed(() => {
         const firstActiveIndex = findActiveIndexForwardFrom(0);
         return selectedIndex.value === firstActiveIndex;
@@ -126,6 +134,15 @@ export function useIndexSelector(
         }
     }
 
+    watch(
+        () => list.value.length,
+        () => {
+            if (isOutOfRange(selectedIndex.value)) {
+                selectedIndex.value = NOT_SELECTED;
+            }
+        },
+    );
+
     return {
         selectedIndex,
         isSelected,
@@ -135,6 +152,7 @@ export function useIndexSelector(
         findActiveIndexForwardFrom,
         findActiveIndexBackwardFrom,
         selectIndex,
+        syncIndex,
         handleKeydown,
         isFirstEdge,
         isLastEdge,

--- a/packages/vlossom/src/composables/list-index-selector/list-index-selector-composable.ts
+++ b/packages/vlossom/src/composables/list-index-selector/list-index-selector-composable.ts
@@ -79,11 +79,13 @@ export function useIndexSelector(
     }
 
     function selectIndex(index: number) {
-        if (isOutOfRange(index) || isAllDisabled() || isDisabled(index)) {
+        if (isOutOfRange(index)) {
             selectedIndex.value = NOT_SELECTED;
             return;
         }
-
+        if (isAllDisabled() || isDisabled(index)) {
+            return;
+        }
         selectedIndex.value = index;
     }
 


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary
list-index-selector composable의 동작을 변경합니다

## Description
- table 서버 모드로 구성할 경우 vs-pagination이 index를 유지하지 못 해서 버그 상황 발생
- index 선택 시 동작 방식을 변경합니다
  - out of range인 경우에 기존처럼 -1로 옮김
  - component가 disabled로 설정될 경우 model value 유지
- vs-tabs, vs-steps, vs-pagination 선택에 영향을 줌
<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
