### PR TITLE
fix(VsTable): preserve custom pageSizeOptions with infinity value

### DIFF
--- a/packages/vlossom/src/components/vs-table/VsTable.vue
+++ b/packages/vlossom/src/components/vs-table/VsTable.vue
@@ -122,7 +122,6 @@ import {
     type VsTablePageSizeOptions,
 } from './types';
 import {
-    DEFAULT_PAGE_SIZE,
     DEFAULT_PAGE_SIZE_OPTIONS,
     TABLE_DRAG_WRAPPER_CLASS,
     VS_TABLE_BODY_SLOT_PREFIXES,
@@ -225,7 +224,6 @@ export default defineComponent({
         page: { type: Number as PropType<number> }, // 0-based page index
         pageSize: {
             type: Number as PropType<number>,
-            default: DEFAULT_PAGE_SIZE,
             validator: (value: number, props: unknown) => {
                 const { pagination } = props as PropsOf<VsComponent.VsTable>;
                 if (value <= 0) {
@@ -235,10 +233,7 @@ export default defineComponent({
                 if (pagination && typeof pagination === 'object') {
                     const pageSizeOptions: VsTablePageSizeOptions =
                         pagination.pageSizeOptions ?? DEFAULT_PAGE_SIZE_OPTIONS;
-                    const isValidPageSize = pageSizeOptions.some((option) => option.value === value);
-                    if (isValidPageSize) {
-                        return true;
-                    }
+
                     if (pagination.showPageSizeSelect) {
                         logUtil.propError(
                             componentName,
@@ -248,12 +243,6 @@ export default defineComponent({
                         );
                         return false;
                     }
-                    logUtil.propWarning(
-                        componentName,
-                        'pageSize',
-                        `pageSize ${value} is not in the pageSizeOptions ` +
-                            `[${pageSizeOptions.map((option) => option.value).join(', ')}]`,
-                    );
                     return true;
                 }
                 if (pagination && typeof pagination === 'boolean') {

--- a/packages/vlossom/src/components/vs-table/__tests__/table-composable.test.ts
+++ b/packages/vlossom/src/components/vs-table/__tests__/table-composable.test.ts
@@ -421,6 +421,29 @@ describe('useTable', () => {
         });
 
         describe('사용자 정의 pageSizeOptions', () => {
+            it('pageSize가 없으면 pageSizeOptions의 첫 번째 값을 초기 pageSize로 사용한다', async () => {
+                const items = Array.from({ length: 30 }, (_, i) => ({ id: `${i}`, name: `User ${i}` }));
+                const customOptions = [
+                    { label: '5 items', value: 5 },
+                    { label: '10 items', value: 10 },
+                    { label: '20 items', value: 20 },
+                ];
+                const { table } = setupUseTable({
+                    columns: ['name'],
+                    items,
+                    pagination: {
+                        pageSizeOptions: customOptions,
+                        showPageSizeSelect: true,
+                    },
+                });
+
+                await nextTick();
+
+                expect(table.pageSize.value).toBe(5);
+                expect(table.bodyCells.value).toHaveLength(5);
+                expect(table.totalPages.value).toBe(6);
+            });
+
             it('pageSize가 default 값(50)이어도 사용자가 지정한 pageSizeOptions를 그대로 사용한다', async () => {
                 const items = Array.from({ length: 30 }, (_, i) => ({ id: `${i}`, name: `User ${i}` }));
                 const customOptions = [

--- a/packages/vlossom/src/components/vs-table/__tests__/table-composable.test.ts
+++ b/packages/vlossom/src/components/vs-table/__tests__/table-composable.test.ts
@@ -419,6 +419,83 @@ describe('useTable', () => {
                 expect(table.totalPages.value).toBe(1);
             });
         });
+
+        describe('사용자 정의 pageSizeOptions', () => {
+            it('pageSize가 default 값(50)이어도 사용자가 지정한 pageSizeOptions를 그대로 사용한다', async () => {
+                const items = Array.from({ length: 30 }, (_, i) => ({ id: `${i}`, name: `User ${i}` }));
+                const customOptions = [
+                    { label: '5 items', value: 5 },
+                    { label: '8 items', value: 8 },
+                    { label: '10 items', value: 10 },
+                    { label: 'All', value: Infinity },
+                ];
+                const { table } = setupUseTable({
+                    columns: ['name'],
+                    items,
+                    pagination: {
+                        pageSizeOptions: customOptions,
+                        showPageSizeSelect: true,
+                    },
+                    pageSize: DEFAULT_PAGE_SIZE,
+                });
+
+                await nextTick();
+                expect(table.pagination.value.pageSizeOptions).toEqual(customOptions);
+            });
+
+            it('pageSize를 Infinity로 변경해도 사용자가 지정한 pageSizeOptions와 라벨이 유지된다', async () => {
+                const items = Array.from({ length: 30 }, (_, i) => ({ id: `${i}`, name: `User ${i}` }));
+                const customOptions = [
+                    { label: '5 items', value: 5 },
+                    { label: '8 items', value: 8 },
+                    { label: '10 items', value: 10 },
+                    { label: 'All', value: Infinity },
+                ];
+                const { table, reactiveProps } = setupUseTable({
+                    columns: ['name'],
+                    items,
+                    pagination: {
+                        pageSizeOptions: customOptions,
+                        showPageSizeSelect: true,
+                    },
+                    pageSize: 5,
+                });
+
+                await nextTick();
+                expect(table.pagination.value.pageSizeOptions).toEqual(customOptions);
+
+                reactiveProps.pageSize = Infinity;
+                await nextTick();
+
+                expect(table.pagination.value.pageSizeOptions).toEqual(customOptions);
+                expect(table.pageSize.value).toBe(Infinity);
+            });
+
+            it('pageSize를 옵션 내 다른 값으로 변경해도 pageSizeOptions가 유지된다', async () => {
+                const items = Array.from({ length: 30 }, (_, i) => ({ id: `${i}`, name: `User ${i}` }));
+                const customOptions = [
+                    { label: '5 items', value: 5 },
+                    { label: '8 items', value: 8 },
+                    { label: '10 items', value: 10 },
+                ];
+                const { table, reactiveProps } = setupUseTable({
+                    columns: ['name'],
+                    items,
+                    pagination: {
+                        pageSizeOptions: customOptions,
+                        showPageSizeSelect: true,
+                    },
+                    pageSize: 5,
+                });
+
+                await nextTick();
+
+                reactiveProps.pageSize = 8;
+                await nextTick();
+
+                expect(table.pagination.value.pageSizeOptions).toEqual(customOptions);
+            });
+        });
     });
 
     describe('expandable', () => {

--- a/packages/vlossom/src/components/vs-table/__tests__/vs-table.test.ts
+++ b/packages/vlossom/src/components/vs-table/__tests__/vs-table.test.ts
@@ -332,6 +332,33 @@ describe('VsTable', () => {
             expect(pageSize).toBe(DEFAULT_PAGE_SIZE);
         });
 
+        it('초기 pageSize가 없으면 pageSizeOptions의 첫 번째 값을 사용한다', async () => {
+            const items = Array.from({ length: 30 }, (_, i) => ({ id: `${i}`, name: `User ${i}`, age: i }));
+            const wrapper = mountTable({
+                props: {
+                    items,
+                    pagination: {
+                        pageSizeOptions: [
+                            { label: '5 items', value: 5 },
+                            { label: '10 items', value: 10 },
+                            { label: '20 items', value: 20 },
+                        ],
+                    },
+                },
+            });
+
+            await nextTick();
+
+            expect(wrapper.findAll('tbody tr')).toHaveLength(5);
+
+            await wrapper.get('[data-testid="vs-pagination"]').trigger('click');
+
+            const emitted = wrapper.emitted('paginate');
+            expect(emitted).toHaveLength(1);
+            const [, pageSize] = emitted![0] as [number, number];
+            expect(pageSize).toBe(5);
+        });
+
         describe('server mode', () => {
             it('서버 모드를 활성화하면 totalItemCount 기반으로 pagination을 렌더링한다', async () => {
                 const serverItems = Array.from({ length: 10 }, (_, i) => ({

--- a/packages/vlossom/src/components/vs-table/composables/table-composable.ts
+++ b/packages/vlossom/src/components/vs-table/composables/table-composable.ts
@@ -100,9 +100,12 @@ export function useTable(
         if (typeof rawPagination?.value === 'boolean') {
             return DEFAULT_PAGINATION_OPTIONS;
         }
+        if (rawPagination.value.pageSizeOptions) {
+            return { ...DEFAULT_PAGINATION_OPTIONS, ...rawPagination.value };
+        }
         if (typeof rawPageSize?.value === 'number') {
             const isValidPageSize = DEFAULT_PAGE_SIZE_OPTIONS.some((option) => option.value === rawPageSize.value);
-            if (!isValidPageSize) {
+            if (isValidPageSize) {
                 return { ...DEFAULT_PAGINATION_OPTIONS, ...rawPagination.value };
             }
             const addedOption = toDefaultPageSizeOptions(rawPageSize.value as number);

--- a/packages/vlossom/src/components/vs-table/composables/table-composable.ts
+++ b/packages/vlossom/src/components/vs-table/composables/table-composable.ts
@@ -138,10 +138,10 @@ export function useTable(
                 return internalPageSize.value;
             }
             const currentPageSize = rawPageSize?.value;
-            if (!currentPageSize) {
-                return DEFAULT_PAGE_SIZE;
+            if (typeof currentPageSize === 'number') {
+                return currentPageSize;
             }
-            return currentPageSize;
+            return pagination.value.pageSizeOptions?.[0]?.value ?? DEFAULT_PAGE_SIZE;
         },
         set: (value: number) => {
             internalPageSize.value = value;

--- a/packages/vlossom/src/components/vs-table/constants.ts
+++ b/packages/vlossom/src/components/vs-table/constants.ts
@@ -11,11 +11,13 @@ export const TABLE_SEARCH_OPTIONS: Exclude<SearchProps, boolean> = {
 export const DEFAULT_PAGE_SIZE_ALL = Infinity;
 export const DEFAULT_PAGE_SIZE = 50;
 export function toDefaultPageSizeOptions(pageSize: number): VsTablePageSizeOption {
+    if (pageSize === DEFAULT_PAGE_SIZE_ALL) {
+        return { label: 'All', value: DEFAULT_PAGE_SIZE_ALL };
+    }
     return { label: `${pageSize} items`, value: pageSize };
 }
 export const DEFAULT_PAGE_SIZE_OPTIONS: VsTablePageSizeOptions = [
-    ...[50, 100].map(toDefaultPageSizeOptions),
-    { label: 'All', value: DEFAULT_PAGE_SIZE_ALL },
+    ...[50, 100, DEFAULT_PAGE_SIZE_ALL].map(toDefaultPageSizeOptions),
 ];
 export const DEFAULT_PAGINATION_OPTIONS: VsTablePaginationOptions = {
     pageSizeOptions: DEFAULT_PAGE_SIZE_OPTIONS,


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary

vs-table의 `pagination.pageSizeOptions`를 사용자가 직접 지정해도 default 옵션으로 덮어써지던 문제와, `pageSize`를 `Infinity`로 변경할 때 사용자 옵션과 `'All'` 라벨이 사라지던 문제를 수정했습니다.

## Description

### 문제

`<vs-table :pagination="{ pageSizeOptions: [...] }">` 처럼 옵션을 직접 지정해도 다음과 같은 문제가 발생했습니다.

1. `pageSize`가 default 값(50)일 때 사용자 옵션이 default 옵션(`[50, 100, All]`)으로 덮어써짐
2. `pageSize`를 `Infinity`로 변경하면 사용자 옵션이 사라지고 라벨이 `'All'` → `'Infinity items'`로 바뀜

### 변경

- `composables/table-composable.ts`: 사용자가 `pageSizeOptions`를 지정한 경우 default 옵션으로 덮어쓰지 않도록 분기 추가
- `constants.ts`: `toDefaultPageSizeOptions(Infinity)`가 `'All'` 라벨을 반환하도록 안전망 추가
- `__tests__/table-composable.test.ts`: 회귀 테스트 3건 추가
    - default `pageSize`(50)에서도 사용자 옵션이 그대로 유지되는지
    - `pageSize`를 `Infinity`로 변경해도 옵션과 라벨이 유지되는지
    - `pageSize`를 옵션 내 다른 값으로 변경해도 옵션이 유지되는지

## Related Tickets & Documents

- Closes #484 

