### PR TITLE
fix: add min-width on buttons of plugins (confirm, alert, prompt)

### DIFF
--- a/packages/vlossom/src/declaration/enums.ts
+++ b/packages/vlossom/src/declaration/enums.ts
@@ -1,5 +1,6 @@
 export enum VsComponent {
     VsAccordion = 'VsAccordion',
+    VsAlert = 'VsAlert',
     VsAvatar = 'VsAvatar',
     VsBar = 'VsBar',
     VsBlock = 'VsBlock',
@@ -37,6 +38,7 @@ export enum VsComponent {
     VsPage = 'VsPage',
     VsPagination = 'VsPagination',
     VsProgress = 'VsProgress',
+    VsPrompt = 'VsPrompt',
     VsRadio = 'VsRadio',
     VsRadioSet = 'VsRadioSet',
     VsRender = 'VsRender',

--- a/packages/vlossom/src/plugins/alert-plugin/alert-plugin.ts
+++ b/packages/vlossom/src/plugins/alert-plugin/alert-plugin.ts
@@ -1,10 +1,11 @@
-import { h, type Component } from 'vue';
+import { h, ref, type Component, type Ref } from 'vue';
 import { ALERT_OK, OVERLAY_CLOSE } from '@/declaration';
 import { useOverlayCallbackStore } from '@/stores';
+import { useStyleSet } from '@/composables';
 import { VsRender } from '@/components';
 import { vnodeUtils } from './../utils/vnode-utils';
 import type { ModalPlugin } from './../modal-plugin';
-import type { AlertModalOptions, AlertPlugin } from './types';
+import type { AlertModalOptions, AlertPlugin, VsAlertStyleSet } from './types';
 
 export function createAlertPlugin(modalPlugin: ModalPlugin): AlertPlugin {
     const overlayCallback = useOverlayCallbackStore();
@@ -22,17 +23,22 @@ export function createAlertPlugin(modalPlugin: ModalPlugin): AlertPlugin {
             const { componentProps, ...modalOptions } = options;
             const { container = 'body', colorScheme, styleSet, okText = 'OK' } = modalOptions;
 
+            const baseStyleSet: Ref<Partial<VsAlertStyleSet>> = ref({
+                $okButton: { minWidth: '8rem' },
+            });
+            const { componentStyleSet } = useStyleSet<VsAlertStyleSet>('VsAlert', ref(styleSet), baseStyleSet);
+
             const buttonsClass = ['flex', 'w-full', 'items-center', 'justify-center', 'gap-2'];
             const contentClass = ['flex', 'h-full', 'flex-col', 'items-center', 'justify-center', 'gap-12', 'pt-6'];
 
             const okButton = vnodeUtils.createVsButton({
-                props: { colorScheme, styleSet: styleSet?.$okButton },
+                props: { colorScheme, styleSet: componentStyleSet.value.$okButton },
                 content: okText,
                 onClickEvent: handleOk,
             });
 
             const contents = h(VsRender, { content, componentProps });
-            const buttons = h('div', { class: buttonsClass, style: styleSet?.$buttons }, [okButton]);
+            const buttons = h('div', { class: buttonsClass, style: componentStyleSet.value.$buttons }, [okButton]);
             const alert = h('div', { class: contentClass }, [contents, buttons]);
 
             return new Promise((resolve) => {

--- a/packages/vlossom/src/plugins/alert-plugin/alert-plugin.ts
+++ b/packages/vlossom/src/plugins/alert-plugin/alert-plugin.ts
@@ -1,5 +1,5 @@
 import { h, ref, type Component, type Ref } from 'vue';
-import { ALERT_OK, OVERLAY_CLOSE } from '@/declaration';
+import { ALERT_OK, OVERLAY_CLOSE, VsComponent } from '@/declaration';
 import { useOverlayCallbackStore } from '@/stores';
 import { useStyleSet } from '@/composables';
 import { VsRender } from '@/components';
@@ -26,7 +26,11 @@ export function createAlertPlugin(modalPlugin: ModalPlugin): AlertPlugin {
             const baseStyleSet: Ref<Partial<VsAlertStyleSet>> = ref({
                 $okButton: { minWidth: '8rem' },
             });
-            const { componentStyleSet } = useStyleSet<VsAlertStyleSet>('VsAlert', ref(styleSet), baseStyleSet);
+            const { componentStyleSet } = useStyleSet<VsAlertStyleSet>(
+                VsComponent.VsAlert,
+                ref(styleSet),
+                baseStyleSet,
+            );
 
             const buttonsClass = ['flex', 'w-full', 'items-center', 'justify-center', 'gap-2'];
             const contentClass = ['flex', 'h-full', 'flex-col', 'items-center', 'justify-center', 'gap-12', 'pt-6'];

--- a/packages/vlossom/src/plugins/alert-plugin/alert-plugin.ts
+++ b/packages/vlossom/src/plugins/alert-plugin/alert-plugin.ts
@@ -32,7 +32,7 @@ export function createAlertPlugin(modalPlugin: ModalPlugin): AlertPlugin {
             const contentClass = ['flex', 'h-full', 'flex-col', 'items-center', 'justify-center', 'gap-12', 'pt-6'];
 
             const okButton = vnodeUtils.createVsButton({
-                props: { colorScheme, styleSet: componentStyleSet.value.$okButton },
+                props: { colorScheme, styleSet: componentStyleSet.value.$okButton, primary: true },
                 content: okText,
                 onClickEvent: handleOk,
             });

--- a/packages/vlossom/src/plugins/confirm-plugin/confirm-plugin.ts
+++ b/packages/vlossom/src/plugins/confirm-plugin/confirm-plugin.ts
@@ -1,11 +1,12 @@
-import { h, type Component } from 'vue';
+import { h, ref, type Component, type Ref } from 'vue';
 import { VsRender } from '@/components';
+import { useStyleSet } from '@/composables';
 import { useOverlayCallbackStore } from '@/stores';
-import { CONFIRM_CANCEL, CONFIRM_OK, OVERLAY_CLOSE } from '@/declaration';
+import { CONFIRM_CANCEL, CONFIRM_OK, OVERLAY_CLOSE, VsComponent } from '@/declaration';
 import type { ModalPlugin } from '@/plugins';
 
 import { vnodeUtils } from './../utils/vnode-utils';
-import type { ConfirmModalOptions, ConfirmPlugin } from './types';
+import type { ConfirmModalOptions, ConfirmPlugin, VsConfirmStyleSet } from './types';
 
 export function createConfirmPlugin(modalPlugin: ModalPlugin): ConfirmPlugin {
     const overlayCallback = useOverlayCallbackStore();
@@ -30,14 +31,24 @@ export function createConfirmPlugin(modalPlugin: ModalPlugin): ConfirmPlugin {
                 swapButtons,
             } = modalOptions;
 
+            const baseStyleSet: Ref<Partial<VsConfirmStyleSet>> = ref({
+                $okButton: { minWidth: '8rem' },
+                $cancelButton: { minWidth: '8rem' },
+            });
+            const { componentStyleSet } = useStyleSet<VsConfirmStyleSet>(
+                VsComponent.VsConfirm,
+                ref(styleSet),
+                baseStyleSet,
+            );
+
             const okButton = vnodeUtils.createVsButton({
-                props: { colorScheme, styleSet: styleSet?.$okButton, primary: true },
+                props: { colorScheme, styleSet: componentStyleSet.value.$okButton, primary: true },
                 content: okText,
                 onClickEvent: () => handleButton(CONFIRM_OK),
             });
 
             const cancelButton = vnodeUtils.createVsButton({
-                props: { colorScheme, styleSet: styleSet?.$cancelButton },
+                props: { colorScheme, styleSet: componentStyleSet.value.$cancelButton },
                 content: cancelText,
                 onClickEvent: () => handleButton(CONFIRM_CANCEL),
             });
@@ -48,7 +59,10 @@ export function createConfirmPlugin(modalPlugin: ModalPlugin): ConfirmPlugin {
             const contents = h(VsRender, { content, componentProps });
             const buttons = h(
                 'div',
-                { class: [...buttonsClass, swapButtons && 'flex-row-reverse'], style: styleSet?.$buttons },
+                {
+                    class: [...buttonsClass, swapButtons && 'flex-row-reverse'],
+                    style: componentStyleSet.value.$buttons,
+                },
                 [okButton, cancelButton],
             );
             const confirm = h('div', { class: contentClass }, [contents, buttons]);

--- a/packages/vlossom/src/plugins/prompt-plugin/prompt-plugin.ts
+++ b/packages/vlossom/src/plugins/prompt-plugin/prompt-plugin.ts
@@ -1,5 +1,5 @@
 import { h, type Component, ref, type Ref } from 'vue';
-import { OVERLAY_CLOSE, PROMPT_CANCEL, PROMPT_OK } from '@/declaration';
+import { OVERLAY_CLOSE, PROMPT_CANCEL, PROMPT_OK, VsComponent } from '@/declaration';
 import { useOverlayCallbackStore } from '@/stores';
 import { useStyleSet } from '@/composables';
 import { VsInput, VsRender, type VsInputRef, type VsInputValueType } from '@/components';
@@ -38,7 +38,11 @@ export function createPromptPlugin(modalPlugin: ModalPlugin): PromptPlugin {
                 $okButton: { minWidth: '8rem' },
                 $cancelButton: { minWidth: '8rem' },
             });
-            const { componentStyleSet } = useStyleSet<VsPromptStyleSet>('VsPrompt', ref(styleSet), baseStyleSet);
+            const { componentStyleSet } = useStyleSet<VsPromptStyleSet>(
+                VsComponent.VsPrompt,
+                ref(styleSet),
+                baseStyleSet,
+            );
 
             const buttonsClass = ['flex', 'w-full', 'items-center', 'justify-center', 'gap-2'];
             const interactsClass = ['flex', 'h-full', 'flex-col', 'items-center', 'justify-center', 'gap-8'];

--- a/packages/vlossom/src/plugins/prompt-plugin/prompt-plugin.ts
+++ b/packages/vlossom/src/plugins/prompt-plugin/prompt-plugin.ts
@@ -1,9 +1,10 @@
-import { h, type Component, ref } from 'vue';
+import { h, type Component, ref, type Ref } from 'vue';
 import { OVERLAY_CLOSE, PROMPT_CANCEL, PROMPT_OK } from '@/declaration';
 import { useOverlayCallbackStore } from '@/stores';
+import { useStyleSet } from '@/composables';
 import { VsInput, VsRender, type VsInputRef, type VsInputValueType } from '@/components';
 import type { ModalPlugin } from './../modal-plugin';
-import type { PromptModalOptions, PromptPlugin } from './types';
+import type { PromptModalOptions, PromptPlugin, VsPromptStyleSet } from './types';
 import { vnodeUtils } from './../utils/vnode-utils';
 
 export function createPromptPlugin(modalPlugin: ModalPlugin): PromptPlugin {
@@ -33,23 +34,32 @@ export function createPromptPlugin(modalPlugin: ModalPlugin): PromptPlugin {
             const inputRef = ref<VsInputRef | null>(null);
             const inputValue = ref<VsInputValueType>(inputOptions?.initialValue ?? null);
 
+            const baseStyleSet: Ref<Partial<VsPromptStyleSet>> = ref({
+                $okButton: { minWidth: '8rem' },
+                $cancelButton: { minWidth: '8rem' },
+            });
+            const { componentStyleSet } = useStyleSet<VsPromptStyleSet>('VsPrompt', ref(styleSet), baseStyleSet);
+
             const buttonsClass = ['flex', 'w-full', 'items-center', 'justify-center', 'gap-2'];
             const interactsClass = ['flex', 'h-full', 'flex-col', 'items-center', 'justify-center', 'gap-8'];
             const wrapperClass = ['flex', 'h-full', 'flex-col', 'items-center', 'justify-center', 'gap-4', 'pt-8'];
 
             const okButton = vnodeUtils.createVsButton({
-                props: { colorScheme, styleSet: styleSet?.$okButton, primary: true },
+                props: { colorScheme, styleSet: componentStyleSet.value.$okButton, primary: true },
                 content: okText,
                 onClickEvent: () => handleButton(PROMPT_OK),
             });
             const cancelButton = vnodeUtils.createVsButton({
-                props: { colorScheme, styleSet: styleSet?.$cancelButton },
+                props: { colorScheme, styleSet: componentStyleSet.value.$cancelButton },
                 content: cancelText,
                 onClickEvent: () => handleButton(PROMPT_CANCEL),
             });
             const buttons = h(
                 'div',
-                { class: [...buttonsClass, swapButtons && 'flex-row-reverse'], style: styleSet?.$buttons },
+                {
+                    class: [...buttonsClass, swapButtons && 'flex-row-reverse'],
+                    style: componentStyleSet.value.$buttons,
+                },
                 [okButton, cancelButton],
             );
             const contents = h(VsRender, { content, componentProps });
@@ -59,7 +69,7 @@ export function createPromptPlugin(modalPlugin: ModalPlugin): PromptPlugin {
                 const input = h(VsInput, {
                     ...inputOptions,
                     colorScheme,
-                    styleSet: styleSet?.$input,
+                    styleSet: componentStyleSet.value.$input,
 
                     ref: inputRef,
                     modelValue: inputValue.value,


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
confirm, alert, prompt 버튼들의 최소 width를 지정합니다 (for design)

## Description
- useStyleSet을 이용해서 style-set 정제 후에 바인딩
- baseStyleSet으로 min-width: 8rem 지정
- alert에 누락된 primary 추가
- VsComponent에 VsAlert, VsPrompt 추가

<img width="659" height="361" alt="image" src="https://github.com/user-attachments/assets/eb93f777-151d-4f10-9e07-995b8e0fa749" />

<img width="584" height="325" alt="image" src="https://github.com/user-attachments/assets/cfc3bf95-4b16-4a03-8748-c2c5ac8e0bd4" />


<img width="577" height="321" alt="image" src="https://github.com/user-attachments/assets/f35a0cea-3b3e-4cb7-9bd7-32f978336fe2" />


<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
