### PR TITLE
feat(VsTabs, VsSteps): add visible keyboard focus indicators

### DIFF
--- a/packages/vlossom/src/components/vs-steps/VsSteps.css
+++ b/packages/vlossom/src/components/vs-steps/VsSteps.css
@@ -42,6 +42,13 @@
                 @apply outline-none;
             }
 
+            &:focus-visible:not(.vs-disabled) {
+                .vs-step-num {
+                    outline-offset: 6px;
+                    box-shadow: 0 0 0 3px var(--vs-cs-bg-primary);
+                }
+            }
+
             .vs-step-num {
                 @apply flex items-center justify-center font-semibold;
 

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.css
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.css
@@ -150,6 +150,10 @@
                     color: var(--vs-cs-font-primary);
                 }
 
+                .vs-tab-item.vs-selected:focus-visible:not(.vs-disabled) {
+                    outline-color: var(--vs-cs-font-primary);
+                }
+
                 .vs-tab-indicator {
                     border-color: var(--vs-cs-bg-primary);
                     background-color: var(--vs-cs-bg-primary);

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.css
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.css
@@ -35,6 +35,7 @@
                     whitespace-nowrap;
 
                 transition: var(--tab-transition);
+                transition-property: border-color, background-color, color;
                 border: var(--tab-border);
                 border-bottom: transparent;
                 border-top-right-radius: var(--tab-radius);
@@ -50,6 +51,11 @@
 
                 &:focus {
                     @apply outline-none;
+                }
+
+                &:focus-visible:not(.vs-disabled) {
+                    outline: 1px solid var(--vs-cs-line);
+                    outline-offset: -3px;
                 }
             }
 


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary
vs-tabs, vs-steps에 focus가 있을 때 indicator를 추가합니다

## Description
- vs-tabs는 안쪽 outline으로 표시
<img width="441" height="113" alt="image" src="https://github.com/user-attachments/assets/42f752c5-fce3-4e66-b3fc-37ac9a25d6e3" />

<img width="448" height="116" alt="image" src="https://github.com/user-attachments/assets/6463d942-1597-46f2-8c7d-9942c62abee0" />


- vs-steps는 선택 상태가 더 커지는 방식으로 표시
<img width="417" height="152" alt="image" src="https://github.com/user-attachments/assets/ba0044dd-dccf-4c75-ab5f-d8851e0d7192" />


<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
