### PR TITLE
fix(VsFileDrop): add file equal check

### DIFF
--- a/packages/vlossom/src/composables/input/__tests__/input-composable.test.ts
+++ b/packages/vlossom/src/composables/input/__tests__/input-composable.test.ts
@@ -503,13 +503,6 @@ describe('useInput composable', () => {
         function makeFile(name: string) {
             return new File(['x'], name, { type: 'text/plain' });
         }
-        function changeFileNameSameInstance(file: File, newName: string) {
-            Object.defineProperty(file, 'name', {
-                value: newName,
-                configurable: true,
-            });
-            return file;
-        }
 
         function setupFileInput() {
             const fileInputValue = ref<File[]>([]);
@@ -555,27 +548,6 @@ describe('useInput composable', () => {
             expect(fileOnChangeSpy).toHaveBeenCalledTimes(2);
             expect(wrapper.emitted('change')).toHaveLength(2);
             expect(wrapper.emitted('change')?.[1]).toEqual([[file2]]);
-
-            wrapper.unmount();
-        });
-
-        it('동일한 File 인스턴스의 이름만 변경하면 참조 비교로 변경을 감지할 수 없다', async () => {
-            // given
-            const { wrapper, fileInputValue, fileOnChangeSpy } = setupFileInput();
-            const file = makeFile('a.txt');
-
-            // when
-            await nextTick();
-            fileInputValue.value = [file];
-            await nextTick();
-            changeFileNameSameInstance(file, 'b.txt');
-            fileInputValue.value = [file];
-            await nextTick();
-
-            // then
-            expect(file.name).toBe('b.txt');
-            expect(fileOnChangeSpy).toHaveBeenCalledTimes(1);
-            expect(wrapper.emitted('change')).toHaveLength(1);
 
             wrapper.unmount();
         });

--- a/packages/vlossom/src/composables/input/__tests__/input-composable.test.ts
+++ b/packages/vlossom/src/composables/input/__tests__/input-composable.test.ts
@@ -497,6 +497,103 @@ describe('useInput composable', () => {
         });
     });
 
+    describe('File[] inputValue', () => {
+        // radash isEqual은 own key가 없는 File을 서로 다른 인스턴스끼리도 동등 판정하므로,
+        // File을 담은 inputValue가 reference 비교 기반으로 동작하는지 회귀를 가드한다.
+        function makeFile(name: string) {
+            return new File(['x'], name, { type: 'text/plain' });
+        }
+
+        function setupFileInput() {
+            const fileInputValue = ref<File[]>([]);
+            const fileOnChangeSpy = vi.fn();
+
+            const FileInputComponent = defineComponent({
+                render: () => null,
+                props: {
+                    ...getInputProps<File[]>(),
+                    modelValue: { type: Array, default: () => [] },
+                },
+                setup(props, ctx) {
+                    const { modelValue, id } = toRefs(props);
+                    return {
+                        ...useInput(ctx, {
+                            inputValue: fileInputValue,
+                            modelValue: modelValue,
+                            id,
+                            callbacks: { onChange: fileOnChangeSpy },
+                        }),
+                    };
+                },
+            });
+
+            const wrapper = mount(FileInputComponent);
+            return { wrapper, fileInputValue, fileOnChangeSpy };
+        }
+
+        it('같은 길이의 다른 File 배열로 교체하면 change/update:modelValue가 emit된다', async () => {
+            // given
+            const { wrapper, fileInputValue, fileOnChangeSpy } = setupFileInput();
+            const file1 = makeFile('a.txt');
+            const file2 = makeFile('b.txt');
+
+            // when
+            await nextTick();
+            fileInputValue.value = [file1];
+            await nextTick();
+            fileInputValue.value = [file2];
+            await nextTick();
+
+            // then
+            expect(fileOnChangeSpy).toHaveBeenCalledTimes(2);
+            expect(wrapper.emitted('change')).toHaveLength(2);
+            expect(wrapper.emitted('change')?.[1]).toEqual([[file2]]);
+
+            wrapper.unmount();
+        });
+
+        it('multiple: 같은 길이의 다른 File 배열로 교체해도 emit된다', async () => {
+            // given
+            const { wrapper, fileInputValue, fileOnChangeSpy } = setupFileInput();
+            const a = makeFile('a.txt');
+            const b = makeFile('b.txt');
+            const c = makeFile('c.txt');
+            const d = makeFile('d.txt');
+
+            // when
+            await nextTick();
+            fileInputValue.value = [a, b];
+            await nextTick();
+            fileInputValue.value = [c, d];
+            await nextTick();
+
+            // then
+            expect(fileOnChangeSpy).toHaveBeenCalledTimes(2);
+            expect(wrapper.emitted('change')?.[1]).toEqual([[c, d]]);
+
+            wrapper.unmount();
+        });
+
+        it('동일한 File 인스턴스 배열을 재할당하면 emit되지 않는다', async () => {
+            // given
+            const { wrapper, fileInputValue, fileOnChangeSpy } = setupFileInput();
+            const file1 = makeFile('a.txt');
+
+            // when
+            await nextTick();
+            fileInputValue.value = [file1];
+            await nextTick();
+            fileInputValue.value = [file1];
+            await nextTick();
+
+            // then
+            expect(fileOnChangeSpy).toHaveBeenCalledTimes(1);
+            expect(wrapper.emitted('change')).toHaveLength(1);
+
+            wrapper.unmount();
+        });
+    });
+
     describe('clear', () => {
         it('clear 함수를 호출하면 onClear callback이 실행된다', async () => {
             // given

--- a/packages/vlossom/src/composables/input/__tests__/input-composable.test.ts
+++ b/packages/vlossom/src/composables/input/__tests__/input-composable.test.ts
@@ -503,6 +503,13 @@ describe('useInput composable', () => {
         function makeFile(name: string) {
             return new File(['x'], name, { type: 'text/plain' });
         }
+        function changeFileNameSameInstance(file: File, newName: string) {
+            Object.defineProperty(file, 'name', {
+                value: newName,
+                configurable: true,
+            });
+            return file;
+        }
 
         function setupFileInput() {
             const fileInputValue = ref<File[]>([]);
@@ -548,6 +555,27 @@ describe('useInput composable', () => {
             expect(fileOnChangeSpy).toHaveBeenCalledTimes(2);
             expect(wrapper.emitted('change')).toHaveLength(2);
             expect(wrapper.emitted('change')?.[1]).toEqual([[file2]]);
+
+            wrapper.unmount();
+        });
+
+        it('동일한 File 인스턴스의 이름만 변경하면 참조 비교로 변경을 감지할 수 없다', async () => {
+            // given
+            const { wrapper, fileInputValue, fileOnChangeSpy } = setupFileInput();
+            const file = makeFile('a.txt');
+
+            // when
+            await nextTick();
+            fileInputValue.value = [file];
+            await nextTick();
+            changeFileNameSameInstance(file, 'b.txt');
+            fileInputValue.value = [file];
+            await nextTick();
+
+            // then
+            expect(file.name).toBe('b.txt');
+            expect(fileOnChangeSpy).toHaveBeenCalledTimes(1);
+            expect(wrapper.emitted('change')).toHaveLength(1);
 
             wrapper.unmount();
         });

--- a/packages/vlossom/src/composables/input/input-composable.ts
+++ b/packages/vlossom/src/composables/input/input-composable.ts
@@ -31,10 +31,24 @@ export function useInput<T = unknown>(ctx: any, inputParams: InputComponentParam
 
     const { computedMessages, checkMessages, showRuleMessages } = useInputMessages(inputValue, messages, ruleMessages);
 
+    // File은 own key가 없어서 radash isEqual이 서로 다른 인스턴스끼리도 동등 판정함 → reference 비교.
+    function isInputValueEqual(a: unknown, b: unknown): boolean {
+        if (a instanceof File && b instanceof File) {
+            return a === b;
+        }
+        if (Array.isArray(a) && Array.isArray(b) && a.some((v) => v instanceof File)) {
+            if (a.length !== b.length) {
+                return false;
+            }
+            return a.every((v, i) => v === b[i]);
+        }
+        return objectUtil.isEqual(a, b);
+    }
+
     watch(
         inputValue,
         (value, oldValue) => {
-            if (objectUtil.isEqual(value, oldValue)) {
+            if (isInputValueEqual(value, oldValue)) {
                 return;
             }
 
@@ -59,7 +73,7 @@ export function useInput<T = unknown>(ctx: any, inputParams: InputComponentParam
     watch(
         modelValue,
         (value) => {
-            if (objectUtil.isEqual(value, inputValue.value)) {
+            if (isInputValueEqual(value, inputValue.value)) {
                 return;
             }
             inputValue.value = value;


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
vs-file-drop File, File[] 변경에서 equality를 useInput에서 제대로 잡아내지 못 함

## Description
- 원인: inputValue 변화를 radash isEqual로 비교하는데, radash는 Reflect.ownKeys로 비교. File 객체는 name/size/type 같은 속성이 prototype getter라 own key가 비어있어서, 서로 다른 두 File을 항상 equal로 판단.
- isEqual에 File 비교를 추가함 

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
