### PR TITLE
feat(modal-plugin): support componentProps for rendered components

### DIFF
--- a/packages/vlossom/src/components/vs-modal/VsModalView.vue
+++ b/packages/vlossom/src/components/vs-modal/VsModalView.vue
@@ -17,7 +17,7 @@
                 :size="modal.size"
                 @close="onClose(modal.id)"
             >
-                <vs-render :content="modal.content" />
+                <vs-render :content="modal.content" :component-props="modal.componentProps" />
             </vs-modal-node>
         </TransitionGroup>
     </div>

--- a/packages/vlossom/src/components/vs-render/README.ko.md
+++ b/packages/vlossom/src/components/vs-render/README.ko.md
@@ -11,6 +11,7 @@
 - 일반 텍스트, HTML 문자열, Vue 컴포넌트, 렌더 함수 렌더링 지원
 - `DOMParser`를 사용하여 HTML 문자열을 파싱하고 Vue 가상 DOM으로 변환
 - `attrs`를 통해 루트 렌더링 요소에 HTML 속성 전달
+- `componentProps`로 컴포넌트 콘텐츠에 명시적 props 전달
 - 일반 텍스트 또는 파싱 실패 시 `<span>` 래퍼로 폴백
 
 ## 기본 사용법
@@ -43,11 +44,26 @@ import MyIcon from './MyIcon.vue';
 </script>
 ```
 
+### 컴포넌트에 Props 전달
+
+```html
+<template>
+    <vs-render :content="Greeting" :component-props="{ name: 'world', count: 3 }" />
+</template>
+
+<script setup>
+import Greeting from './Greeting.vue';
+</script>
+```
+
+`componentProps`는 `content`가 컴포넌트일 때만 적용되며, 문자열 콘텐츠에서는 무시됩니다.
+
 ## Props
 
-| Prop      | Type                        | Default | Required | 설명                                                    |
-| --------- | --------------------------- | ------- | -------- | ------------------------------------------------------- |
-| `content` | `string \| Component`       | -       | Yes      | 렌더링할 콘텐츠: 문자열, HTML 문자열, 또는 Vue 컴포넌트 |
+| Prop             | Type                        | Default | Required | 설명                                                    |
+| ---------------- | --------------------------- | ------- | -------- | ------------------------------------------------------- |
+| `content`        | `string \| Component`       | -       | Yes      | 렌더링할 콘텐츠: 문자열, HTML 문자열, 또는 Vue 컴포넌트 |
+| `componentProps` | `Record<string, any>`       | `{}`    | -        | 렌더링되는 컴포넌트에 전달할 props. `content`가 문자열인 경우 무시됩니다. |
 
 ## Types
 

--- a/packages/vlossom/src/components/vs-render/README.md
+++ b/packages/vlossom/src/components/vs-render/README.md
@@ -11,6 +11,7 @@ A utility component that renders a string (HTML), a Vue component, or a render f
 - Renders plain text, HTML strings, Vue components, and render functions
 - Parses HTML strings using `DOMParser` and converts them to Vue virtual DOM
 - Passes through HTML attributes via `attrs` to the root rendered element
+- Forwards explicit props to component content via `componentProps`
 - Falls back to a `<span>` wrapper for plain text or parse failures
 
 ## Basic Usage
@@ -43,11 +44,26 @@ import MyIcon from './MyIcon.vue';
 </script>
 ```
 
+### Render a Component with Props
+
+```html
+<template>
+    <vs-render :content="Greeting" :component-props="{ name: 'world', count: 3 }" />
+</template>
+
+<script setup>
+import Greeting from './Greeting.vue';
+</script>
+```
+
+`componentProps` only applies when `content` is a component. For string content it is ignored.
+
 ## Props
 
-| Prop      | Type                        | Default | Required | Description                                           |
-| --------- | --------------------------- | ------- | -------- | ----------------------------------------------------- |
-| `content` | `string \| Component`       | -       | Yes      | Content to render: a string, HTML string, or Vue component |
+| Prop             | Type                        | Default | Required | Description                                           |
+| ---------------- | --------------------------- | ------- | -------- | ----------------------------------------------------- |
+| `content`        | `string \| Component`       | -       | Yes      | Content to render: a string, HTML string, or Vue component |
+| `componentProps` | `Record<string, any>`       | `{}`    | -        | Props forwarded to the rendered component. Ignored when `content` is a string. |
 
 ## Types
 

--- a/packages/vlossom/src/components/vs-render/VsRender.vue
+++ b/packages/vlossom/src/components/vs-render/VsRender.vue
@@ -10,22 +10,21 @@ export default defineComponent({
             type: [String, Object, Function] as PropType<string | Component>,
             required: true,
         },
+        componentProps: {
+            type: Object as PropType<Record<string, any>>,
+            default: () => ({}),
+        },
     },
-    setup(props, { attrs }) {
-        const { content } = toRefs(props);
+    setup(props) {
+        const { content, componentProps } = toRefs(props);
 
         // 요소를 재귀적으로 렌더링하는 함수 (최상위부터)
-        function renderElement(element: Element, isRoot: boolean = false) {
+        function renderElement(element: Element) {
             // 요소의 속성들을 객체로 변환
             const attributes: Record<string, any> = {};
             Array.from(element.attributes).forEach((attr) => {
                 attributes[attr.name] = attr.value;
             });
-
-            // 최상위 엘리먼트인 경우 attrs를 병합
-            if (isRoot) {
-                Object.assign(attributes, attrs);
-            }
 
             // 하위 노드들을 처리
             const children: any[] = [];
@@ -46,7 +45,7 @@ export default defineComponent({
         function renderStringAsComponent(htmlString: string) {
             // HTML 태그가 없는 경우 텍스트만 렌더링
             if (!htmlString || !/<[^>]*>/.test(htmlString)) {
-                return () => h('span', attrs, htmlString);
+                return () => h('span', null, htmlString);
             }
             // HTML이 있는 경우 파싱하여 적절한 태그로 렌더링
             try {
@@ -59,13 +58,13 @@ export default defineComponent({
                 const element = doc.body.firstElementChild;
 
                 if (!element) {
-                    return () => h('span', attrs, htmlString);
+                    return () => h('span', null, htmlString);
                 }
 
-                return () => renderElement(element, true);
+                return () => renderElement(element);
             } catch {
                 // 파싱 실패 시 텍스트 렌더링
-                return () => h('span', attrs, htmlString);
+                return () => h('span', null, htmlString);
             }
         }
 
@@ -74,7 +73,7 @@ export default defineComponent({
                 const componentFn = renderStringAsComponent(content.value);
                 return componentFn();
             }
-            return h(content.value, attrs);
+            return h(content.value, componentProps.value);
         };
     },
 });

--- a/packages/vlossom/src/components/vs-render/__tests__/vs-render.test.ts
+++ b/packages/vlossom/src/components/vs-render/__tests__/vs-render.test.ts
@@ -137,6 +137,102 @@ describe('VsRender', () => {
         });
     });
 
+    describe('componentProps 바인딩', () => {
+        it('컴포넌트 content에 componentProps가 전달되어야 한다', () => {
+            //given
+            const TestComponent = markRaw({
+                props: ['message', 'count'],
+                template: '<div class="test-component">{{ message }} - {{ count }}</div>',
+            });
+
+            const wrapper = mount(VsRender, {
+                props: {
+                    content: TestComponent,
+                    componentProps: { message: '안녕', count: 3 },
+                },
+            });
+
+            expect(wrapper.find('.test-component').text()).toBe('안녕 - 3');
+        });
+
+        it('componentProps와 attrs가 동시에 주어지면 둘 다 컴포넌트에 전달되어야 한다', () => {
+            //given
+            const TestComponent = markRaw({
+                props: ['message'],
+                template: '<div class="test-component">{{ message }}</div>',
+            });
+
+            const wrapper = mount(VsRender, {
+                props: {
+                    content: TestComponent,
+                    componentProps: { message: 'from props' },
+                },
+                attrs: {
+                    id: 'attr-id',
+                },
+            });
+
+            expect(wrapper.find('.test-component').text()).toBe('from props');
+            expect(wrapper.find('.test-component').attributes('id')).toBe('attr-id');
+        });
+
+        it('동일한 키가 attrs와 componentProps 모두에 있으면 attrs가 우선되어야 한다 (Vue 기본 동작)', () => {
+            //given
+            const TestComponent = markRaw({
+                props: ['message'],
+                template: '<div class="test-component">{{ message }}</div>',
+            });
+
+            const wrapper = mount(VsRender, {
+                props: {
+                    content: TestComponent,
+                    componentProps: { message: 'from componentProps' },
+                },
+                attrs: {
+                    message: 'from attrs',
+                },
+            });
+
+            expect(wrapper.find('.test-component').text()).toBe('from attrs');
+        });
+
+        it('문자열 content가 주어지면 componentProps가 무시되고 attrs만 적용되어야 한다', () => {
+            //given
+            const wrapper = mount(VsRender, {
+                props: {
+                    content: '<div class="text">텍스트</div>',
+                    componentProps: { id: 'ignored', message: 'ignored' },
+                },
+                attrs: {
+                    'data-test': 'value',
+                },
+            });
+
+            // componentProps는 DOM에 새지 않음
+            expect(wrapper.find('.text').attributes('id')).toBeUndefined();
+            expect(wrapper.find('.text').attributes('message')).toBeUndefined();
+            // attrs는 정상 적용 (자동 상속)
+            expect(wrapper.find('.text').attributes('data-test')).toBe('value');
+        });
+
+        it('HTML 문자열의 class와 부모 attrs의 class가 자동 머지되어야 한다', () => {
+            //given
+            const wrapper = mount(VsRender, {
+                props: {
+                    content: '<button class="btn-primary">Click</button>',
+                },
+                attrs: {
+                    class: 'size-4',
+                },
+            });
+
+            // 자동 상속이 class를 머지: btn-primary + size-4
+            const classes = wrapper.find('button').classes();
+            expect(classes).toContain('btn-primary');
+            expect(classes).toContain('size-4');
+        });
+    });
+
     describe('attrs 바인딩', () => {
         it('문자열 content와 attrs가 주어지고, attrs가 최상위 엘리먼트에 바인딩되어야 한다', () => {
             //given

--- a/packages/vlossom/src/plugins/alert-plugin/README.ko.md
+++ b/packages/vlossom/src/plugins/alert-plugin/README.ko.md
@@ -35,6 +35,24 @@ async function showAlert() {
 </script>
 ```
 
+### Vue 컴포넌트와 Props 전달
+
+```html
+<script setup>
+import { useVlossom } from 'vlossom';
+import AlertBody from './AlertBody.vue';
+
+const $vs = useVlossom();
+
+function showCustomAlert() {
+    $vs.alert.open(AlertBody, {
+        componentProps: { title: '알림', icon: 'info' },
+        okText: '확인',
+    });
+}
+</script>
+```
+
 ### 커스텀 확인 텍스트 및 스타일
 
 ```html
@@ -77,7 +95,8 @@ interface AlertModalOptions extends ModalOptions {
 }
 
 interface AlertPlugin {
-    open(content: string | Component, options?: AlertModalOptions): Promise<void>;
+    open(content: string, options?: Omit<AlertModalOptions, 'componentProps'>): Promise<void>;
+    open(content: Component, options?: AlertModalOptions): Promise<void>;
 }
 ```
 

--- a/packages/vlossom/src/plugins/alert-plugin/README.md
+++ b/packages/vlossom/src/plugins/alert-plugin/README.md
@@ -35,6 +35,24 @@ async function showAlert() {
 </script>
 ```
 
+### Using a Vue Component with Props
+
+```html
+<script setup>
+import { useVlossom } from 'vlossom';
+import AlertBody from './AlertBody.vue';
+
+const $vs = useVlossom();
+
+function showCustomAlert() {
+    $vs.alert.open(AlertBody, {
+        componentProps: { title: 'Notice', icon: 'info' },
+        okText: 'OK',
+    });
+}
+</script>
+```
+
 ### Custom OK Text and Style
 
 ```html
@@ -77,7 +95,8 @@ interface AlertModalOptions extends ModalOptions {
 }
 
 interface AlertPlugin {
-    open(content: string | Component, options?: AlertModalOptions): Promise<void>;
+    open(content: string, options?: Omit<AlertModalOptions, 'componentProps'>): Promise<void>;
+    open(content: Component, options?: AlertModalOptions): Promise<void>;
 }
 ```
 

--- a/packages/vlossom/src/plugins/alert-plugin/__stories__/alert-plugin.stories.ts
+++ b/packages/vlossom/src/plugins/alert-plugin/__stories__/alert-plugin.stories.ts
@@ -1,6 +1,22 @@
+import { defineComponent, h } from 'vue';
 import type { Meta, StoryObj } from '@storybook/vue3-vite';
 import { useVlossom } from '@/framework';
 import VsButton from '@/components/vs-button/VsButton.vue';
+
+const AlertBody = defineComponent({
+    name: 'AlertBody',
+    props: {
+        title: { type: String, default: 'Notice' },
+        message: { type: String, default: '' },
+    },
+    setup(props) {
+        return () =>
+            h('div', { style: { textAlign: 'center' } }, [
+                h('h3', { style: { marginBottom: '0.5rem', fontWeight: 600 } }, props.title),
+                h('p', props.message),
+            ]);
+    },
+});
 
 const meta: Meta = {
     title: 'Plugins/Alert Plugin',
@@ -53,6 +69,36 @@ export const Default: Story = {
                     <vs-button @click="handleOpenBasic">Open Alert</vs-button>
                     <vs-button color-scheme="emerald" @click="handleOpenCustom">Open Alert (Custom)</vs-button>
                 </div>
+            </div>
+        `,
+    }),
+};
+
+export const WithComponentProps: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'componentProps로 알림 컴포넌트에 props를 전달하는 예시입니다.',
+            },
+        },
+    },
+    render: () => ({
+        components: { VsButton },
+        setup() {
+            const $vs = useVlossom();
+
+            async function handleOpen() {
+                await $vs.alert.open(AlertBody, {
+                    componentProps: { title: '저장 완료', message: '변경 내용이 안전하게 저장되었습니다.' },
+                    okText: '확인',
+                });
+            }
+
+            return { handleOpen };
+        },
+        template: `
+            <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
+                <vs-button @click="handleOpen">Open Alert (with componentProps)</vs-button>
             </div>
         `,
     }),

--- a/packages/vlossom/src/plugins/alert-plugin/__tests__/alert-plugin.test.ts
+++ b/packages/vlossom/src/plugins/alert-plugin/__tests__/alert-plugin.test.ts
@@ -53,4 +53,17 @@ describe('alert-plugin', () => {
         await expect(promise).resolves.toBeUndefined();
         expect(closeWithId).toHaveBeenCalledWith('body', 'modal-id');
     });
+
+    it('componentProps는 modalPlugin.open에 전달되지 않아야 한다', () => {
+        const alertPlugin = createAlertPlugin(modalPlugin);
+        const { defineComponent } = require('vue');
+        const SomeComp = defineComponent({ template: '<div />' });
+
+        alertPlugin.open(SomeComp, { componentProps: { foo: 'bar' }, okText: '확인' });
+
+        const callArgs = (modalPlugin.open as any).mock.calls[0];
+        const passedOptions = callArgs[1];
+        expect(passedOptions.componentProps).toBeUndefined();
+        expect(passedOptions.okText).toBe('확인');
+    });
 });

--- a/packages/vlossom/src/plugins/alert-plugin/__tests__/alert-plugin.test.ts
+++ b/packages/vlossom/src/plugins/alert-plugin/__tests__/alert-plugin.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { defineComponent } from 'vue';
 import { ALERT_OK } from '@/declaration';
 import { createAlertPlugin } from './../alert-plugin';
 import type { ModalPlugin } from '@/plugins/modal-plugin';
@@ -56,7 +57,6 @@ describe('alert-plugin', () => {
 
     it('componentProps는 modalPlugin.open에 전달되지 않아야 한다', () => {
         const alertPlugin = createAlertPlugin(modalPlugin);
-        const { defineComponent } = require('vue');
         const SomeComp = defineComponent({ template: '<div />' });
 
         alertPlugin.open(SomeComp, { componentProps: { foo: 'bar' }, okText: '확인' });

--- a/packages/vlossom/src/plugins/alert-plugin/alert-plugin.ts
+++ b/packages/vlossom/src/plugins/alert-plugin/alert-plugin.ts
@@ -19,7 +19,8 @@ export function createAlertPlugin(modalPlugin: ModalPlugin): AlertPlugin {
 
     return {
         open(content: string | Component, options: AlertModalOptions = {}): Promise<void> {
-            const { container = 'body', colorScheme, styleSet, okText = 'OK' } = options;
+            const { componentProps, ...modalOptions } = options;
+            const { container = 'body', colorScheme, styleSet, okText = 'OK' } = modalOptions;
 
             const buttonsClass = ['flex', 'w-full', 'items-center', 'justify-center', 'gap-2'];
             const contentClass = ['flex', 'h-full', 'flex-col', 'items-center', 'justify-center', 'gap-12', 'pt-6'];
@@ -30,15 +31,15 @@ export function createAlertPlugin(modalPlugin: ModalPlugin): AlertPlugin {
                 onClickEvent: handleOk,
             });
 
-            const contents = h(VsRender, { content });
+            const contents = h(VsRender, { content, componentProps });
             const buttons = h('div', { class: buttonsClass, style: styleSet?.$buttons }, [okButton]);
             const alert = h('div', { class: contentClass }, [contents, buttons]);
 
             return new Promise((resolve) => {
                 const modalId = modalPlugin.open(alert, {
-                    ...options,
+                    ...modalOptions,
                     callbacks: {
-                        ...options?.callbacks,
+                        ...modalOptions.callbacks,
                         [ALERT_OK]: () => {
                             resolve();
                             modalPlugin.closeWithId(container, modalId);

--- a/packages/vlossom/src/plugins/alert-plugin/types.ts
+++ b/packages/vlossom/src/plugins/alert-plugin/types.ts
@@ -15,5 +15,6 @@ export interface AlertModalOptions extends Omit<ModalOptions, 'beforeClose'> {
 }
 
 export interface AlertPlugin {
-    open(content: string | Component, options?: AlertModalOptions): Promise<void>;
+    open(content: string, options?: Omit<AlertModalOptions, 'componentProps'>): Promise<void>;
+    open(content: Component, options?: AlertModalOptions): Promise<void>;
 }

--- a/packages/vlossom/src/plugins/confirm-plugin/README.ko.md
+++ b/packages/vlossom/src/plugins/confirm-plugin/README.ko.md
@@ -40,6 +40,25 @@ async function handleDelete() {
 </script>
 ```
 
+### Vue 컴포넌트와 Props 전달
+
+```html
+<script setup>
+import { useVlossom } from 'vlossom';
+import ConfirmBody from './ConfirmBody.vue';
+
+const $vs = useVlossom();
+
+async function confirmDelete(item) {
+    const ok = await $vs.confirm.open(ConfirmBody, {
+        componentProps: { item, severity: 'high' },
+        okText: '삭제',
+        cancelText: '취소',
+    });
+}
+</script>
+```
+
 ### 커스텀 버튼 텍스트 및 스타일
 
 ```html
@@ -87,7 +106,8 @@ interface ConfirmModalOptions extends ModalOptions {
 }
 
 interface ConfirmPlugin {
-    open(content: string | Component, options?: ConfirmModalOptions): Promise<boolean>;
+    open(content: string, options?: Omit<ConfirmModalOptions, 'componentProps'>): Promise<boolean>;
+    open(content: Component, options?: ConfirmModalOptions): Promise<boolean>;
 }
 ```
 

--- a/packages/vlossom/src/plugins/confirm-plugin/README.md
+++ b/packages/vlossom/src/plugins/confirm-plugin/README.md
@@ -40,6 +40,25 @@ async function handleDelete() {
 </script>
 ```
 
+### Using a Vue Component with Props
+
+```html
+<script setup>
+import { useVlossom } from 'vlossom';
+import ConfirmBody from './ConfirmBody.vue';
+
+const $vs = useVlossom();
+
+async function confirmDelete(item) {
+    const ok = await $vs.confirm.open(ConfirmBody, {
+        componentProps: { item, severity: 'high' },
+        okText: 'Delete',
+        cancelText: 'Cancel',
+    });
+}
+</script>
+```
+
 ### Custom Button Text and Style
 
 ```html
@@ -87,7 +106,8 @@ interface ConfirmModalOptions extends ModalOptions {
 }
 
 interface ConfirmPlugin {
-    open(content: string | Component, options?: ConfirmModalOptions): Promise<boolean>;
+    open(content: string, options?: Omit<ConfirmModalOptions, 'componentProps'>): Promise<boolean>;
+    open(content: Component, options?: ConfirmModalOptions): Promise<boolean>;
 }
 ```
 

--- a/packages/vlossom/src/plugins/confirm-plugin/__stories__/confirm-plugin.stories.ts
+++ b/packages/vlossom/src/plugins/confirm-plugin/__stories__/confirm-plugin.stories.ts
@@ -1,7 +1,27 @@
-import { ref } from 'vue';
+import { defineComponent, h, ref } from 'vue';
 import type { Meta, StoryObj } from '@storybook/vue3-vite';
 import { useVlossom } from '@/framework';
 import VsButton from '@/components/vs-button/VsButton.vue';
+
+const ConfirmBody = defineComponent({
+    name: 'ConfirmBody',
+    props: {
+        itemName: { type: String, default: '' },
+        severity: { type: String as () => 'low' | 'high', default: 'low' },
+    },
+    setup(props) {
+        return () =>
+            h('div', { style: { textAlign: 'center' } }, [
+                h('h3', { style: { marginBottom: '0.5rem', fontWeight: 600 } }, '항목 삭제 확인'),
+                h('p', `대상: ${props.itemName}`),
+                h(
+                    'p',
+                    { style: { color: props.severity === 'high' ? '#dc2626' : '#4b5563' } },
+                    props.severity === 'high' ? '이 작업은 되돌릴 수 없습니다.' : '계속 진행할까요?',
+                ),
+            ]);
+    },
+});
 
 const meta: Meta = {
     title: 'Plugins/Confirm Plugin',
@@ -61,6 +81,45 @@ export const Default: Story = {
                 <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
                     <vs-button @click="handleOpenDefault">Open Confirm</vs-button>
                     <vs-button color-scheme="red" @click="handleOpenCustom">Open Confirm (Danger)</vs-button>
+                </div>
+                <div style="font-size: 0.875rem; color: var(--vs-gray-700, #4b5563);">
+                    {{ resultText }}
+                </div>
+            </div>
+        `,
+    }),
+};
+
+export const WithComponentProps: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'componentProps로 확인 다이얼로그 컴포넌트에 props를 전달하는 예시입니다.',
+            },
+        },
+    },
+    render: () => ({
+        components: { VsButton },
+        setup() {
+            const $vs = useVlossom();
+            const resultText = ref('아직 응답 없음');
+
+            async function handleOpen() {
+                const ok = await $vs.confirm.open(ConfirmBody, {
+                    componentProps: { itemName: 'report-2025.pdf', severity: 'high' },
+                    colorScheme: 'red',
+                    okText: '삭제',
+                    cancelText: '취소',
+                });
+                resultText.value = ok ? '삭제 진행' : '삭제 취소';
+            }
+
+            return { handleOpen, resultText };
+        },
+        template: `
+            <div style="display: flex; flex-direction: column; gap: 0.75rem; max-width: 320px;">
+                <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
+                    <vs-button color-scheme="red" @click="handleOpen">Open Confirm (with componentProps)</vs-button>
                 </div>
                 <div style="font-size: 0.875rem; color: var(--vs-gray-700, #4b5563);">
                     {{ resultText }}

--- a/packages/vlossom/src/plugins/confirm-plugin/confirm-plugin.ts
+++ b/packages/vlossom/src/plugins/confirm-plugin/confirm-plugin.ts
@@ -20,6 +20,7 @@ export function createConfirmPlugin(modalPlugin: ModalPlugin): ConfirmPlugin {
 
     return {
         open(content: string | Component, options: ConfirmModalOptions = {}): Promise<boolean> {
+            const { componentProps, ...modalOptions } = options;
             const {
                 container = 'body',
                 colorScheme,
@@ -27,7 +28,7 @@ export function createConfirmPlugin(modalPlugin: ModalPlugin): ConfirmPlugin {
                 okText = 'OK',
                 cancelText = 'Cancel',
                 swapButtons,
-            } = options;
+            } = modalOptions;
 
             const okButton = vnodeUtils.createVsButton({
                 props: { colorScheme, styleSet: styleSet?.$okButton, primary: true },
@@ -44,7 +45,7 @@ export function createConfirmPlugin(modalPlugin: ModalPlugin): ConfirmPlugin {
             const buttonsClass = ['flex', 'w-full', 'items-center', 'justify-center', 'gap-2'];
             const contentClass = ['flex', 'h-full', 'flex-col', 'items-center', 'justify-center', 'gap-12', 'pt-6'];
 
-            const contents = h(VsRender, { content });
+            const contents = h(VsRender, { content, componentProps });
             const buttons = h(
                 'div',
                 { class: [...buttonsClass, swapButtons && 'flex-row-reverse'], style: styleSet?.$buttons },
@@ -54,9 +55,9 @@ export function createConfirmPlugin(modalPlugin: ModalPlugin): ConfirmPlugin {
 
             return new Promise((resolve) => {
                 const modalId = modalPlugin.open(confirm, {
-                    ...options,
+                    ...modalOptions,
                     callbacks: {
-                        ...options?.callbacks,
+                        ...modalOptions.callbacks,
                         [CONFIRM_OK]: () => {
                             resolve(true);
                             modalPlugin.closeWithId(container, modalId);

--- a/packages/vlossom/src/plugins/confirm-plugin/types.ts
+++ b/packages/vlossom/src/plugins/confirm-plugin/types.ts
@@ -18,5 +18,6 @@ export interface ConfirmModalOptions extends Omit<ModalOptions, 'beforeClose'> {
 }
 
 export interface ConfirmPlugin {
-    open(content: string | Component, options?: ConfirmModalOptions): Promise<boolean>;
+    open(content: string, options?: Omit<ConfirmModalOptions, 'componentProps'>): Promise<boolean>;
+    open(content: Component, options?: ConfirmModalOptions): Promise<boolean>;
 }

--- a/packages/vlossom/src/plugins/modal-plugin/README.ko.md
+++ b/packages/vlossom/src/plugins/modal-plugin/README.ko.md
@@ -60,6 +60,26 @@ function openModal() {
 </script>
 ```
 
+### 컴포넌트에 Props 전달
+
+`componentProps`로 렌더링되는 컴포넌트에 props를 전달할 수 있습니다. `content`가 컴포넌트일 때만 적용되며, 문자열인 경우 무시됩니다.
+
+```html
+<script setup>
+import { useVlossom } from 'vlossom';
+import UserProfile from './UserProfile.vue';
+
+const $vs = useVlossom();
+
+function openProfile(userId) {
+    $vs.modal.open(UserProfile, {
+        componentProps: { userId, editable: true },
+        size: 'md',
+    });
+}
+</script>
+```
+
 ### ID로 모달 닫기
 
 ```html
@@ -88,7 +108,7 @@ function closeModal() {
 
 | 메서드          | 파라미터                                                                   | 설명                                                                                                     |
 | --------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `open`          | `content: string \| Component, options?: ModalOptions`      | 주어진 콘텐츠와 옵션으로 모달을 엽니다. 모달의 고유 문자열 ID를 반환합니다.                             |
+| `open`          | `content: string \| Component, options?: ModalOptions`      | 주어진 콘텐츠와 옵션으로 모달을 엽니다. 모달의 고유 문자열 ID를 반환합니다. `content`가 컴포넌트인 경우 옵션의 `componentProps`로 props를 전달할 수 있습니다. |
 | `emit`          | `eventName: string, ...args: any[]`                                        | 가장 최근에 열린 모달의 콜백 스토어에 이름이 있는 이벤트를 emit합니다.                                  |
 | `emitWithId`    | `id: string, eventName: string, ...args: any[]`                            | ID로 특정 모달에 이름이 있는 이벤트를 emit합니다.                                                       |
 | `close`         | `container?: string`                                                       | 주어진 컨테이너(기본값: `'body'`)에서 가장 최근에 열린 모달을 닫습니다. 실제로 닫혔는지를 `Promise<boolean>`으로 반환합니다 (`beforeClose`가 `false`를 반환하면 닫기를 취소). |
@@ -110,11 +130,13 @@ interface ModalOptions {
     focusLock?: boolean;
     hideScroll?: boolean;
     id?: string;
+    componentProps?: Record<string, any>;
     size?: SizeProp | { width?: SizeProp; height?: SizeProp };
 }
 
 interface ModalPlugin {
-    open(content: string | Component, options?: ModalOptions): string;
+    open(content: string, options?: Omit<ModalOptions, 'componentProps'>): string;
+    open(content: Component, options?: ModalOptions): string;
     emit(eventName: string, ...args: any[]): void | Promise<void>;
     emitWithId(id: string, eventName: string, ...args: any[]): void | Promise<void>;
     close(container?: string): Promise<boolean>;

--- a/packages/vlossom/src/plugins/modal-plugin/README.md
+++ b/packages/vlossom/src/plugins/modal-plugin/README.md
@@ -60,6 +60,26 @@ function openModal() {
 </script>
 ```
 
+### Passing Props to the Component
+
+Use `componentProps` to forward props to the rendered component. Only applies when `content` is a component — ignored for string content.
+
+```html
+<script setup>
+import { useVlossom } from 'vlossom';
+import UserProfile from './UserProfile.vue';
+
+const $vs = useVlossom();
+
+function openProfile(userId) {
+    $vs.modal.open(UserProfile, {
+        componentProps: { userId, editable: true },
+        size: 'md',
+    });
+}
+</script>
+```
+
 ### Closing a Modal by ID
 
 ```html
@@ -88,7 +108,7 @@ function closeModal() {
 
 | Method          | Parameters                                                                 | Description                                                                                                   |
 | --------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `open`          | `content: string \| Component, options?: ModalOptions`      | Opens a modal with the given content and options. Returns the modal's unique string ID.                       |
+| `open`          | `content: string \| Component, options?: ModalOptions`      | Opens a modal with the given content and options. Returns the modal's unique string ID. When `content` is a component, pass `componentProps` in options to forward props. |
 | `emit`          | `eventName: string, ...args: any[]`                                        | Emits a named event on the most recently opened modal's callback store.                                       |
 | `emitWithId`    | `id: string, eventName: string, ...args: any[]`                            | Emits a named event on a specific modal by its ID.                                                            |
 | `close`         | `container?: string`                                                       | Closes the most recently opened modal in the given container (defaults to `'body'`). Returns `Promise<boolean>` indicating whether the modal actually closed (a `beforeClose` hook can abort by resolving `false`). |
@@ -110,11 +130,13 @@ interface ModalOptions {
     focusLock?: boolean;
     hideScroll?: boolean;
     id?: string;
+    componentProps?: Record<string, any>;
     size?: SizeProp | { width?: SizeProp; height?: SizeProp };
 }
 
 interface ModalPlugin {
-    open(content: string | Component, options?: ModalOptions): string;
+    open(content: string, options?: Omit<ModalOptions, 'componentProps'>): string;
+    open(content: Component, options?: ModalOptions): string;
     emit(eventName: string, ...args: any[]): void | Promise<void>;
     emitWithId(id: string, eventName: string, ...args: any[]): void | Promise<void>;
     close(container?: string): Promise<boolean>;

--- a/packages/vlossom/src/plugins/modal-plugin/__stories__/modal-plugin.stories.ts
+++ b/packages/vlossom/src/plugins/modal-plugin/__stories__/modal-plugin.stories.ts
@@ -1,6 +1,22 @@
+import { defineComponent, h } from 'vue';
 import type { Meta, StoryObj } from '@storybook/vue3-vite';
 import { useVlossom } from '@/framework';
 import VsButton from '@/components/vs-button/VsButton.vue';
+
+const Greeting = defineComponent({
+    name: 'Greeting',
+    props: {
+        name: { type: String, default: 'unknown' },
+        count: { type: Number, default: 0 },
+    },
+    setup(props) {
+        return () =>
+            h('div', { style: { padding: '1rem', textAlign: 'center' } }, [
+                h('p', `Hello, ${props.name}!`),
+                h('p', `count = ${props.count}`),
+            ]);
+    },
+});
 
 const meta: Meta = {
     title: 'Plugins/Modal Plugin',
@@ -80,6 +96,36 @@ export const Default: Story = {
                 <vs-button outline @click="handleClose">Close</vs-button>
                 <vs-button outline @click="handleCloseWithId">Close (With ID)</vs-button>
                 <vs-button outline @click="handleClear">Clear</vs-button>
+            </div>
+        `,
+    }),
+};
+
+export const WithComponentProps: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'componentProps로 컴포넌트에 props를 전달하는 예시입니다.',
+            },
+        },
+    },
+    render: () => ({
+        components: { VsButton },
+        setup() {
+            const $vs = useVlossom();
+
+            function openWithProps() {
+                $vs.modal.open(Greeting, {
+                    componentProps: { name: 'Modal', count: 42 },
+                    size: 'sm',
+                });
+            }
+
+            return { openWithProps };
+        },
+        template: `
+            <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
+                <vs-button @click="openWithProps">Open (with componentProps)</vs-button>
             </div>
         `,
     }),

--- a/packages/vlossom/src/plugins/modal-plugin/types.ts
+++ b/packages/vlossom/src/plugins/modal-plugin/types.ts
@@ -14,6 +14,7 @@ export interface ModalOptions {
     focusLock?: boolean;
     hideScroll?: boolean;
     id?: string;
+    componentProps?: Record<string, any>;
     size?: SizeProp | { width?: SizeProp; height?: SizeProp };
 }
 
@@ -24,7 +25,8 @@ export interface ModalInfo extends ModalOptions {
 }
 
 export interface ModalPlugin {
-    open(content: string | Component, options?: ModalOptions): string;
+    open(content: string, options?: Omit<ModalOptions, 'componentProps'>): string;
+    open(content: Component, options?: ModalOptions): string;
     emit(eventName: string, ...args: any[]): void | Promise<void>;
     emitWithId(id: string, eventName: string, ...args: any[]): void | Promise<void>;
     close(container?: string): Promise<boolean>;

--- a/packages/vlossom/src/plugins/prompt-plugin/README.ko.md
+++ b/packages/vlossom/src/plugins/prompt-plugin/README.ko.md
@@ -38,6 +38,24 @@ async function askName() {
 </script>
 ```
 
+### Vue 컴포넌트와 Props 전달
+
+```html
+<script setup>
+import { useVlossom } from 'vlossom';
+import PromptHeader from './PromptHeader.vue';
+
+const $vs = useVlossom();
+
+async function askWithCustomHeader() {
+    const value = await $vs.prompt.open(PromptHeader, {
+        componentProps: { label: '사용자명', hint: '소문자만 허용' },
+        input: { placeholder: 'username' },
+    });
+}
+</script>
+```
+
 ### 입력 구성 및 초기값 사용
 
 ```html
@@ -90,7 +108,8 @@ interface PromptModalOptions extends ModalOptions {
 }
 
 interface PromptPlugin {
-    open(content: string | Component, options?: PromptModalOptions): Promise<VsInputValueType>;
+    open(content: string, options?: Omit<PromptModalOptions, 'componentProps'>): Promise<VsInputValueType>;
+    open(content: Component, options?: PromptModalOptions): Promise<VsInputValueType>;
 }
 ```
 

--- a/packages/vlossom/src/plugins/prompt-plugin/README.md
+++ b/packages/vlossom/src/plugins/prompt-plugin/README.md
@@ -38,6 +38,24 @@ async function askName() {
 </script>
 ```
 
+### Using a Vue Component with Props
+
+```html
+<script setup>
+import { useVlossom } from 'vlossom';
+import PromptHeader from './PromptHeader.vue';
+
+const $vs = useVlossom();
+
+async function askWithCustomHeader() {
+    const value = await $vs.prompt.open(PromptHeader, {
+        componentProps: { label: 'Username', hint: 'lowercase only' },
+        input: { placeholder: 'username' },
+    });
+}
+</script>
+```
+
 ### With Input Configuration and Initial Value
 
 ```html
@@ -90,7 +108,8 @@ interface PromptModalOptions extends ModalOptions {
 }
 
 interface PromptPlugin {
-    open(content: string | Component, options?: PromptModalOptions): Promise<VsInputValueType>;
+    open(content: string, options?: Omit<PromptModalOptions, 'componentProps'>): Promise<VsInputValueType>;
+    open(content: Component, options?: PromptModalOptions): Promise<VsInputValueType>;
 }
 ```
 

--- a/packages/vlossom/src/plugins/prompt-plugin/__stories__/prompt-plugin.stories.ts
+++ b/packages/vlossom/src/plugins/prompt-plugin/__stories__/prompt-plugin.stories.ts
@@ -1,7 +1,22 @@
-import { ref } from 'vue';
+import { defineComponent, h, ref } from 'vue';
 import type { Meta, StoryObj } from '@storybook/vue3-vite';
 import { useVlossom } from '@/framework';
 import { type VsInputValueType, VsButton } from '@/components';
+
+const PromptHeader = defineComponent({
+    name: 'PromptHeader',
+    props: {
+        label: { type: String, default: '' },
+        hint: { type: String, default: '' },
+    },
+    setup(props) {
+        return () =>
+            h('div', { style: { textAlign: 'center' } }, [
+                h('h3', { style: { marginBottom: '0.25rem', fontWeight: 600 } }, props.label),
+                h('p', { style: { fontSize: '0.875rem', color: '#6b7280' } }, props.hint),
+            ]);
+    },
+});
 
 const meta: Meta = {
     title: 'Plugins/Prompt Plugin',
@@ -93,6 +108,45 @@ export const Default: Story = {
                 <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
                     <vs-button @click="handleOpenBasic">Open Prompt</vs-button>
                     <vs-button color-scheme="indigo" @click="handleOpenCustom">Open Prompt (Custom)</vs-button>
+                </div>
+                <div style="font-size: 0.875rem; color: var(--vs-gray-700, #4b5563);">
+                    {{ resultText }}
+                </div>
+            </div>
+        `,
+    }),
+};
+
+export const WithComponentProps: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'componentProps로 프롬프트 헤더 컴포넌트에 props를 전달하는 예시입니다.',
+            },
+        },
+    },
+    render: () => ({
+        components: { VsButton },
+        setup() {
+            const $vs = useVlossom();
+            const resultText = ref('아직 입력 없음');
+
+            async function handleOpen() {
+                const value = await $vs.prompt.open(PromptHeader, {
+                    componentProps: { label: '사용자명 입력', hint: '소문자만 허용됩니다' },
+                    input: { placeholder: 'username' },
+                    okText: '확인',
+                    cancelText: '취소',
+                });
+                resultText.value = value === null || value === '' ? '취소됨' : `입력 값: ${value}`;
+            }
+
+            return { handleOpen, resultText };
+        },
+        template: `
+            <div style="display: flex; flex-direction: column; gap: 0.75rem; max-width: 360px;">
+                <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
+                    <vs-button @click="handleOpen">Open Prompt (with componentProps)</vs-button>
                 </div>
                 <div style="font-size: 0.875rem; color: var(--vs-gray-700, #4b5563);">
                     {{ resultText }}

--- a/packages/vlossom/src/plugins/prompt-plugin/prompt-plugin.ts
+++ b/packages/vlossom/src/plugins/prompt-plugin/prompt-plugin.ts
@@ -19,6 +19,7 @@ export function createPromptPlugin(modalPlugin: ModalPlugin): PromptPlugin {
 
     return {
         open(content: string | Component, options: PromptModalOptions = {}): Promise<string | number | null> {
+            const { componentProps, ...modalOptions } = options;
             const {
                 container = 'body',
                 colorScheme,
@@ -27,7 +28,7 @@ export function createPromptPlugin(modalPlugin: ModalPlugin): PromptPlugin {
                 cancelText = 'Cancel',
                 swapButtons,
                 input: inputOptions,
-            } = options;
+            } = modalOptions;
 
             const inputRef = ref<VsInputRef | null>(null);
             const inputValue = ref<VsInputValueType>(inputOptions?.initialValue ?? null);
@@ -51,7 +52,7 @@ export function createPromptPlugin(modalPlugin: ModalPlugin): PromptPlugin {
                 { class: [...buttonsClass, swapButtons && 'flex-row-reverse'], style: styleSet?.$buttons },
                 [okButton, cancelButton],
             );
-            const contents = h(VsRender, { content });
+            const contents = h(VsRender, { content, componentProps });
 
             // NOTE. 함수형 VNode를 사용하여 컴포넌트 인스턴스(`inputRef`)를 가져올 수 있도록 하기 위함
             const prompt = () => {
@@ -73,9 +74,9 @@ export function createPromptPlugin(modalPlugin: ModalPlugin): PromptPlugin {
 
             return new Promise((resolve) => {
                 const modalId = modalPlugin.open(prompt, {
-                    ...options,
+                    ...modalOptions,
                     callbacks: {
-                        ...options?.callbacks,
+                        ...modalOptions.callbacks,
                         [PROMPT_OK]: () => {
                             if (!inputRef.value?.validate()) {
                                 return;

--- a/packages/vlossom/src/plugins/prompt-plugin/types.ts
+++ b/packages/vlossom/src/plugins/prompt-plugin/types.ts
@@ -20,5 +20,6 @@ export interface PromptModalOptions extends Omit<ModalOptions, 'beforeClose'> {
 }
 
 export interface PromptPlugin {
-    open(content: string | Component, options?: PromptModalOptions): Promise<VsInputValueType>;
+    open(content: string, options?: Omit<PromptModalOptions, 'componentProps'>): Promise<VsInputValueType>;
+    open(content: Component, options?: PromptModalOptions): Promise<VsInputValueType>;
 }


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary
$vs.modal/alert/confirm/prompt.open() 옵션에 componentProps 추가 — 렌더링되는 컴포넌트에 props 전달.

## Description
- ModalOptions에 componentProps 추가
  - content가 component인 경우에만 유효하기 때문에 명시적으로 componentProps로 명명
  - content가 string인 경우는 사용할 수 없도록 타입 오버로딩
```ts
$vs.modal.open(MyComp, { componentProps: { userId: 1 }, size: 'lg' });
```

- VsModal에서 사용하는 VsRender에 componentProps prop 추가
- alert/confirm/prompt는 componentProps 분리해 안쪽 VsRender로만 전달

### 참고 - 중간에 props를 추가하는 방향으로 개발하지 못한 이유
- 원래 기대했던 interface
```ts
$vs.modal.open(Modal, props, modalOptions});
```
- props는 사용하지 않더라도 modalOptions가 필요한 경우 중간에 불필요한 빈 객체를 넣어야 하는 경우가 생길 수 있음
```ts
$vs.modal.open(Modal, {}, { escClose: true }});
```
- 인자 개수로 구분한다고 하더라고 둘 다 optional object라서 인자가 2개인 경우에 대응 안 됨
- alert, confirm, prompt interface에도 모두 영향을 주게 되는데, 위 구조로 갔을 때 사용성이 떨어짐