### PR TITLE
feat(VsTable): add pagination style-set

### DIFF
--- a/packages/vlossom/src/components/vs-table/README.ko.md
+++ b/packages/vlossom/src/components/vs-table/README.ko.md
@@ -142,6 +142,8 @@ interface VsTableStyleSet extends CSSProperties {
         $selected?: CSSProperties;
     };
     $cell?: CSSProperties;
+    $pagination?: VsPaginationStyleSet;
+    $pageSizeSelect?: VsSelectStyleSet;
 }
 
 interface VsTableColumnDef<I = VsTableItem> {

--- a/packages/vlossom/src/components/vs-table/README.md
+++ b/packages/vlossom/src/components/vs-table/README.md
@@ -142,6 +142,8 @@ interface VsTableStyleSet extends CSSProperties {
         $selected?: CSSProperties;
     };
     $cell?: CSSProperties;
+    $pagination?: VsPaginationStyleSet;
+    $pageSizeSelect?: VsSelectStyleSet;
 }
 
 interface VsTableColumnDef<I = VsTableItem> {

--- a/packages/vlossom/src/components/vs-table/VsTablePagination.vue
+++ b/packages/vlossom/src/components/vs-table/VsTablePagination.vue
@@ -6,6 +6,7 @@
                 v-model="pageSize"
                 :options="pageSizeOptions"
                 :color-scheme
+                :style-set="tableStyleSet?.$pageSizeSelect"
                 :disabled="loading"
                 option-label="label"
                 option-value="value"
@@ -21,6 +22,7 @@
         <vs-pagination
             v-model="page"
             :color-scheme
+            :style-set="tableStyleSet?.$pagination"
             :disabled="loading"
             :length="totalPages"
             :showing-length="pagination.showingLength"
@@ -34,7 +36,12 @@
 import { computed, defineComponent, inject, type ComputedRef } from 'vue';
 import type { ColorScheme } from '@/declaration';
 import { TABLE_COMPOSABLE_TOKEN, type TableComposable } from './composables/table-composable';
-import { TABLE_COLOR_SCHEME_TOKEN, type VsTablePageSizeOptions } from './types';
+import {
+    TABLE_COLOR_SCHEME_TOKEN,
+    TABLE_STYLE_SET_TOKEN,
+    type VsTablePageSizeOptions,
+    type VsTableStyleSet,
+} from './types';
 
 import VsPagination from '@/components/vs-pagination/VsPagination.vue';
 import VsSelect from '@/components/vs-select/VsSelect.vue';
@@ -46,6 +53,7 @@ export default defineComponent({
         const { pagination, totalPages, totalItems, page, pageSize, pageStartIndex, pageEndIndex, loading, primary } =
             inject<TableComposable>(TABLE_COMPOSABLE_TOKEN)!;
         const colorScheme = inject<ComputedRef<ColorScheme | undefined>>(TABLE_COLOR_SCHEME_TOKEN);
+        const tableStyleSet = inject<ComputedRef<VsTableStyleSet>>(TABLE_STYLE_SET_TOKEN);
 
         const pageSizeOptions = computed<VsTablePageSizeOptions>(() => {
             return pagination.value.pageSizeOptions ?? [];
@@ -68,6 +76,7 @@ export default defineComponent({
             loading,
             primary,
             colorScheme,
+            tableStyleSet,
         };
     },
 });

--- a/packages/vlossom/src/components/vs-table/types.ts
+++ b/packages/vlossom/src/components/vs-table/types.ts
@@ -2,6 +2,8 @@ import type { CSSProperties } from 'vue';
 import type { SizeProp, TextAlignment, VerticalAlignment } from '@/declaration';
 import type VsTable from './VsTable.vue';
 import type { VsSearchInputStyleSet } from '@/components/vs-search-input/types';
+import type { VsPaginationStyleSet } from '@/components/vs-pagination/types';
+import type { VsSelectStyleSet } from '@/components/vs-select/types';
 
 declare module 'vue' {
     interface GlobalComponents {
@@ -20,6 +22,8 @@ export interface VsTableStyleSet extends CSSProperties {
         $selected?: CSSProperties;
     };
     $cell?: CSSProperties;
+    $pagination?: VsPaginationStyleSet;
+    $pageSizeSelect?: VsSelectStyleSet;
 }
 
 export type VsTablePageSizeOption = { label: string; value: number };


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary
vs-table에 누락된 style-set을 추가

## Description
- style-set에 pagination에 쓰이는 nested component의 style-set 추가
  - $pagination?: VsPaginationStyleSet;
  - $pageSizeSelect?: VsSelectStyleSet;
<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
