### PR TITLE
feat(VsTooltip): support slot-based tooltip trigger

### DIFF
--- a/packages/vlossom/playground/Sandbox.vue
+++ b/packages/vlossom/playground/Sandbox.vue
@@ -1,18 +1,172 @@
 <template>
-    <vs-page class="mb-8" :style-set="{ padding: '0' }">
+    <vs-page class="mb-8" :style-set="{ padding: '1.5rem' }">
         <div class="sandbox">
-            <h1>Sandbox</h1>
+            <h1 class="mb-6 text-2xl font-bold">VsTooltip Sandbox</h1>
+
+            <!-- 1. Slot mode: 기본 (target 없음, default slot에 trigger 감싸기) -->
+            <section class="mb-12">
+                <h2 class="mb-4 text-lg font-semibold">1. Slot mode (target 없음)</h2>
+                <p class="mb-3 text-sm text-gray-500">
+                    target 없이 default slot으로 trigger를 감싸는 모드. 다양한 placement 조합.
+                </p>
+                <div class="flex flex-wrap items-center gap-4">
+                    <vs-tooltip placement="top">
+                        <vs-button>top</vs-button>
+                        <template #tooltip>Top placement</template>
+                    </vs-tooltip>
+
+                    <vs-tooltip placement="bottom">
+                        <vs-button>bottom</vs-button>
+                        <template #tooltip>Bottom placement</template>
+                    </vs-tooltip>
+
+                    <vs-tooltip placement="left">
+                        <vs-button>left</vs-button>
+                        <template #tooltip>Left placement</template>
+                    </vs-tooltip>
+
+                    <vs-tooltip placement="right">
+                        <vs-button>right</vs-button>
+                        <template #tooltip>Right placement</template>
+                    </vs-tooltip>
+                </div>
+            </section>
+
+            <!-- 2. Slot mode: align 조합 -->
+            <section class="mb-12">
+                <h2 class="mb-4 text-lg font-semibold">2. Align variations</h2>
+                <p class="mb-3 text-sm text-gray-500">placement=top + align: start / center / end</p>
+                <div class="flex flex-wrap items-center gap-4">
+                    <vs-tooltip placement="top" align="start">
+                        <vs-button style-set="{ width: '14rem' }">top + start</vs-button>
+                        <template #tooltip>start aligned</template>
+                    </vs-tooltip>
+
+                    <vs-tooltip placement="top" align="center">
+                        <vs-button style-set="{ width: '14rem' }">top + center</vs-button>
+                        <template #tooltip>center aligned</template>
+                    </vs-tooltip>
+
+                    <vs-tooltip placement="top" align="end">
+                        <vs-button style-set="{ width: '14rem' }">top + end</vs-button>
+                        <template #tooltip>end aligned</template>
+                    </vs-tooltip>
+                </div>
+
+                <p class="mt-6 mb-3 text-sm text-gray-500">placement=right + align: start / center / end</p>
+                <div class="flex flex-col items-start gap-2">
+                    <vs-tooltip placement="right" align="start">
+                        <vs-button>right + start</vs-button>
+                        <template #tooltip>start aligned</template>
+                    </vs-tooltip>
+
+                    <vs-tooltip placement="right" align="center">
+                        <vs-button>right + center</vs-button>
+                        <template #tooltip>center aligned</template>
+                    </vs-tooltip>
+
+                    <vs-tooltip placement="right" align="end">
+                        <vs-button>right + end</vs-button>
+                        <template #tooltip>end aligned</template>
+                    </vs-tooltip>
+                </div>
+            </section>
+
+            <!-- 3. Target mode -->
+            <section class="mb-12">
+                <h2 class="mb-4 text-lg font-semibold">3. Target mode (외부 selector 지정)</h2>
+                <p class="mb-3 text-sm text-gray-500">target prop으로 selector를 지정하면 해당 요소에 붙음.</p>
+                <div class="flex flex-wrap items-center gap-4">
+                    <button id="external-target-1" class="rounded border px-3 py-2">#external-target-1</button>
+                    <button id="external-target-2" class="rounded border px-3 py-2">#external-target-2</button>
+                </div>
+
+                <vs-tooltip target="#external-target-1" placement="bottom" align="start">
+                    <template #tooltip>외부 버튼에 attached (bottom + start)</template>
+                </vs-tooltip>
+
+                <vs-tooltip target="#external-target-2" placement="right" align="center">
+                    <template #tooltip>외부 버튼에 attached (right + center)</template>
+                </vs-tooltip>
+            </section>
+
+            <!-- 4. Tag prop variation -->
+            <section class="mb-12">
+                <h2 class="mb-4 text-lg font-semibold">4. Wrapper tag 변경</h2>
+                <p class="mb-3 text-sm text-gray-500">tag prop으로 wrapper 엘리먼트 변경 (기본 span).</p>
+                <div class="flex flex-wrap items-center gap-4">
+                    <vs-tooltip placement="top" tag="span">
+                        <span class="underline decoration-dotted">span wrapper (inline)</span>
+                        <template #tooltip>span으로 감쌈</template>
+                    </vs-tooltip>
+
+                    <vs-tooltip placement="bottom" tag="div">
+                        <div class="rounded bg-gray-100 px-3 py-2 dark:bg-gray-700">div wrapper (block)</div>
+                        <template #tooltip>div로 감쌈</template>
+                    </vs-tooltip>
+                </div>
+            </section>
+
+            <!-- 5. Behavior options -->
+            <section class="mb-12">
+                <h2 class="mb-4 text-lg font-semibold">5. Behavior options</h2>
+                <div class="flex flex-wrap items-center gap-4">
+                    <vs-tooltip placement="top" clickable>
+                        <vs-button>clickable</vs-button>
+                        <template #tooltip>클릭해서 토글</template>
+                    </vs-tooltip>
+
+                    <vs-tooltip placement="top" contents-hover>
+                        <vs-button>contentsHover</vs-button>
+                        <template #tooltip>
+                            <span>툴팁 위에 마우스 올려도 유지됨</span>
+                        </template>
+                    </vs-tooltip>
+
+                    <vs-tooltip placement="top" :enter-delay="500" :leave-delay="300">
+                        <vs-button>delay (500ms / 300ms)</vs-button>
+                        <template #tooltip>enter/leave delay 적용</template>
+                    </vs-tooltip>
+                </div>
+            </section>
+
+            <!-- 6. Grid showcase: 4 placements × 3 aligns = 12 -->
+            <section class="mb-12">
+                <h2 class="mb-4 text-lg font-semibold">6. 전체 조합 (4 placements × 3 aligns)</h2>
+                <div class="grid grid-cols-3 gap-6">
+                    <template v-for="placement in placements" :key="placement">
+                        <vs-tooltip
+                            v-for="align in alignments"
+                            :key="`${placement}-${align}`"
+                            :placement
+                            :align
+                        >
+                            <vs-button style-set="{ width: '12rem' }">
+                                {{ placement }} / {{ align }}
+                            </vs-button>
+                            <template #tooltip>{{ placement }} + {{ align }}</template>
+                        </vs-tooltip>
+                    </template>
+                </div>
+            </section>
         </div>
     </vs-page>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import type { Placement, Alignment } from '@/declaration';
 
 export default defineComponent({
     name: 'Sandbox',
     setup() {
-        return {};
+        const placements: Exclude<Placement, 'middle'>[] = ['top', 'bottom', 'left', 'right'];
+        const alignments: Alignment[] = ['start', 'center', 'end'];
+
+        return {
+            placements,
+            alignments,
+        };
     },
 });
 </script>

--- a/packages/vlossom/playground/Sandbox.vue
+++ b/packages/vlossom/playground/Sandbox.vue
@@ -1,172 +1,18 @@
 <template>
-    <vs-page class="mb-8" :style-set="{ padding: '1.5rem' }">
+    <vs-page class="mb-8" :style-set="{ padding: '0' }">
         <div class="sandbox">
-            <h1 class="mb-6 text-2xl font-bold">VsTooltip Sandbox</h1>
-
-            <!-- 1. Slot mode: 기본 (target 없음, default slot에 trigger 감싸기) -->
-            <section class="mb-12">
-                <h2 class="mb-4 text-lg font-semibold">1. Slot mode (target 없음)</h2>
-                <p class="mb-3 text-sm text-gray-500">
-                    target 없이 default slot으로 trigger를 감싸는 모드. 다양한 placement 조합.
-                </p>
-                <div class="flex flex-wrap items-center gap-4">
-                    <vs-tooltip placement="top">
-                        <vs-button>top</vs-button>
-                        <template #tooltip>Top placement</template>
-                    </vs-tooltip>
-
-                    <vs-tooltip placement="bottom">
-                        <vs-button>bottom</vs-button>
-                        <template #tooltip>Bottom placement</template>
-                    </vs-tooltip>
-
-                    <vs-tooltip placement="left">
-                        <vs-button>left</vs-button>
-                        <template #tooltip>Left placement</template>
-                    </vs-tooltip>
-
-                    <vs-tooltip placement="right">
-                        <vs-button>right</vs-button>
-                        <template #tooltip>Right placement</template>
-                    </vs-tooltip>
-                </div>
-            </section>
-
-            <!-- 2. Slot mode: align 조합 -->
-            <section class="mb-12">
-                <h2 class="mb-4 text-lg font-semibold">2. Align variations</h2>
-                <p class="mb-3 text-sm text-gray-500">placement=top + align: start / center / end</p>
-                <div class="flex flex-wrap items-center gap-4">
-                    <vs-tooltip placement="top" align="start">
-                        <vs-button style-set="{ width: '14rem' }">top + start</vs-button>
-                        <template #tooltip>start aligned</template>
-                    </vs-tooltip>
-
-                    <vs-tooltip placement="top" align="center">
-                        <vs-button style-set="{ width: '14rem' }">top + center</vs-button>
-                        <template #tooltip>center aligned</template>
-                    </vs-tooltip>
-
-                    <vs-tooltip placement="top" align="end">
-                        <vs-button style-set="{ width: '14rem' }">top + end</vs-button>
-                        <template #tooltip>end aligned</template>
-                    </vs-tooltip>
-                </div>
-
-                <p class="mt-6 mb-3 text-sm text-gray-500">placement=right + align: start / center / end</p>
-                <div class="flex flex-col items-start gap-2">
-                    <vs-tooltip placement="right" align="start">
-                        <vs-button>right + start</vs-button>
-                        <template #tooltip>start aligned</template>
-                    </vs-tooltip>
-
-                    <vs-tooltip placement="right" align="center">
-                        <vs-button>right + center</vs-button>
-                        <template #tooltip>center aligned</template>
-                    </vs-tooltip>
-
-                    <vs-tooltip placement="right" align="end">
-                        <vs-button>right + end</vs-button>
-                        <template #tooltip>end aligned</template>
-                    </vs-tooltip>
-                </div>
-            </section>
-
-            <!-- 3. Target mode -->
-            <section class="mb-12">
-                <h2 class="mb-4 text-lg font-semibold">3. Target mode (외부 selector 지정)</h2>
-                <p class="mb-3 text-sm text-gray-500">target prop으로 selector를 지정하면 해당 요소에 붙음.</p>
-                <div class="flex flex-wrap items-center gap-4">
-                    <button id="external-target-1" class="rounded border px-3 py-2">#external-target-1</button>
-                    <button id="external-target-2" class="rounded border px-3 py-2">#external-target-2</button>
-                </div>
-
-                <vs-tooltip target="#external-target-1" placement="bottom" align="start">
-                    <template #tooltip>외부 버튼에 attached (bottom + start)</template>
-                </vs-tooltip>
-
-                <vs-tooltip target="#external-target-2" placement="right" align="center">
-                    <template #tooltip>외부 버튼에 attached (right + center)</template>
-                </vs-tooltip>
-            </section>
-
-            <!-- 4. Tag prop variation -->
-            <section class="mb-12">
-                <h2 class="mb-4 text-lg font-semibold">4. Wrapper tag 변경</h2>
-                <p class="mb-3 text-sm text-gray-500">tag prop으로 wrapper 엘리먼트 변경 (기본 span).</p>
-                <div class="flex flex-wrap items-center gap-4">
-                    <vs-tooltip placement="top" tag="span">
-                        <span class="underline decoration-dotted">span wrapper (inline)</span>
-                        <template #tooltip>span으로 감쌈</template>
-                    </vs-tooltip>
-
-                    <vs-tooltip placement="bottom" tag="div">
-                        <div class="rounded bg-gray-100 px-3 py-2 dark:bg-gray-700">div wrapper (block)</div>
-                        <template #tooltip>div로 감쌈</template>
-                    </vs-tooltip>
-                </div>
-            </section>
-
-            <!-- 5. Behavior options -->
-            <section class="mb-12">
-                <h2 class="mb-4 text-lg font-semibold">5. Behavior options</h2>
-                <div class="flex flex-wrap items-center gap-4">
-                    <vs-tooltip placement="top" clickable>
-                        <vs-button>clickable</vs-button>
-                        <template #tooltip>클릭해서 토글</template>
-                    </vs-tooltip>
-
-                    <vs-tooltip placement="top" contents-hover>
-                        <vs-button>contentsHover</vs-button>
-                        <template #tooltip>
-                            <span>툴팁 위에 마우스 올려도 유지됨</span>
-                        </template>
-                    </vs-tooltip>
-
-                    <vs-tooltip placement="top" :enter-delay="500" :leave-delay="300">
-                        <vs-button>delay (500ms / 300ms)</vs-button>
-                        <template #tooltip>enter/leave delay 적용</template>
-                    </vs-tooltip>
-                </div>
-            </section>
-
-            <!-- 6. Grid showcase: 4 placements × 3 aligns = 12 -->
-            <section class="mb-12">
-                <h2 class="mb-4 text-lg font-semibold">6. 전체 조합 (4 placements × 3 aligns)</h2>
-                <div class="grid grid-cols-3 gap-6">
-                    <template v-for="placement in placements" :key="placement">
-                        <vs-tooltip
-                            v-for="align in alignments"
-                            :key="`${placement}-${align}`"
-                            :placement
-                            :align
-                        >
-                            <vs-button style-set="{ width: '12rem' }">
-                                {{ placement }} / {{ align }}
-                            </vs-button>
-                            <template #tooltip>{{ placement }} + {{ align }}</template>
-                        </vs-tooltip>
-                    </template>
-                </div>
-            </section>
+            <h1>Sandbox</h1>
         </div>
     </vs-page>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import type { Placement, Alignment } from '@/declaration';
 
 export default defineComponent({
     name: 'Sandbox',
     setup() {
-        const placements: Exclude<Placement, 'middle'>[] = ['top', 'bottom', 'left', 'right'];
-        const alignments: Alignment[] = ['start', 'center', 'end'];
-
-        return {
-            placements,
-            alignments,
-        };
+        return {};
     },
 });
 </script>

--- a/packages/vlossom/playground/views/Overlay.vue
+++ b/packages/vlossom/playground/views/Overlay.vue
@@ -158,9 +158,7 @@
             </vs-grid>
         </vs-block>
         <div class="flex flex-wrap items-start gap-4">
-            <vs-button id="tooltip-demo">Hover me</vs-button>
             <vs-tooltip
-                target="#tooltip-demo"
                 :placement="tooltipOptions.placement"
                 :align="tooltipOptions.align"
                 :clickable="tooltipOptions.clickable"
@@ -170,7 +168,23 @@
                 :no-animation="tooltipOptions.noAnimation"
                 :disabled="tooltipOptions.disabled"
             >
-                Tooltip content here
+                <vs-button>Hover me (slot mode)</vs-button>
+                <template #tooltip>Tooltip content here</template>
+            </vs-tooltip>
+
+            <vs-button id="tooltip-demo-target">Hover me (target mode)</vs-button>
+            <vs-tooltip
+                target="#tooltip-demo-target"
+                :placement="tooltipOptions.placement"
+                :align="tooltipOptions.align"
+                :clickable="tooltipOptions.clickable"
+                :contents-hover="tooltipOptions.contentsHover"
+                :enter-delay="tooltipOptions.enterDelay"
+                :leave-delay="tooltipOptions.leaveDelay"
+                :no-animation="tooltipOptions.noAnimation"
+                :disabled="tooltipOptions.disabled"
+            >
+                <template #tooltip>Attached via target selector</template>
             </vs-tooltip>
         </div>
     </section>

--- a/packages/vlossom/src/components/vs-tooltip/README.ko.md
+++ b/packages/vlossom/src/components/vs-tooltip/README.ko.md
@@ -117,6 +117,7 @@ interface VsTooltipStyleSet {
     $arrowSize?: string;
 
     $tooltip?: CSSProperties;
+    $trigger?: CSSProperties; // slot 모드에서 wrapper 엘리먼트에 적용될 스타일
 }
 ```
 

--- a/packages/vlossom/src/components/vs-tooltip/README.ko.md
+++ b/packages/vlossom/src/components/vs-tooltip/README.ko.md
@@ -8,20 +8,38 @@
 
 ## 기능
 
-- CSS 선택자를 통해 모든 대상 요소에 연결
+- 두 가지 사용 방식: default slot으로 trigger를 감싸거나, CSS selector로 외부 요소에 연결
 - 호버, 클릭 열기, 콘텐츠 호버 모드 지원
 - 설정 가능한 배치 (top, bottom, left, right) 및 정렬 (start, center, end)
+- Slot 모드에서 wrapper 태그 설정 가능 (기본 `span`)
 - 색상 및 크기를 커스터마이징할 수 있는 화살표 인디케이터
 - Escape 키로 툴팁 닫기 (설정 가능)
 - 설정 가능한 표시/숨김 딜레이
 
 ## 기본 사용법
 
+### Slot 모드 (기본)
+
+`target`을 지정하지 않으면 default slot이 wrapper 엘리먼트로 감싸져 trigger 역할을 합니다.
+
+```html
+<template>
+    <vs-tooltip>
+        <button>마우스를 올려보세요</button>
+        <template #tooltip>툴팁입니다</template>
+    </vs-tooltip>
+</template>
+```
+
+### Target 모드
+
+`target` prop에 CSS selector를 지정하면 외부 요소에 툴팁이 붙습니다.
+
 ```html
 <template>
     <button id="my-btn">마우스를 올려보세요</button>
     <vs-tooltip target="#my-btn">
-        툴팁입니다
+        <template #tooltip>툴팁입니다</template>
     </vs-tooltip>
 </template>
 ```
@@ -30,9 +48,9 @@
 
 ```html
 <template>
-    <button id="click-btn">클릭하세요</button>
-    <vs-tooltip target="#click-btn" clickable>
-        클릭으로 열림
+    <vs-tooltip clickable>
+        <button>클릭하세요</button>
+        <template #tooltip>클릭으로 열림</template>
     </vs-tooltip>
 </template>
 ```
@@ -41,9 +59,9 @@
 
 ```html
 <template>
-    <button id="bottom-btn">마우스를 올려보세요</button>
-    <vs-tooltip target="#bottom-btn" placement="bottom" align="start">
-        하단-시작 툴팁
+    <vs-tooltip placement="bottom" align="start">
+        <button>마우스를 올려보세요</button>
+        <template #tooltip>하단-시작 툴팁</template>
     </vs-tooltip>
 </template>
 ```
@@ -52,9 +70,22 @@
 
 ```html
 <template>
-    <button id="hover-btn">마우스를 올려보세요</button>
-    <vs-tooltip target="#hover-btn" contents-hover>
-        <a href="#">툴팁 내부의 링크를 클릭하세요</a>
+    <vs-tooltip contents-hover>
+        <button>마우스를 올려보세요</button>
+        <template #tooltip>
+            <a href="#">툴팁 내부의 링크를 클릭하세요</a>
+        </template>
+    </vs-tooltip>
+</template>
+```
+
+### Wrapper 태그 변경
+
+```html
+<template>
+    <vs-tooltip tag="div">
+        <div class="trigger-area">Block-level trigger</div>
+        <template #tooltip>div로 감싸짐</template>
     </vs-tooltip>
 </template>
 ```
@@ -65,7 +96,8 @@
 | ---- | ---- | ------ | ---- | ---- |
 | `colorScheme` | `string` | | | 컴포넌트 색상 스키마 |
 | `styleSet` | `string \| VsTooltipStyleSet` | | | 컴포넌트 커스텀 스타일 세트 |
-| `target` | `string` | `''` | 필수 | 트리거 요소의 CSS 선택자 |
+| `target` | `string` | `''` | | 트리거 요소의 CSS 선택자. 생략 시 default slot이 wrapper로 감싸져 trigger로 사용됨 |
+| `tag` | `string` | `'span'` | | default slot을 감싸는 wrapper 엘리먼트의 태그 (slot 모드 전용) |
 | `align` | `Alignment` | `'center'` | | 대상에 대한 툴팁 정렬 (`start`, `center`, `end`) |
 | `clickable` | `boolean` | `false` | | 열기 위해 대상 클릭 필요 |
 | `contentsHover` | `boolean` | `false` | | 콘텐츠에 마우스를 올리는 동안 툴팁 유지 |
@@ -92,9 +124,7 @@ interface VsTooltipStyleSet {
 
 ```html
 <template>
-    <button id="styled-btn">마우스를 올려보세요</button>
     <vs-tooltip
-        target="#styled-btn"
         :style-set="{
             $arrowColor: '#323232',
             $arrowSize: '0.5rem',
@@ -106,7 +136,8 @@ interface VsTooltipStyleSet {
             },
         }"
     >
-        커스텀 툴팁
+        <button>마우스를 올려보세요</button>
+        <template #tooltip>커스텀 툴팁</template>
     </vs-tooltip>
 </template>
 ```
@@ -120,7 +151,8 @@ interface VsTooltipStyleSet {
 
 | 슬롯 | 설명 |
 | ---- | ---- |
-| `default` | 툴팁 내용 |
+| `default` | Trigger 내용 (target이 없을 때만 렌더링되며, `tag` 엘리먼트로 감싸짐) |
+| `tooltip` | 플로팅 패널에 표시되는 툴팁 내용 |
 
 ## 메서드
 

--- a/packages/vlossom/src/components/vs-tooltip/README.md
+++ b/packages/vlossom/src/components/vs-tooltip/README.md
@@ -8,20 +8,38 @@ A floating tooltip component that attaches to a target element and supports hove
 
 ## Feature
 
-- Attaches to any target element via a CSS selector
+- Two usage modes: wrap the trigger via the default slot, or attach to an external element via a CSS selector
 - Supports hover, click-to-open, and contents-hover modes
 - Configurable placement (top, bottom, left, right) and alignment (start, center, end)
+- Configurable wrapper tag (`span` by default) for slot mode
 - Arrow indicator with customizable color and size
 - Escape key closes the tooltip (configurable)
 - Configurable enter and leave delays
 
 ## Basic Usage
 
+### Slot Mode (default)
+
+When `target` is omitted, the default slot is wrapped by an element that becomes the trigger.
+
+```html
+<template>
+    <vs-tooltip>
+        <button>Hover me</button>
+        <template #tooltip>This is a tooltip</template>
+    </vs-tooltip>
+</template>
+```
+
+### Target Mode
+
+Pass `target` as a CSS selector to attach the tooltip to an external element.
+
 ```html
 <template>
     <button id="my-btn">Hover me</button>
     <vs-tooltip target="#my-btn">
-        This is a tooltip
+        <template #tooltip>This is a tooltip</template>
     </vs-tooltip>
 </template>
 ```
@@ -30,9 +48,9 @@ A floating tooltip component that attaches to a target element and supports hove
 
 ```html
 <template>
-    <button id="click-btn">Click me</button>
-    <vs-tooltip target="#click-btn" clickable>
-        Opened by click
+    <vs-tooltip clickable>
+        <button>Click me</button>
+        <template #tooltip>Opened by click</template>
     </vs-tooltip>
 </template>
 ```
@@ -41,9 +59,9 @@ A floating tooltip component that attaches to a target element and supports hove
 
 ```html
 <template>
-    <button id="bottom-btn">Hover me</button>
-    <vs-tooltip target="#bottom-btn" placement="bottom" align="start">
-        Bottom-start tooltip
+    <vs-tooltip placement="bottom" align="start">
+        <button>Hover me</button>
+        <template #tooltip>Bottom-start tooltip</template>
     </vs-tooltip>
 </template>
 ```
@@ -52,9 +70,22 @@ A floating tooltip component that attaches to a target element and supports hove
 
 ```html
 <template>
-    <button id="hover-btn">Hover me</button>
-    <vs-tooltip target="#hover-btn" contents-hover>
-        <a href="#">Click this link inside the tooltip</a>
+    <vs-tooltip contents-hover>
+        <button>Hover me</button>
+        <template #tooltip>
+            <a href="#">Click this link inside the tooltip</a>
+        </template>
+    </vs-tooltip>
+</template>
+```
+
+### Custom Wrapper Tag
+
+```html
+<template>
+    <vs-tooltip tag="div">
+        <div class="trigger-area">Block-level trigger</div>
+        <template #tooltip>Wrapped by a div</template>
     </vs-tooltip>
 </template>
 ```
@@ -65,7 +96,8 @@ A floating tooltip component that attaches to a target element and supports hove
 | ---- | ---- | ------- | -------- | ----------- |
 | `colorScheme` | `string` | | | Color scheme for the component |
 | `styleSet` | `string \| VsTooltipStyleSet` | | | Custom style set for the component |
-| `target` | `string` | `''` | Yes | CSS selector of the trigger element |
+| `target` | `string` | `''` | | CSS selector of the trigger element. If omitted, the default slot is wrapped and used as the trigger |
+| `tag` | `string` | `'span'` | | Tag name of the wrapper element rendered around the default slot (slot mode only) |
 | `align` | `Alignment` | `'center'` | | Alignment of the tooltip relative to the target (`start`, `center`, `end`) |
 | `clickable` | `boolean` | `false` | | Requires a click on the target to open |
 | `contentsHover` | `boolean` | `false` | | Keeps the tooltip open while hovering its contents |
@@ -92,9 +124,7 @@ interface VsTooltipStyleSet {
 
 ```html
 <template>
-    <button id="styled-btn">Hover me</button>
     <vs-tooltip
-        target="#styled-btn"
         :style-set="{
             $arrowColor: '#323232',
             $arrowSize: '0.5rem',
@@ -106,7 +136,8 @@ interface VsTooltipStyleSet {
             },
         }"
     >
-        Custom tooltip
+        <button>Hover me</button>
+        <template #tooltip>Custom tooltip</template>
     </vs-tooltip>
 </template>
 ```
@@ -120,7 +151,8 @@ interface VsTooltipStyleSet {
 
 | Slot | Description |
 | ---- | ----------- |
-| `default` | Tooltip content |
+| `default` | Trigger content (rendered only when `target` is not provided; wrapped by the `tag` element) |
+| `tooltip` | Tooltip content shown in the floating panel |
 
 ## Methods
 

--- a/packages/vlossom/src/components/vs-tooltip/README.md
+++ b/packages/vlossom/src/components/vs-tooltip/README.md
@@ -117,6 +117,7 @@ interface VsTooltipStyleSet {
     $arrowSize?: string;
 
     $tooltip?: CSSProperties;
+    $trigger?: CSSProperties; // styles for the wrapper element in slot mode
 }
 ```
 

--- a/packages/vlossom/src/components/vs-tooltip/VsTooltip.vue
+++ b/packages/vlossom/src/components/vs-tooltip/VsTooltip.vue
@@ -1,5 +1,10 @@
 <template>
-    <component :is="tag" v-if="!target" :class="['vs-tooltip-trigger', triggerClass]">
+    <component
+        :is="tag"
+        v-if="!target"
+        :class="['vs-tooltip-trigger', triggerClass]"
+        :style="componentStyleSet.$trigger"
+    >
         <slot />
     </component>
     <vs-floating

--- a/packages/vlossom/src/components/vs-tooltip/VsTooltip.vue
+++ b/packages/vlossom/src/components/vs-tooltip/VsTooltip.vue
@@ -1,7 +1,10 @@
 <template>
+    <component :is="tag" v-if="!target" :class="['vs-tooltip-trigger', triggerClass]">
+        <slot />
+    </component>
     <vs-floating
         v-model="computedShow"
-        :target
+        :target="effectiveTarget"
         :placement
         :align
         :margin
@@ -18,7 +21,7 @@
                 @mouseleave.stop="onTooltipLeave"
             >
                 <div class="vs-tooltip-contents" :style="componentStyleSet.$tooltip">
-                    <slot />
+                    <slot name="tooltip" />
                 </div>
             </div>
         </template>
@@ -53,6 +56,8 @@ export default defineComponent({
         ...getColorSchemeProps(),
         ...getStyleSetProps<VsTooltipStyleSet>(),
         ...getFloatingProps({ placement: 'top', align: 'center', margin: 10 }),
+        target: { type: String, default: '' },
+        tag: { type: String, default: 'span' },
         clickable: { type: Boolean, default: false },
         contentsHover: { type: Boolean, default: false },
         escClose: { type: Boolean, default: true },
@@ -61,6 +66,8 @@ export default defineComponent({
         const { colorScheme, styleSet, target, clickable, contentsHover, escClose } = toRefs(props);
 
         const id = ref(stringUtil.createID());
+        const triggerClass = computed(() => `vs-tooltip-trigger-${id.value}`);
+        const effectiveTarget = computed(() => target.value || `.${triggerClass.value}`);
         const triggerOver = ref(false);
         const tooltipOver = ref(false);
         const isMovingOut = ref(false);
@@ -181,7 +188,7 @@ export default defineComponent({
         }
 
         function addTargetEventListeners() {
-            const targetElement = document.querySelector(target.value);
+            const targetElement = document.querySelector(effectiveTarget.value);
             if (!targetElement) {
                 return;
             }
@@ -194,7 +201,7 @@ export default defineComponent({
         }
 
         function removeTargetEventListeners() {
-            const targetElement = document.querySelector(target.value);
+            const targetElement = document.querySelector(effectiveTarget.value);
             if (!targetElement) {
                 return;
             }
@@ -219,6 +226,8 @@ export default defineComponent({
             styleSetVariables,
             componentStyleSet,
             computedShow,
+            triggerClass,
+            effectiveTarget,
             onTooltipEnter,
             onTooltipLeave,
         };

--- a/packages/vlossom/src/components/vs-tooltip/__stories__/vs-tooltip.stories.ts
+++ b/packages/vlossom/src/components/vs-tooltip/__stories__/vs-tooltip.stories.ts
@@ -19,7 +19,11 @@ const meta: Meta<typeof VsTooltip> = {
     argTypes: {
         target: {
             control: 'text',
-            description: '툴팁을 표시할 대상 요소의 selector',
+            description: '툴팁을 표시할 대상 요소의 selector (지정하지 않으면 default slot이 trigger가 됨)',
+        },
+        tag: {
+            control: 'text',
+            description: 'Slot 모드에서 default slot을 감싸는 wrapper 엘리먼트의 태그',
         },
         colorScheme,
         align: {
@@ -74,7 +78,7 @@ export const Default: Story = {
     parameters: {
         docs: {
             description: {
-                story: '기본 툴팁입니다. 마우스 호버 시 툴팁이 표시됩니다.',
+                story: '기본 툴팁입니다. default slot으로 trigger를 감싸고, #tooltip slot에 툴팁 내용을 넣습니다.',
             },
         },
     },
@@ -84,9 +88,58 @@ export const Default: Story = {
             return { args };
         },
         template: `
-            <vs-button id="tooltip-trigger-default">Hover me</vs-button>
-            <vs-tooltip v-bind="args" target="#tooltip-trigger-default">
-                <span>This is a tooltip</span>
+            <vs-tooltip v-bind="args">
+                <vs-button>Hover me</vs-button>
+                <template #tooltip>This is a tooltip</template>
+            </vs-tooltip>
+        `,
+    }),
+};
+
+export const TargetMode: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'target prop으로 외부 요소에 툴팁을 붙이는 모드입니다.',
+            },
+        },
+    },
+    render: (args: any) => ({
+        components: { VsTooltip, VsButton },
+        setup() {
+            return { args };
+        },
+        template: `
+            <vs-button id="tooltip-trigger-target">External trigger</vs-button>
+            <vs-tooltip v-bind="args" target="#tooltip-trigger-target">
+                <template #tooltip>Attached via target selector</template>
+            </vs-tooltip>
+        `,
+    }),
+};
+
+export const CustomTag: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'tag prop으로 wrapper 엘리먼트를 변경할 수 있습니다 (기본 span).',
+            },
+        },
+    },
+    args: {
+        tag: 'div',
+    },
+    render: (args: any) => ({
+        components: { VsTooltip, VsButton },
+        setup() {
+            return { args };
+        },
+        template: `
+            <vs-tooltip v-bind="args">
+                <div style="padding: 0.5rem 1rem; border: 1px dashed #888; display: inline-block;">
+                    Block-level trigger
+                </div>
+                <template #tooltip>Wrapped by a div</template>
             </vs-tooltip>
         `,
     }),
@@ -109,9 +162,9 @@ export const Clickable: Story = {
             return { args };
         },
         template: `
-            <vs-button id="tooltip-trigger-clickable">Click me</vs-button>
-            <vs-tooltip v-bind="args" target="#tooltip-trigger-clickable">
-                <span>Click to toggle tooltip</span>
+            <vs-tooltip v-bind="args">
+                <vs-button>Click me</vs-button>
+                <template #tooltip>Click to toggle tooltip</template>
             </vs-tooltip>
         `,
     }),
@@ -134,9 +187,9 @@ export const ContentsHover: Story = {
             return { args };
         },
         template: `
-            <vs-button id="tooltip-trigger-contents-hover">Hover me</vs-button>
-            <vs-tooltip v-bind="args" target="#tooltip-trigger-contents-hover">
-                <span>You can hover over this tooltip content</span>
+            <vs-tooltip v-bind="args">
+                <vs-button>Hover me</vs-button>
+                <template #tooltip>You can hover over this tooltip content</template>
             </vs-tooltip>
         `,
     }),
@@ -162,9 +215,9 @@ export const ClickableAndContentsHover: Story = {
             return { args };
         },
         template: `
-            <vs-button id="tooltip-trigger-click-hover">Click and hover</vs-button>
-            <vs-tooltip v-bind="args" target="#tooltip-trigger-click-hover">
-                <span>Click to open and hover over this content</span>
+            <vs-tooltip v-bind="args">
+                <vs-button>Click and hover</vs-button>
+                <template #tooltip>Click to open and hover over this content</template>
             </vs-tooltip>
         `,
     }),
@@ -185,20 +238,24 @@ export const Placements: Story = {
         },
         template: `
             <div style="display: flex; flex-direction: column; gap: 2rem; align-items: center; padding: 4rem;">
+                <vs-tooltip v-bind="args" placement="top">
+                    <vs-button>Top</vs-button>
+                    <template #tooltip>Top tooltip</template>
+                </vs-tooltip>
                 <div style="display: flex; gap: 1rem;">
-                    <vs-button id="tooltip-top">Top</vs-button>
-                    <vs-tooltip v-bind="args" target="#tooltip-top" placement="top">Top tooltip</vs-tooltip>
+                    <vs-tooltip v-bind="args" placement="left">
+                        <vs-button>Left</vs-button>
+                        <template #tooltip>Left tooltip</template>
+                    </vs-tooltip>
+                    <vs-tooltip v-bind="args" placement="right">
+                        <vs-button>Right</vs-button>
+                        <template #tooltip>Right tooltip</template>
+                    </vs-tooltip>
                 </div>
-                <div style="display: flex; gap: 1rem;">
-                    <vs-button id="tooltip-left">Left</vs-button>
-                    <vs-tooltip v-bind="args" target="#tooltip-left" placement="left">Left tooltip</vs-tooltip>
-                    <vs-button id="tooltip-right">Right</vs-button>
-                    <vs-tooltip v-bind="args" target="#tooltip-right" placement="right">Right tooltip</vs-tooltip>
-                </div>
-                <div style="display: flex; gap: 1rem;">
-                    <vs-button id="tooltip-bottom">Bottom</vs-button>
-                    <vs-tooltip v-bind="args" target="#tooltip-bottom" placement="bottom">Bottom tooltip</vs-tooltip>
-                </div>
+                <vs-tooltip v-bind="args" placement="bottom">
+                    <vs-button>Bottom</vs-button>
+                    <template #tooltip>Bottom tooltip</template>
+                </vs-tooltip>
             </div>
         `,
     }),
@@ -220,12 +277,18 @@ export const Alignments: Story = {
         template: `
             <div style="display: flex; flex-direction: column; gap: 2rem; align-items: center; padding: 4rem;">
                 <div style="display: flex; gap: 1rem;">
-                    <vs-button id="tooltip-align-start">Start</vs-button>
-                    <vs-tooltip v-bind="args" target="#tooltip-align-start" placement="top" align="start">Start aligned</vs-tooltip>
-                    <vs-button id="tooltip-align-center">Center</vs-button>
-                    <vs-tooltip v-bind="args" target="#tooltip-align-center" placement="top" align="center">Center aligned</vs-tooltip>
-                    <vs-button id="tooltip-align-end">End</vs-button>
-                    <vs-tooltip v-bind="args" target="#tooltip-align-end" placement="top" align="end">End aligned</vs-tooltip>
+                    <vs-tooltip v-bind="args" placement="top" align="start">
+                        <vs-button>Start</vs-button>
+                        <template #tooltip>Start aligned</template>
+                    </vs-tooltip>
+                    <vs-tooltip v-bind="args" placement="top" align="center">
+                        <vs-button>Center</vs-button>
+                        <template #tooltip>Center aligned</template>
+                    </vs-tooltip>
+                    <vs-tooltip v-bind="args" placement="top" align="end">
+                        <vs-button>End</vs-button>
+                        <template #tooltip>End aligned</template>
+                    </vs-tooltip>
                 </div>
             </div>
         `,
@@ -249,9 +312,9 @@ export const Disabled: Story = {
             return { args };
         },
         template: `
-            <vs-button id="tooltip-trigger-disabled">Hover me (disabled)</vs-button>
-            <vs-tooltip v-bind="args" target="#tooltip-trigger-disabled">
-                <span>This tooltip is disabled</span>
+            <vs-tooltip v-bind="args">
+                <vs-button>Hover me (disabled)</vs-button>
+                <template #tooltip>This tooltip is disabled</template>
             </vs-tooltip>
         `,
     }),
@@ -274,9 +337,9 @@ export const NoAnimation: Story = {
             return { args };
         },
         template: `
-            <vs-button id="tooltip-trigger-no-animation">Hover me (no animation)</vs-button>
-            <vs-tooltip v-bind="args" target="#tooltip-trigger-no-animation">
-                <span>This tooltip has no animation</span>
+            <vs-tooltip v-bind="args">
+                <vs-button>Hover me (no animation)</vs-button>
+                <template #tooltip>This tooltip has no animation</template>
             </vs-tooltip>
         `,
     }),
@@ -300,12 +363,10 @@ export const Delays: Story = {
             return { args };
         },
         template: `
-            <div style="display: flex; gap: 1rem;">
-                <vs-button id="tooltip-delayed">Delayed tooltip</vs-button>
-                <vs-tooltip v-bind="args" target="#tooltip-delayed">
-                    <span>This tooltip has delays</span>
-                </vs-tooltip>
-            </div>
+            <vs-tooltip v-bind="args">
+                <vs-button>Delayed tooltip</vs-button>
+                <template #tooltip>This tooltip has delays</template>
+            </vs-tooltip>
         `,
     }),
 };
@@ -327,8 +388,10 @@ export const ColorScheme: Story = {
         template: `
             <div style="display: flex; flex-wrap: wrap; gap: 0.5rem;">
                 ${getColorSchemeTemplate(`
-                    <vs-button id="tooltip-color-{{ color }}">{{ color }}</vs-button>
-                    <vs-tooltip v-bind="args" target="#tooltip-color-{{ color }}" color-scheme="{{ color }}">{{ color }} tooltip</vs-tooltip>
+                    <vs-tooltip v-bind="args" color-scheme="{{ color }}">
+                        <vs-button>{{ color }}</vs-button>
+                        <template #tooltip>{{ color }} tooltip</template>
+                    </vs-tooltip>
                 `)}
             </div>
         `,
@@ -349,9 +412,9 @@ export const StyleSet: Story = {
             return { args };
         },
         template: `
-            <vs-button id="tooltip-custom">Custom tooltip</vs-button>
-            <vs-tooltip v-bind="args" target="#tooltip-custom">
-                <span>Custom styled tooltip</span>
+            <vs-tooltip v-bind="args">
+                <vs-button>Custom tooltip</vs-button>
+                <template #tooltip>Custom styled tooltip</template>
             </vs-tooltip>
         `,
     }),
@@ -406,9 +469,9 @@ export const PreDefinedStyleSet: Story = {
             return { args };
         },
         template: `
-            <vs-button id="tooltip-trigger-predefined">Hover me</vs-button>
-            <vs-tooltip v-bind="args" target="#tooltip-trigger-predefined">
-                <span>This tooltip uses predefined style set</span>
+            <vs-tooltip v-bind="args">
+                <vs-button>Hover me</vs-button>
+                <template #tooltip>This tooltip uses predefined style set</template>
             </vs-tooltip>
         `,
     }),

--- a/packages/vlossom/src/components/vs-tooltip/__tests__/vs-tooltip.test.ts
+++ b/packages/vlossom/src/components/vs-tooltip/__tests__/vs-tooltip.test.ts
@@ -12,7 +12,14 @@ describe('vs-tooltip', () => {
         vi.clearAllTimers();
     });
 
-    describe('기본 렌더링', () => {
+    function cleanupOverlay() {
+        const overlay = document.querySelector('#vs-floating-overlay');
+        if (overlay) {
+            document.body.removeChild(overlay);
+        }
+    }
+
+    describe('target 모드 - 기본 렌더링', () => {
         let wrapper: ReturnType<typeof mount<typeof VsTooltip>>;
         const targetId = 'test-trigger';
 
@@ -27,7 +34,7 @@ describe('vs-tooltip', () => {
                     target: `#${targetId}`,
                 },
                 slots: {
-                    default: 'Tooltip',
+                    tooltip: 'Tooltip',
                 },
                 attachTo: document.body,
             });
@@ -39,15 +46,17 @@ describe('vs-tooltip', () => {
             if (button) {
                 document.body.removeChild(button);
             }
-            const overlay = document.querySelector('#vs-floating-overlay');
-            if (overlay) {
-                document.body.removeChild(overlay);
-            }
+            cleanupOverlay();
         });
 
         it('초기에는 tooltip이 노출되지 않는다', () => {
             //then
             expect(wrapper.vm.computedShow).toBe(false);
+        });
+
+        it('target이 지정되면 wrapper 엘리먼트는 렌더링되지 않는다', () => {
+            //then
+            expect(wrapper.find('.vs-tooltip-trigger').exists()).toBe(false);
         });
 
         it('trigger에 마우스를 올렸을 때 툴팁이 노출된다', async () => {
@@ -108,29 +117,122 @@ describe('vs-tooltip', () => {
         });
     });
 
-    describe('placement', () => {
-        it('placement을 설정하면 해당 위치에 tooltip이 붙는다', async () => {
-            //given
-            const targetId = 'test-trigger-placement';
-            const button = document.createElement('button');
-            button.id = targetId;
-            button.textContent = 'Hover Here!';
-            document.body.appendChild(button);
+    describe('slot 모드 - 기본 렌더링', () => {
+        let wrapper: ReturnType<typeof mount<typeof VsTooltip>>;
 
-            const wrapper = mount(VsTooltip, {
-                props: {
-                    target: `#${targetId}`,
-                    placement: 'bottom',
-                },
+        beforeEach(() => {
+            wrapper = mount(VsTooltip, {
                 slots: {
-                    default: 'Tooltip',
+                    default: '<button>Hover Here!</button>',
+                    tooltip: 'Tooltip',
+                },
+                attachTo: document.body,
+            });
+        });
+
+        afterEach(() => {
+            wrapper.unmount();
+            cleanupOverlay();
+        });
+
+        it('target이 없으면 default slot이 wrapper 엘리먼트로 감싸진다', () => {
+            //then
+            const wrapperEl = wrapper.find('.vs-tooltip-trigger');
+            expect(wrapperEl.exists()).toBe(true);
+            expect(wrapperEl.element.tagName.toLowerCase()).toBe('span');
+            expect(wrapperEl.text()).toBe('Hover Here!');
+        });
+
+        it('wrapper 엘리먼트에는 인스턴스마다 유니크한 클래스가 부여된다', () => {
+            //given
+            const otherWrapper = mount(VsTooltip, {
+                slots: {
+                    default: '<button>Another</button>',
+                    tooltip: 'Other tooltip',
                 },
                 attachTo: document.body,
             });
 
             //when
-            const trigger = document.getElementById(targetId);
-            trigger?.dispatchEvent(new Event('mouseenter'));
+            const classA = wrapper.find('.vs-tooltip-trigger').classes();
+            const classB = otherWrapper.find('.vs-tooltip-trigger').classes();
+            const uniqueA = classA.find((c) => c.startsWith('vs-tooltip-trigger-'));
+            const uniqueB = classB.find((c) => c.startsWith('vs-tooltip-trigger-'));
+
+            //then
+            expect(uniqueA).toBeTruthy();
+            expect(uniqueB).toBeTruthy();
+            expect(uniqueA).not.toBe(uniqueB);
+
+            //cleanup
+            otherWrapper.unmount();
+        });
+
+        it('wrapper 엘리먼트에 마우스를 올리면 툴팁이 노출된다', async () => {
+            //when
+            const trigger = wrapper.find('.vs-tooltip-trigger').element as HTMLElement;
+            trigger.dispatchEvent(new Event('mouseenter'));
+            await vi.advanceTimersByTimeAsync(0);
+            await wrapper.vm.$nextTick();
+
+            //then
+            expect(wrapper.vm.computedShow).toBe(true);
+        });
+
+        it('wrapper 엘리먼트에 마우스를 올렸다 떼면 툴팁이 사라진다', async () => {
+            //when
+            const trigger = wrapper.find('.vs-tooltip-trigger').element as HTMLElement;
+            trigger.dispatchEvent(new Event('mouseenter'));
+            await vi.advanceTimersByTimeAsync(0);
+            await wrapper.vm.$nextTick();
+            expect(wrapper.vm.computedShow).toBe(true);
+
+            trigger.dispatchEvent(new Event('mouseleave'));
+            await vi.advanceTimersByTimeAsync(0);
+            await wrapper.vm.$nextTick();
+
+            //then
+            expect(wrapper.vm.computedShow).toBe(false);
+        });
+    });
+
+    describe('slot 모드 - tag prop', () => {
+        it('tag prop으로 wrapper 엘리먼트의 태그를 변경할 수 있다', () => {
+            //given
+            const wrapper = mount(VsTooltip, {
+                props: { tag: 'div' },
+                slots: {
+                    default: 'Trigger',
+                    tooltip: 'Tooltip',
+                },
+                attachTo: document.body,
+            });
+
+            //then
+            const wrapperEl = wrapper.find('.vs-tooltip-trigger');
+            expect(wrapperEl.element.tagName.toLowerCase()).toBe('div');
+
+            //cleanup
+            wrapper.unmount();
+            cleanupOverlay();
+        });
+    });
+
+    describe('placement', () => {
+        it('placement을 설정하면 해당 위치에 tooltip이 붙는다', async () => {
+            //given
+            const wrapper = mount(VsTooltip, {
+                props: { placement: 'bottom' },
+                slots: {
+                    default: '<button>Hover</button>',
+                    tooltip: 'Tooltip',
+                },
+                attachTo: document.body,
+            });
+
+            //when
+            const trigger = wrapper.find('.vs-tooltip-trigger').element as HTMLElement;
+            trigger.dispatchEvent(new Event('mouseenter'));
             await vi.advanceTimersByTimeAsync(0);
             await wrapper.vm.$nextTick();
 
@@ -140,40 +242,25 @@ describe('vs-tooltip', () => {
 
             //cleanup
             wrapper.unmount();
-            const btn = document.getElementById(targetId);
-            if (btn) {
-                document.body.removeChild(btn);
-            }
-            const overlay = document.querySelector('#vs-floating-overlay');
-            if (overlay) {
-                document.body.removeChild(overlay);
-            }
+            cleanupOverlay();
         });
     });
 
     describe('align', () => {
         it('align을 설정하면 이에 맞게 tooltip이 정렬된다', async () => {
             //given
-            const targetId = 'test-trigger-align';
-            const button = document.createElement('button');
-            button.id = targetId;
-            button.textContent = 'Hover Here!';
-            document.body.appendChild(button);
-
             const wrapper = mount(VsTooltip, {
-                props: {
-                    target: `#${targetId}`,
-                    align: 'end',
-                },
+                props: { align: 'end' },
                 slots: {
-                    default: 'Tooltip',
+                    default: '<button>Hover</button>',
+                    tooltip: 'Tooltip',
                 },
                 attachTo: document.body,
             });
 
             //when
-            const trigger = document.getElementById(targetId);
-            trigger?.dispatchEvent(new Event('mouseenter'));
+            const trigger = wrapper.find('.vs-tooltip-trigger').element as HTMLElement;
+            trigger.dispatchEvent(new Event('mouseenter'));
             await vi.advanceTimersByTimeAsync(0);
             await wrapper.vm.$nextTick();
 
@@ -184,44 +271,29 @@ describe('vs-tooltip', () => {
 
             //cleanup
             wrapper.unmount();
-            const btn = document.getElementById(targetId);
-            if (btn) {
-                document.body.removeChild(btn);
-            }
-            const overlay = document.querySelector('#vs-floating-overlay');
-            if (overlay) {
-                document.body.removeChild(overlay);
-            }
+            cleanupOverlay();
         });
     });
 
     describe('clickable', () => {
         it('clickable이 true일 때 trigger를 클릭하면 툴팁이 노출된다', async () => {
             //given
-            const targetId = 'test-trigger-clickable';
-            const button = document.createElement('button');
-            button.id = targetId;
-            button.textContent = 'Click me';
-            document.body.appendChild(button);
-
             const wrapper = mount(VsTooltip, {
-                props: {
-                    target: `#${targetId}`,
-                    clickable: true,
-                },
+                props: { clickable: true },
                 slots: {
-                    default: 'Tooltip',
+                    default: '<button>Click me</button>',
+                    tooltip: 'Tooltip',
                 },
                 attachTo: document.body,
             });
 
             //when
-            const trigger = document.getElementById(targetId);
-            trigger?.dispatchEvent(new Event('click'));
+            const trigger = wrapper.find('.vs-tooltip-trigger').element as HTMLElement;
+            trigger.dispatchEvent(new Event('click'));
             await vi.advanceTimersByTimeAsync(0);
             await wrapper.vm.$nextTick();
 
-            trigger?.dispatchEvent(new Event('mouseenter'));
+            trigger.dispatchEvent(new Event('mouseenter'));
             await vi.advanceTimersByTimeAsync(0);
             await wrapper.vm.$nextTick();
 
@@ -230,40 +302,25 @@ describe('vs-tooltip', () => {
 
             //cleanup
             wrapper.unmount();
-            const btn = document.getElementById(targetId);
-            if (btn) {
-                document.body.removeChild(btn);
-            }
-            const overlay = document.querySelector('#vs-floating-overlay');
-            if (overlay) {
-                document.body.removeChild(overlay);
-            }
+            cleanupOverlay();
         });
     });
 
     describe('contents hover', () => {
         it('contentsHover가 true일 때 trigger에 hover한 후 tooltip으로 마우스를 옮겨도 툴팁이 유지된다', async () => {
             //given
-            const targetId = 'test-trigger-contents-hover';
-            const button = document.createElement('button');
-            button.id = targetId;
-            button.textContent = 'Hover Here!';
-            document.body.appendChild(button);
-
             const wrapper = mount(VsTooltip, {
-                props: {
-                    target: `#${targetId}`,
-                    contentsHover: true,
-                },
+                props: { contentsHover: true },
                 slots: {
-                    default: 'Tooltip',
+                    default: '<button>Hover</button>',
+                    tooltip: 'Tooltip',
                 },
                 attachTo: document.body,
             });
 
             //when
-            const trigger = document.getElementById(targetId);
-            trigger?.dispatchEvent(new Event('mouseenter'));
+            const trigger = wrapper.find('.vs-tooltip-trigger').element as HTMLElement;
+            trigger.dispatchEvent(new Event('mouseenter'));
             await vi.advanceTimersByTimeAsync(0);
             await wrapper.vm.$nextTick();
             expect(wrapper.vm.computedShow).toBe(true);
@@ -278,45 +335,29 @@ describe('vs-tooltip', () => {
 
             //cleanup
             wrapper.unmount();
-            const btn = document.getElementById(targetId);
-            if (btn) {
-                document.body.removeChild(btn);
-            }
-            const overlay = document.querySelector('#vs-floating-overlay');
-            if (overlay) {
-                document.body.removeChild(overlay);
-            }
+            cleanupOverlay();
         });
     });
 
     describe('clickable + contentsHover 조합', () => {
         it('clickable과 contentsHover가 모두 true일 때 클릭 후 툴팁으로 마우스를 옮겨도 툴팁이 유지된다', async () => {
             //given
-            const targetId = 'test-trigger-clickable-contents-hover';
-            const button = document.createElement('button');
-            button.id = targetId;
-            button.textContent = 'Hover Here!';
-            document.body.appendChild(button);
-
             const wrapper = mount(VsTooltip, {
-                props: {
-                    target: `#${targetId}`,
-                    clickable: true,
-                    contentsHover: true,
-                },
+                props: { clickable: true, contentsHover: true },
                 slots: {
-                    default: 'Tooltip',
+                    default: '<button>Hover</button>',
+                    tooltip: 'Tooltip',
                 },
                 attachTo: document.body,
             });
 
             //when
-            const trigger = document.getElementById(targetId);
-            trigger?.dispatchEvent(new Event('click'));
+            const trigger = wrapper.find('.vs-tooltip-trigger').element as HTMLElement;
+            trigger.dispatchEvent(new Event('click'));
             await vi.advanceTimersByTimeAsync(0);
             await wrapper.vm.$nextTick();
 
-            trigger?.dispatchEvent(new Event('mouseenter'));
+            trigger.dispatchEvent(new Event('mouseenter'));
             await vi.advanceTimersByTimeAsync(0);
             await wrapper.vm.$nextTick();
             expect(wrapper.vm.computedShow).toBe(true);
@@ -331,14 +372,7 @@ describe('vs-tooltip', () => {
 
             //cleanup
             wrapper.unmount();
-            const btn = document.getElementById(targetId);
-            if (btn) {
-                document.body.removeChild(btn);
-            }
-            const overlay = document.querySelector('#vs-floating-overlay');
-            if (overlay) {
-                document.body.removeChild(overlay);
-            }
+            cleanupOverlay();
         });
     });
 });

--- a/packages/vlossom/src/components/vs-tooltip/types.ts
+++ b/packages/vlossom/src/components/vs-tooltip/types.ts
@@ -16,4 +16,5 @@ export interface VsTooltipStyleSet {
     $arrowSize?: string;
 
     $tooltip?: CSSProperties;
+    $trigger?: CSSProperties;
 }


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary
VsTooltip now works in two modes:
- Target mode (existing): attach to an external element via the `target` selector
- Slot mode (new): when `target` is omitted, wrap the default slot with a configurable `tag` element (default `span`) and use it as the trigger

Tooltip content moved from the default slot to a new `#tooltip` slot. Each instance generates a unique trigger class so v-for usages are isolated.

## Description
- vs-tooltip이 예전 구현처럼 default slot을 제공하고, 감쌀 수 있는 형태로 사용 가능하게 함
  - vs-tooltip component 내부에서 id를 생성해서 target에 지정하도록 함 (수정 범위 최소화)
  - default slot 영역은 target이 지정되지 않은 경우에만 노출 (v-if 처리)
  - `.vs-tooltip trigger`로 이름 짓고, `$trigger` style-set 추가 및 bind
- test, README, storybook 수정

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
