### PR TITLE
fix(VsTable): remove asterisk style in vs-table

### DIFF
--- a/packages/vlossom/src/components/vs-table/VsTable.css
+++ b/packages/vlossom/src/components/vs-table/VsTable.css
@@ -75,10 +75,6 @@
             border-right: 1px solid var(--vs-cs-line);
             border-top-right-radius: calc(var(--vs-radius-ratio) * var(--vs-radius-md));
         }
-
-        > * {
-            @apply w-full;
-        }
     }
 
     .vs-table-td {
@@ -87,17 +83,6 @@
         border-top: 1px solid var(--vs-cs-line);
         padding: 0.6rem 0.8rem;
         text-align: left;
-
-        > * {
-            @apply w-full;
-        }
-    }
-
-    .vs-table-th,
-    .vs-table-td {
-        * {
-            min-height: unset;
-        }
     }
 
     /* ── Body rows ── */
@@ -206,9 +191,7 @@
         .vs-table-th,
         .vs-table-td {
             @apply px-[0.375rem] py-[0.5rem];
-            * {
-                font-size: var(--vs-font-size-sm);
-            }
+            font-size: var(--vs-font-size-sm);
         }
 
         .vs-table-td.vs-table-expanded-row {
@@ -281,9 +264,7 @@
             .vs-table-td,
             .vs-table-th {
                 @apply px-[0.375rem] py-[0.5rem];
-                * {
-                    font-size: var(--vs-font-size-sm);
-                }
+                font-size: var(--vs-font-size-sm);
             }
         }
 


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
vs-table에 있는 `*` style이 하위에 들어가는 conents의 스타일에도 영향을 줘서 의도치 않은 문제를 발생시켜서 불필요한 asterisk 스타일을 모두 제거함

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
