### PR TITLE
fix(VsTabs): sync indicator after tabs update

### DIFF
--- a/packages/vlossom/src/components/vs-tabs/VsTabs.vue
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.vue
@@ -24,7 +24,6 @@
                 <li
                     v-for="(tab, index) in tabs"
                     :key="tab"
-                    ref="tabRefs"
                     :style="getTabStyleSet(index)"
                     :class="['vs-tab-item', { 'vs-selected': isSelected(index), 'vs-disabled': isDisabled(index) }]"
                     role="tab"
@@ -82,6 +81,8 @@ import VsButton from '@/components/vs-button/VsButton.vue';
 import VsResponsive from '@/components/vs-responsive/VsResponsive.vue';
 
 const componentName = VsComponent.VsTabs;
+const TAB_ITEM_SELECTOR = '.vs-tab-item';
+
 export default defineComponent({
     name: componentName,
     components: { VsButton, VsResponsive, ChevronLeftIcon, ChevronRightIcon },
@@ -117,7 +118,6 @@ export default defineComponent({
         const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
         const tabsRef: Ref<HTMLElement | null> = ref(null);
-        const tabRefs: Ref<HTMLElement[]> = ref([]);
         const visibleTabCount = ref(0);
         const indicatorStyle = ref<Record<string, string> | null>(null);
 
@@ -169,13 +169,20 @@ export default defineComponent({
             return controls.value === 'show';
         });
 
+        function getTabItems(): HTMLElement[] {
+            return Array.from(tabsRef.value?.querySelectorAll<HTMLElement>(TAB_ITEM_SELECTOR) ?? []);
+        }
+
         function scrollTo(index: number) {
-            if (!tabRefs.value[index]) {
+            const tabItems = getTabItems();
+            const targetTab = tabItems[index];
+
+            if (!targetTab) {
                 return;
             }
 
-            tabRefs.value[index].focus();
-            tabRefs.value[index].scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
+            targetTab.focus();
+            targetTab.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
         }
 
         function goPrev() {
@@ -199,8 +206,10 @@ export default defineComponent({
             let visibleTabsCount = 0;
             let accumulatedSize = 0;
 
-            tabRefs.value.some((tabRef) => {
-                const tabSize = vertical.value ? tabRef.offsetHeight : tabRef.offsetWidth;
+            const tabItems = getTabItems();
+
+            tabItems.some((tabItem) => {
+                const tabSize = vertical.value ? tabItem.offsetHeight : tabItem.offsetWidth;
                 const canFit = accumulatedSize + tabSize <= tabListSize;
 
                 if (canFit) {
@@ -220,7 +229,12 @@ export default defineComponent({
                 return;
             }
 
-            const selectedTab = tabRefs.value[selectedIndex.value];
+            const selectedTab = getTabItems()[selectedIndex.value];
+
+            if (!selectedTab) {
+                indicatorStyle.value = null;
+                return;
+            }
 
             if (vertical.value) {
                 indicatorStyle.value = {
@@ -245,6 +259,11 @@ export default defineComponent({
         function getTabStyleSet(index: number): CSSProperties {
             const { $active = {}, ...base } = componentStyleSet.value.$tab ?? {};
             return isSelected(index) ? objectUtil.assign(base, $active) : base;
+        }
+
+        function updateTabsLayout() {
+            calculateVisibleTabCount();
+            updateIndicatorPosition();
         }
 
         onMounted(() => {
@@ -272,6 +291,8 @@ export default defineComponent({
 
         watch(modelValue, syncIndex, { immediate: true });
 
+        watch(tabs, updateTabsLayout, { deep: true, flush: 'post' });
+
         return {
             // Style
             colorSchemeClass,
@@ -292,7 +313,6 @@ export default defineComponent({
 
             // DOM Refs
             tabsRef,
-            tabRefs,
 
             // Event Handlers
             handleKeydown,

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.vue
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.vue
@@ -229,7 +229,8 @@ export default defineComponent({
                 return;
             }
 
-            const selectedTab = getTabItems()[selectedIndex.value];
+            const tabItems = getTabItems();
+            const selectedTab = tabItems[selectedIndex.value];
 
             if (!selectedTab) {
                 indicatorStyle.value = null;

--- a/packages/vlossom/src/components/vs-tabs/__tests__/vs-tabs.test.ts
+++ b/packages/vlossom/src/components/vs-tabs/__tests__/vs-tabs.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { nextTick } from 'vue';
 import VsTabs from './../VsTabs.vue';
@@ -406,6 +406,41 @@ describe('VsTabs', () => {
     });
 
     describe('reactivity', () => {
+        it('tabs가 교체되어 선택 인덱스가 유지되어도 indicator 위치가 갱신되어야 한다', async () => {
+            // given
+            const offsetLeftMock = vi
+                .spyOn(HTMLElement.prototype, 'offsetLeft', 'get')
+                .mockImplementation(function (this: HTMLElement) {
+                    return this.textContent?.includes('First Tab') ? 24 : 8;
+                });
+            const offsetWidthMock = vi
+                .spyOn(HTMLElement.prototype, 'offsetWidth', 'get')
+                .mockImplementation(function (this: HTMLElement) {
+                    return this.textContent?.includes('First Tab') ? 120 : 80;
+                });
+
+            try {
+                const wrapper = mount(VsTabs, {
+                    props: {
+                        tabs: ['Initial Tab'],
+                        modelValue: 0,
+                    },
+                });
+
+                await nextTick();
+
+                // when
+                await wrapper.setProps({ tabs: ['First Tab', 'Second Tab', 'Third Tab'] });
+                await nextTick();
+
+                // then
+                expect(wrapper.vm.indicatorStyle).toEqual({ left: '24px', width: '120px' });
+            } finally {
+                offsetLeftMock.mockRestore();
+                offsetWidthMock.mockRestore();
+            }
+        });
+
         it('tabs 길이가 줄어서 현재 선택이 범위를 벗어나면 선택이 해제되어야 한다', async () => {
             // given
             const wrapper = mount(VsTabs, {


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Fix Bug (fix)

## Summary

**Before**

<img width="611" height="257" alt="vs-tabs-bug" src="https://github.com/user-attachments/assets/ffe24b74-501c-47b9-acb7-79c357a4250a" />

**After**

<img width="611" height="257" alt="vs-tabs-fix" src="https://github.com/user-attachments/assets/81d08723-32d2-4570-88c9-4b5ef0058a49" />

`vs-tabs`의 `tabs` 목록이 비동기적으로 변경될 때 active tab과 indicator 위치가 어긋나는 문제를 수정합니다.

## Description

- 기존에는 `selectedIndex`가 변경될 때만 indicator 위치를 갱신했으나, tab 목록이 변경된 뒤 DOM 업데이트가 끝난 시점에서 layout을 다시 계산하도록 수정합니다.
  - `.vs-tab-item`의 DOM을 기준으로 scroll, visible count, indicator 위치를 계산하도록 변경합니다.

## Related Tickets & Documents

- Closes #494 