### PR TITLE
fix(click): remove invalid preventDefault from click event

### DIFF
--- a/packages/vlossom/src/components/vs-accordion/VsAccordion.vue
+++ b/packages/vlossom/src/components/vs-accordion/VsAccordion.vue
@@ -8,7 +8,7 @@
         @keydown.enter.prevent.stop="toggle"
         @keydown.space.prevent.stop="toggle"
     >
-        <div class="vs-accordion-title" :style="componentStyleSet.$title" @click.prevent.stop="toggle">
+        <div class="vs-accordion-title" :style="componentStyleSet.$title" @click.stop="toggle">
             <slot name="title" />
         </div>
         <vs-expandable :open="isOpen" :size :style-set="componentStyleSet.$content">

--- a/packages/vlossom/src/components/vs-grouped-list/VsGroupedList.vue
+++ b/packages/vlossom/src/components/vs-grouped-list/VsGroupedList.vue
@@ -28,7 +28,7 @@
                     :id="item.id"
                     :class="['vs-grouped-list-item', { 'vs-disabled': item.disabled }]"
                     :style="componentStyleSet.$item"
-                    @click.prevent.stop="emitClickItem(item, groupedIndex, group, groupIndex)"
+                    @click.stop="emitClickItem(item, groupedIndex, group, groupIndex)"
                 >
                     <slot name="item" v-bind="item" :groupedIndex :group :groupIndex>
                         <div class="vs-grouped-list-item-content">

--- a/packages/vlossom/src/components/vs-steps/VsSteps.vue
+++ b/packages/vlossom/src/components/vs-steps/VsSteps.vue
@@ -27,7 +27,7 @@
                 ]"
                 role="tab"
                 :tabindex="isSelected(index) ? 0 : -1"
-                @click.prevent.stop="selectStep(index)"
+                @click.stop="selectStep(index)"
                 @keydown.stop="(e) => handleKeydown(e, vertical)"
             >
                 <div class="vs-step-num" :style="getStepStyleSet(index)">

--- a/packages/vlossom/src/components/vs-table/VsTableBodyRow.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableBodyRow.vue
@@ -12,7 +12,7 @@
                 :id="cell.id"
                 :style="getCellStyle(index)"
                 :data-label="getHeaderLabel(cell.colIdx, cell.colKey)"
-                @click.prevent.stop="clickCell(cell, $event)"
+                @click.stop="clickCell(cell, $event)"
             >
                 <vs-skeleton v-if="loading" :color-scheme :style-set="skeletonStyleSet" />
                 <template v-else>

--- a/packages/vlossom/src/components/vs-table/VsTableCheckboxCell.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableCheckboxCell.vue
@@ -1,6 +1,6 @@
 <template>
     <template v-if="isBodyRow(cells)">
-        <td class="vs-table-td" v-if="anySelectable" :style="cellStyle" @click.prevent.stop="selectRow(cells, $event)">
+        <td class="vs-table-td" v-if="anySelectable" :style="cellStyle" @click.stop="selectRow(cells, $event)">
             <slot name="select" :item="getRowItem(cells)" :value="isSelected(cells)" :rowIdx>
                 <vs-checkbox
                     v-if="isRowSelectable(cells, rowIdx)"
@@ -17,7 +17,7 @@
     </template>
 
     <template v-else>
-        <th class="vs-table-th" v-if="anySelectable" :style="cellStyle" @click.prevent.stop="selectRow(cells, $event)">
+        <th class="vs-table-th" v-if="anySelectable" :style="cellStyle" @click.stop="selectRow(cells, $event)">
             <slot name="select" :item="null" :value="isSelected(cells)" :rowIdx="HEADER_ROW_INDEX">
                 <vs-checkbox
                     :style-set="headerCheckboxStyle"

--- a/packages/vlossom/src/components/vs-tabs/VsTabs.vue
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.vue
@@ -30,7 +30,7 @@
                     :aria-selected="isSelected(index)"
                     :aria-disabled="isDisabled(index)"
                     :tabindex="isSelected(index) ? 0 : -1"
-                    @click.prevent.stop="selectTab(index)"
+                    @click.stop="selectTab(index)"
                     @keydown.stop="(e) => handleKeydown(e, vertical)"
                 >
                     <slot name="tab" :tab :index>

--- a/packages/vlossom/src/components/vs-text-wrap/VsTextWrap.vue
+++ b/packages/vlossom/src/components/vs-text-wrap/VsTextWrap.vue
@@ -11,7 +11,7 @@
                 type="button"
                 class="vs-text-wrap-button vs-copy-button"
                 aria-label="copy"
-                @click.prevent.stop="copyInnerText"
+                @click.stop="copyInnerText"
             >
                 <component
                     :is="copied ? CheckIcon : CopyIcon"
@@ -26,7 +26,7 @@
                 type="button"
                 class="vs-text-wrap-button vs-link-button"
                 aria-label="link"
-                @click.prevent.stop="openLink"
+                @click.stop="openLink"
             >
                 <LinkIcon class="vs-icon-container" :style="componentStyleSet.$linkIcon" />
             </button>


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
#522 문제를 해결하기 위해 click event에 불필요한 prevent를 제거함

## Description
- 이슈에 원인과 해결법이 정리되어 있음
- slot 내부에 checkbox가 들어갈 때 취약해서 slot으로 구성되는 UI에 붙은 클릭 이벤트를 위주로 작업