### PR TITLE
feat(VsImage, package): add default fallback UI and update version in package.json

### DIFF
--- a/packages/vlossom/package.json
+++ b/packages/vlossom/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vlossom",
     "description": "Vlossom UI components for Vue",
-    "version": "2.0.0-beta.3",
+    "version": "2.0.0-beta.5",
     "author": "vlossom",
     "repository": {
         "type": "git",

--- a/packages/vlossom/src/components/vs-image/README.ko.md
+++ b/packages/vlossom/src/components/vs-image/README.ko.md
@@ -12,6 +12,7 @@
 - 이미지 로딩 중 스켈레톤 플레이스홀더를 보여줍니다.
 - Intersection Observer API를 통한 지연 로딩을 지원합니다.
 - 로드 오류 시 `fallback` 이미지로 자동 전환됩니다.
+- `fallback`이 없거나 fallback 이미지도 실패하면 기본 fallback UI를 표시합니다.
 - 이미지 로드 실패 시 `error` 이벤트를 발생시킵니다.
 
 ## Basic Usage
@@ -34,7 +35,7 @@
 
 ### 대체 이미지
 
-기본 소스 로드 실패 시 표시할 대체 이미지 URL을 제공합니다.
+기본 소스 로드 실패 시 표시할 대체 이미지 URL을 제공합니다. fallback이 없거나 fallback 이미지도 로드에 실패하면 기본 fallback UI를 표시합니다.
 
 ```html
 <template>
@@ -62,7 +63,7 @@
 | ----------- | ------------------------------ | ------- | -------- | ------------------------------------------------ |
 | `styleSet`  | `string \| VsImageStyleSet`    | -       | -        | 컴포넌트의 커스텀 스타일 셋.                     |
 | `alt`       | `string`                       | `''`    | -        | 이미지 요소의 alt 텍스트.                        |
-| `fallback`  | `string`                       | `''`    | -        | 기본 src 실패 시 표시할 대체 이미지 URL.         |
+| `fallback`  | `string`                       | `''`    | -        | 기본 src 실패 시 표시할 대체 이미지 URL. 생략되었거나 실패하면 기본 fallback UI를 표시합니다. |
 | `lazy`      | `boolean`                      | `false` | -        | Intersection Observer를 사용한 지연 로딩 활성화. |
 | `noSkeleton`| `boolean`                      | `false` | -        | 로딩 중 스켈레톤 플레이스홀더 비활성화.          |
 | `src`       | `string`                       | `''`    | `true`   | 이미지의 소스 URL.                               |

--- a/packages/vlossom/src/components/vs-image/README.ko.md
+++ b/packages/vlossom/src/components/vs-image/README.ko.md
@@ -12,7 +12,7 @@
 - 이미지 로딩 중 스켈레톤 플레이스홀더를 보여줍니다.
 - Intersection Observer API를 통한 지연 로딩을 지원합니다.
 - 로드 오류 시 `fallback` 이미지로 자동 전환됩니다.
-- `fallback`이 없거나 fallback 이미지도 실패하면 기본 fallback UI를 표시합니다.
+- `fallback`이 없거나 fallback 이미지도 실패하면 no image icon을 표시합니다.
 - 이미지 로드 실패 시 `error` 이벤트를 발생시킵니다.
 
 ## Basic Usage
@@ -59,16 +59,16 @@
 
 ## Props
 
-| Prop        | Type                           | Default | Required | Description                                      |
-| ----------- | ------------------------------ | ------- | -------- | ------------------------------------------------ |
-| `styleSet`  | `string \| VsImageStyleSet`    | -       | -        | 컴포넌트의 커스텀 스타일 셋.                     |
-| `alt`       | `string`                       | `''`    | -        | 이미지 요소의 alt 텍스트.                        |
-| `fallback`  | `string`                       | `''`    | -        | 기본 src 실패 시 표시할 대체 이미지 URL. 생략되었거나 실패하면 기본 fallback UI를 표시합니다. |
-| `lazy`      | `boolean`                      | `false` | -        | Intersection Observer를 사용한 지연 로딩 활성화. |
-| `noSkeleton`| `boolean`                      | `false` | -        | 로딩 중 스켈레톤 플레이스홀더 비활성화.          |
-| `src`       | `string`                       | `''`    | `true`   | 이미지의 소스 URL.                               |
-| `width`     | `string \| number`             | -       | -        | 이미지 컴포넌트의 너비.                          |
-| `height`    | `string \| number`             | -       | -        | 이미지 컴포넌트의 높이.                          |
+| Prop         | Type                        | Default | Required | Description                                                                                |
+| ------------ | --------------------------- | ------- | -------- | ------------------------------------------------------------------------------------------ |
+| `styleSet`   | `string \| VsImageStyleSet` | -       | -        | 컴포넌트의 커스텀 스타일 셋.                                                               |
+| `alt`        | `string`                    | `''`    | -        | 이미지 요소의 alt 텍스트.                                                                  |
+| `fallback`   | `string`                    | `''`    | -        | 기본 src 실패 시 표시할 대체 이미지 URL. 생략되었거나 실패하면 no image icon을 표시합니다. |
+| `lazy`       | `boolean`                   | `false` | -        | Intersection Observer를 사용한 지연 로딩 활성화.                                           |
+| `noSkeleton` | `boolean`                   | `false` | -        | 로딩 중 스켈레톤 플레이스홀더 비활성화.                                                    |
+| `src`        | `string`                    | `''`    | `true`   | 이미지의 소스 URL.                                                                         |
+| `width`      | `string \| number`          | -       | -        | 이미지 컴포넌트의 너비.                                                                    |
+| `height`     | `string \| number`          | -       | -        | 이미지 컴포넌트의 높이.                                                                    |
 
 ## Types
 
@@ -103,15 +103,15 @@ interface VsImageStyleSet extends CSSProperties {
 
 ## Events
 
-| 이벤트  | 페이로드 | 설명                              |
-| ------- | -------- | --------------------------------- |
-| `error` | -        | 이미지 로드 실패 시 발생합니다.   |
+| 이벤트  | 페이로드 | 설명                            |
+| ------- | -------- | ------------------------------- |
+| `error` | -        | 이미지 로드 실패 시 발생합니다. |
 
 ## Slots
 
-| 슬롯       | 설명                                         |
-| ---------- | -------------------------------------------- |
-| `skeleton` | 스켈레톤 상태에서 표시할 커스텀 콘텐츠.      |
+| 슬롯       | 설명                                    |
+| ---------- | --------------------------------------- |
+| `skeleton` | 스켈레톤 상태에서 표시할 커스텀 콘텐츠. |
 
 ## Methods
 

--- a/packages/vlossom/src/components/vs-image/README.md
+++ b/packages/vlossom/src/components/vs-image/README.md
@@ -12,7 +12,7 @@ A component for displaying images with support for lazy loading, fallback images
 - Shows a skeleton placeholder while the image is loading.
 - Supports lazy loading via the Intersection Observer API.
 - Automatically switches to the `fallback` image on load error.
-- Displays the default fallback UI when no `fallback` is provided or the fallback image also fails.
+- Displays the no image icon when no `fallback` is provided or the fallback image also fails.
 - Fires an `error` event when an image fails to load.
 
 ## Basic Usage
@@ -59,16 +59,16 @@ Disable the skeleton placeholder during loading.
 
 ## Props
 
-| Prop        | Type                           | Default | Required | Description                                           |
-| ----------- | ------------------------------ | ------- | -------- | ----------------------------------------------------- |
-| `styleSet`  | `string \| VsImageStyleSet`    | -       | -        | Custom style set for the component.                   |
-| `alt`       | `string`                       | `''`    | -        | Alt text for the image element.                       |
-| `fallback`  | `string`                       | `''`    | -        | Fallback image URL shown when the primary src fails. If omitted or failed, the default fallback UI is shown. |
-| `lazy`      | `boolean`                      | `false` | -        | Enables lazy loading using the Intersection Observer. |
-| `noSkeleton`| `boolean`                      | `false` | -        | Disables the skeleton placeholder during loading.     |
-| `src`       | `string`                       | `''`    | `true`   | The source URL of the image.                          |
-| `width`     | `string \| number`             | -       | -        | Width of the image component.                         |
-| `height`    | `string \| number`             | -       | -        | Height of the image component.                        |
+| Prop         | Type                        | Default | Required | Description                                                                                            |
+| ------------ | --------------------------- | ------- | -------- | ------------------------------------------------------------------------------------------------------ |
+| `styleSet`   | `string \| VsImageStyleSet` | -       | -        | Custom style set for the component.                                                                    |
+| `alt`        | `string`                    | `''`    | -        | Alt text for the image element.                                                                        |
+| `fallback`   | `string`                    | `''`    | -        | Fallback image URL shown when the primary src fails. If omitted or failed, the no image icon is shown. |
+| `lazy`       | `boolean`                   | `false` | -        | Enables lazy loading using the Intersection Observer.                                                  |
+| `noSkeleton` | `boolean`                   | `false` | -        | Disables the skeleton placeholder during loading.                                                      |
+| `src`        | `string`                    | `''`    | `true`   | The source URL of the image.                                                                           |
+| `width`      | `string \| number`          | -       | -        | Width of the image component.                                                                          |
+| `height`     | `string \| number`          | -       | -        | Height of the image component.                                                                         |
 
 ## Types
 
@@ -103,9 +103,9 @@ interface VsImageStyleSet extends CSSProperties {
 
 ## Events
 
-| Event   | Payload | Description                              |
-| ------- | ------- | ---------------------------------------- |
-| `error` | -       | Emitted when the image fails to load.    |
+| Event   | Payload | Description                           |
+| ------- | ------- | ------------------------------------- |
+| `error` | -       | Emitted when the image fails to load. |
 
 ## Slots
 

--- a/packages/vlossom/src/components/vs-image/README.md
+++ b/packages/vlossom/src/components/vs-image/README.md
@@ -12,6 +12,7 @@ A component for displaying images with support for lazy loading, fallback images
 - Shows a skeleton placeholder while the image is loading.
 - Supports lazy loading via the Intersection Observer API.
 - Automatically switches to the `fallback` image on load error.
+- Displays the default fallback UI when no `fallback` is provided or the fallback image also fails.
 - Fires an `error` event when an image fails to load.
 
 ## Basic Usage
@@ -34,7 +35,7 @@ Defer image loading until the element enters the viewport.
 
 ### Fallback Image
 
-Provide a fallback image URL that is shown when the primary source fails.
+Provide a fallback image URL that is shown when the primary source fails. If no fallback is provided, or if the fallback image also fails to load, the default fallback UI is shown.
 
 ```html
 <template>
@@ -62,7 +63,7 @@ Disable the skeleton placeholder during loading.
 | ----------- | ------------------------------ | ------- | -------- | ----------------------------------------------------- |
 | `styleSet`  | `string \| VsImageStyleSet`    | -       | -        | Custom style set for the component.                   |
 | `alt`       | `string`                       | `''`    | -        | Alt text for the image element.                       |
-| `fallback`  | `string`                       | `''`    | -        | Fallback image URL shown when the primary src fails.  |
+| `fallback`  | `string`                       | `''`    | -        | Fallback image URL shown when the primary src fails. If omitted or failed, the default fallback UI is shown. |
 | `lazy`      | `boolean`                      | `false` | -        | Enables lazy loading using the Intersection Observer. |
 | `noSkeleton`| `boolean`                      | `false` | -        | Disables the skeleton placeholder during loading.     |
 | `src`       | `string`                       | `''`    | `true`   | The source URL of the image.                          |

--- a/packages/vlossom/src/components/vs-image/VsImage.css
+++ b/packages/vlossom/src/components/vs-image/VsImage.css
@@ -1,9 +1,19 @@
+@reference 'tailwindcss';
+
 .vs-image {
     @apply relative inline-block;
 
     background-color: transparent;
     width: 100%;
     height: 100%;
+
+    .vs-image-fallback {
+        @apply flex h-full min-h-full w-full items-center justify-center bg-gray-100 text-gray-500;
+    }
+
+    .vs-image-fallback-icon {
+        @apply h-1/2 max-h-10 w-1/2 max-w-10;
+    }
 
     .vs-image-tag {
         @apply relative h-full w-full;

--- a/packages/vlossom/src/components/vs-image/VsImage.css
+++ b/packages/vlossom/src/components/vs-image/VsImage.css
@@ -12,7 +12,7 @@
     }
 
     .vs-image-fallback-icon {
-        @apply h-1/2 max-h-10 w-1/2 max-w-10;
+        @apply h-1/2 w-1/2;
     }
 
     .vs-image-tag {

--- a/packages/vlossom/src/components/vs-image/VsImage.css
+++ b/packages/vlossom/src/components/vs-image/VsImage.css
@@ -8,7 +8,7 @@
     height: 100%;
 
     .vs-image-fallback {
-        @apply flex h-full min-h-full w-full items-center justify-center bg-gray-100 text-gray-500;
+        @apply flex h-full w-full items-center justify-center bg-gray-100 text-gray-500;
     }
 
     .vs-image-fallback-icon {

--- a/packages/vlossom/src/components/vs-image/VsImage.css
+++ b/packages/vlossom/src/components/vs-image/VsImage.css
@@ -12,7 +12,7 @@
     }
 
     .vs-image-fallback-icon {
-        @apply h-1/2 w-1/2;
+        @apply h-1/2 w-1/2 text-red-400;
     }
 
     .vs-image-tag {

--- a/packages/vlossom/src/components/vs-image/VsImage.vue
+++ b/packages/vlossom/src/components/vs-image/VsImage.vue
@@ -4,15 +4,15 @@
             <slot name="skeleton" />
         </vs-skeleton>
         <img
-            :class="['vs-image-tag', { 'vs-hidden': isLoading || showDefaultFallback }]"
+            :class="['vs-image-tag', { 'vs-hidden': isLoading || isNoImage }]"
             :src="computedSrc"
             :alt="alt"
             :style="componentStyleSet.$image"
             @load.stop="onImageLoad"
             @error.stop="onImageError"
         />
-        <div v-if="showDefaultFallback" class="vs-image-fallback">
-            <ImageIcon class="vs-image-fallback-icon" />
+        <div v-if="isNoImage" class="vs-image-fallback">
+            <ImageOffIcon class="vs-image-fallback-icon" />
         </div>
     </div>
 </template>
@@ -25,7 +25,7 @@ import { VsComponent } from '@/declaration';
 import { getStyleSetProps } from '@/props';
 import { objectUtil, stringUtil } from '@/utils';
 
-import { ImageIcon } from '@lucide/vue';
+import { ImageOffIcon } from '@lucide/vue';
 import VsSkeleton from '@/components/vs-skeleton/VsSkeleton.vue';
 
 import type { VsImageStyleSet } from './types';
@@ -33,7 +33,7 @@ import type { VsImageStyleSet } from './types';
 const componentName = VsComponent.VsImage;
 export default defineComponent({
     name: componentName,
-    components: { VsSkeleton, ImageIcon },
+    components: { VsSkeleton, ImageOffIcon },
     props: {
         ...getStyleSetProps<VsImageStyleSet>(),
         alt: { type: String, default: '' },
@@ -69,14 +69,14 @@ export default defineComponent({
 
         const isLoading = ref(true); // check if img tag src is loaded
         const isLoaded = ref(hasIntersectionObserver && lazy.value ? false : true);
-        const showCustomFallback = ref(false);
-        const showDefaultFallback = ref(false);
+        const isFallback = ref(false);
+        const isNoImage = ref(false);
 
         const computedSrc: ComputedRef<string> = computed(() => {
             if (!isLoaded.value) {
                 return '';
             }
-            if (showCustomFallback.value) {
+            if (isFallback.value) {
                 return fallback.value;
             }
 
@@ -84,8 +84,8 @@ export default defineComponent({
         });
 
         watch([src, fallback], () => {
-            showCustomFallback.value = false;
-            showDefaultFallback.value = false;
+            isFallback.value = false;
+            isNoImage.value = false;
         });
 
         function onImageLoad() {
@@ -100,12 +100,12 @@ export default defineComponent({
             emit('error');
             isLoading.value = false;
 
-            if (fallback.value && !showCustomFallback.value) {
-                showCustomFallback.value = true;
+            if (fallback.value && !isFallback.value) {
+                isFallback.value = true;
                 return;
             }
 
-            showDefaultFallback.value = true;
+            isNoImage.value = true;
         }
 
         if (hasIntersectionObserver && lazy.value) {
@@ -125,7 +125,7 @@ export default defineComponent({
             computedSrc,
             vsImageRef,
             isLoading,
-            showDefaultFallback,
+            isNoImage,
             onImageLoad,
             onImageError,
         };

--- a/packages/vlossom/src/components/vs-image/VsImage.vue
+++ b/packages/vlossom/src/components/vs-image/VsImage.vue
@@ -3,9 +3,6 @@
         <vs-skeleton v-if="isLoading && !noSkeleton" :style-set="componentStyleSet.$skeleton">
             <slot name="skeleton" />
         </vs-skeleton>
-        <div v-if="showDefaultFallback" class="vs-image-fallback">
-            <ImageIcon class="vs-image-fallback-icon" />
-        </div>
         <img
             :class="['vs-image-tag', { 'vs-hidden': isLoading || showDefaultFallback }]"
             :src="computedSrc"
@@ -14,6 +11,9 @@
             @load.stop="onImageLoad"
             @error.stop="onImageError"
         />
+        <div v-if="showDefaultFallback" class="vs-image-fallback">
+            <ImageIcon class="vs-image-fallback-icon" />
+        </div>
     </div>
 </template>
 
@@ -69,14 +69,14 @@ export default defineComponent({
 
         const isLoading = ref(true); // check if img tag src is loaded
         const isLoaded = ref(hasIntersectionObserver && lazy.value ? false : true);
-        const isFallback = ref(false);
+        const showCustomFallback = ref(false);
         const showDefaultFallback = ref(false);
 
         const computedSrc: ComputedRef<string> = computed(() => {
             if (!isLoaded.value) {
                 return '';
             }
-            if (isFallback.value) {
+            if (showCustomFallback.value) {
                 return fallback.value;
             }
 
@@ -84,7 +84,7 @@ export default defineComponent({
         });
 
         watch([src, fallback], () => {
-            isFallback.value = false;
+            showCustomFallback.value = false;
             showDefaultFallback.value = false;
         });
 
@@ -100,8 +100,8 @@ export default defineComponent({
             emit('error');
             isLoading.value = false;
 
-            if (fallback.value && !isFallback.value) {
-                isFallback.value = true;
+            if (fallback.value && !showCustomFallback.value) {
+                showCustomFallback.value = true;
                 return;
             }
 

--- a/packages/vlossom/src/components/vs-image/VsImage.vue
+++ b/packages/vlossom/src/components/vs-image/VsImage.vue
@@ -3,8 +3,11 @@
         <vs-skeleton v-if="isLoading && !noSkeleton" :style-set="componentStyleSet.$skeleton">
             <slot name="skeleton" />
         </vs-skeleton>
+        <div v-if="showDefaultFallback" class="vs-image-fallback">
+            <ImageIcon class="vs-image-fallback-icon" />
+        </div>
         <img
-            :class="['vs-image-tag', { 'vs-hidden': isLoading }]"
+            :class="['vs-image-tag', { 'vs-hidden': isLoading || showDefaultFallback }]"
             :src="computedSrc"
             :alt="alt"
             :style="componentStyleSet.$image"
@@ -22,6 +25,7 @@ import { VsComponent } from '@/declaration';
 import { getStyleSetProps } from '@/props';
 import { objectUtil, stringUtil } from '@/utils';
 
+import { ImageIcon } from '@lucide/vue';
 import VsSkeleton from '@/components/vs-skeleton/VsSkeleton.vue';
 
 import type { VsImageStyleSet } from './types';
@@ -29,7 +33,7 @@ import type { VsImageStyleSet } from './types';
 const componentName = VsComponent.VsImage;
 export default defineComponent({
     name: componentName,
-    components: { VsSkeleton },
+    components: { VsSkeleton, ImageIcon },
     props: {
         ...getStyleSetProps<VsImageStyleSet>(),
         alt: { type: String, default: '' },
@@ -66,6 +70,7 @@ export default defineComponent({
         const isLoading = ref(true); // check if img tag src is loaded
         const isLoaded = ref(hasIntersectionObserver && lazy.value ? false : true);
         const isFallback = ref(false);
+        const showDefaultFallback = ref(false);
 
         const computedSrc: ComputedRef<string> = computed(() => {
             if (!isLoaded.value) {
@@ -80,6 +85,7 @@ export default defineComponent({
 
         watch([src, fallback], () => {
             isFallback.value = false;
+            showDefaultFallback.value = false;
         });
 
         function onImageLoad() {
@@ -98,6 +104,8 @@ export default defineComponent({
                 isFallback.value = true;
                 return;
             }
+
+            showDefaultFallback.value = true;
         }
 
         if (hasIntersectionObserver && lazy.value) {
@@ -117,6 +125,7 @@ export default defineComponent({
             computedSrc,
             vsImageRef,
             isLoading,
+            showDefaultFallback,
             onImageLoad,
             onImageError,
         };

--- a/packages/vlossom/src/components/vs-image/__tests__/vs-image.test.ts
+++ b/packages/vlossom/src/components/vs-image/__tests__/vs-image.test.ts
@@ -59,6 +59,48 @@ describe('vs-image', () => {
             expect(wrapper.html()).not.toContain(imagePath);
             expect(wrapper.vm.computedSrc).toBe(fallbackPath);
         });
+
+        it('<img /> error 발생 시, fallback이 설정되어 있지 않으면 기본 fallback을 보여줘야 한다', async () => {
+            // given
+            const imagePath = '/images/test.png';
+            const wrapper = mount(VsImage, {
+                props: {
+                    src: imagePath,
+                },
+            });
+
+            // when
+            await wrapper.find('img').trigger('error');
+
+            // then
+            expect(wrapper.vm.showDefaultFallback).toBe(true);
+            expect(wrapper.find('.vs-image-fallback').exists()).toBe(true);
+            expect(wrapper.find('.vs-image-tag').classes()).toContain('vs-hidden');
+            expect(wrapper.emitted('error')).toHaveLength(1);
+        });
+
+        it('fallback 이미지에서도 error가 발생하면 기본 fallback을 보여줘야 한다', async () => {
+            // given
+            const imagePath = '/images/test.png';
+            const fallbackPath = '/images/fallback.png';
+            const wrapper = mount(VsImage, {
+                props: {
+                    src: imagePath,
+                    fallback: fallbackPath,
+                },
+            });
+
+            // when
+            await wrapper.find('img').trigger('error');
+            await wrapper.find('img').trigger('error');
+
+            // then
+            expect(wrapper.vm.computedSrc).toBe(fallbackPath);
+            expect(wrapper.vm.showDefaultFallback).toBe(true);
+            expect(wrapper.find('.vs-image-fallback').exists()).toBe(true);
+            expect(wrapper.find('.vs-image-tag').classes()).toContain('vs-hidden');
+            expect(wrapper.emitted('error')).toHaveLength(2);
+        });
     });
 
     describe('lazy', () => {

--- a/packages/vlossom/src/components/vs-image/__tests__/vs-image.test.ts
+++ b/packages/vlossom/src/components/vs-image/__tests__/vs-image.test.ts
@@ -73,7 +73,7 @@ describe('vs-image', () => {
             await wrapper.find('img').trigger('error');
 
             // then
-            expect(wrapper.vm.showDefaultFallback).toBe(true);
+            expect(wrapper.vm.isNoImage).toBe(true);
             expect(wrapper.find('.vs-image-fallback').exists()).toBe(true);
             expect(wrapper.find('.vs-image-tag').classes()).toContain('vs-hidden');
             expect(wrapper.emitted('error')).toHaveLength(1);
@@ -96,7 +96,7 @@ describe('vs-image', () => {
 
             // then
             expect(wrapper.vm.computedSrc).toBe(fallbackPath);
-            expect(wrapper.vm.showDefaultFallback).toBe(true);
+            expect(wrapper.vm.isNoImage).toBe(true);
             expect(wrapper.find('.vs-image-fallback').exists()).toBe(true);
             expect(wrapper.find('.vs-image-tag').classes()).toContain('vs-hidden');
             expect(wrapper.emitted('error')).toHaveLength(2);


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)
-   [x] Chore (chore)

## Summary

<img width="212" height="153" alt="image" src="https://github.com/user-attachments/assets/37d0750d-bbea-4bf1-93b9-eee2550366b2" />

VsImage에 위 형태의 기본 fallback UI를 추가하고, `package.json`의 `version`을 업데이트합니다.

## Description

- `fallback` prop이 없을 때 이미지 로드가 실패하면 기본 fallback 아이콘 UI를 표시합니다.
- `fallback` 이미지가 설정되어 있어도 해당 이미지까지 로드 실패하면 기본 fallback UI로 전환됩니다.
- 테스트 및 README를 수정합니다.
- `package.json`의 `version`을 `release/2.0.0-beta.5`로 업데이트 합니다.

## Related Tickets & Documents

- Closes #490 
