### PR TITLE
feat(VsDatePicker): add placeholder + key binding

### DIFF
--- a/packages/vlossom/src/components/vs-date-picker/README.ko.md
+++ b/packages/vlossom/src/components/vs-date-picker/README.ko.md
@@ -90,11 +90,13 @@ value = '2026-05';
 
 네이티브 캘린더는 다음 중 하나로 열립니다:
 
-- input 영역을 클릭하거나,
-- 오른쪽 끝의 캘린더 아이콘 버튼을 누르거나,
+- input 영역(또는 캘린더 아이콘)을 클릭 — 열린 상태에서 다시 클릭하면 닫힙니다.
+- 필드가 포커스된 상태(클릭이든 Tab 이동이든)에서 **Enter** 키를 누르면 picker가 열리고, 다시 누르면 닫힙니다(토글).
 - 사용자 제스처 안에서 `dpRef.value.open()`을 호출.
 
-`disabled`/`readonly` 상태에서는 세 가지 모두 무시됩니다.
+`disabled`/`readonly` 상태에서는 모두 무시됩니다.
+
+> **placeholder 참고**: 네이티브 `date`/`time` input은 `placeholder` 속성을 무시합니다. 값이 비어 있고 포커스되지 않은 동안에는 `text` input으로 렌더링해 `placeholder`가 보이게 하고, 상호작용 시 네이티브 picker 타입으로 전환합니다.
 
 ## 커스텀 룰
 

--- a/packages/vlossom/src/components/vs-date-picker/README.md
+++ b/packages/vlossom/src/components/vs-date-picker/README.md
@@ -90,11 +90,13 @@ value = '2026-05';
 
 The native calendar opens when:
 
-- the input area is clicked, or
-- the trailing calendar icon button is pressed, or
+- the input area (or the calendar icon) is clicked — clicking again while it is open closes it, or
+- the **Enter** key is pressed while the field is focused (whether reached by click or by Tab) — Enter toggles the picker open and closed, or
 - `dpRef.value.open()` is invoked inside a user-gesture handler.
 
-When `disabled` or `readonly` is set, all three triggers are no-ops.
+When `disabled` or `readonly` is set, all triggers are no-ops.
+
+> **Placeholder note**: native `date`/`time` inputs ignore the `placeholder` attribute. While the field is empty and unfocused it is rendered as a `text` input so the `placeholder` is visible, then switched to the native picker type on interaction.
 
 ## Custom Rules
 

--- a/packages/vlossom/src/components/vs-date-picker/VsDatePicker.vue
+++ b/packages/vlossom/src/components/vs-date-picker/VsDatePicker.vue
@@ -39,7 +39,9 @@
             @update:model-value="onDateInput"
             @focus="onFocus"
             @blur="onBlur"
-            @click="open"
+            @pointerdown="onPointerDown"
+            @click="onClick"
+            @keydown.enter.stop="onKeydownEnter"
         >
             <template #prepend>
                 <slot v-if="$slots['prepend']" name="prepend" />
@@ -180,6 +182,11 @@ export default defineComponent({
         const dateInputRef: TemplateRef<VsInputRef> = useTemplateRef('dateInputRef');
 
         const inputValue: Ref<VsDatePickerValueType> = ref(modelValue.value);
+        const isFocused = ref(false);
+        const pointerInitiated = ref(false);
+        // 네이티브 picker는 열기/닫기 API가 없어 상태를 직접 추적
+        const pickerOpen = ref(false);
+        const suppressFocusEvents = ref(false);
 
         const { componentStyleSet } = useStyleSet<VsDatePickerStyleSet>(componentName, styleSet);
 
@@ -234,16 +241,17 @@ export default defineComponent({
             return CalendarIcon;
         });
 
-        /** What is THIS?!?
-         * VsInputType is intentionally narrower for the public VsInput API.
-         * VsDatePicker still needs to pass native date/time input types to reuse VsInput's UI shell.
-         * Runtime validation stays in VsDatePicker, so this cast only bridges the internal prop type.
-         */
+        // date/time input은 placeholder를 무시 → 비어있고 비포커스면 text로 노출 후 네이티브 타입으로 캐스팅
         const deceiveType = computed<VsInputType>(() => {
+            if (!isFocused.value && !displayValue.value) {
+                return 'text';
+            }
             return type.value as unknown as VsInputType;
         });
 
         function onDateInput(value: string | number | null): void {
+            pickerOpen.value = false;
+
             const raw = value?.toString() ?? '';
             if (!raw) {
                 if (inputValue.value && !isValidFormat(inputValue.value, type.value)) {
@@ -274,26 +282,99 @@ export default defineComponent({
             emit('clear');
         }
 
+        function onPointerDown(): void {
+            pointerInitiated.value = true;
+        }
+
         function onFocus(e: FocusEvent): void {
+            // 포인터 focus는 click까지 text 유지(타입 변경 시 click 무시), 키보드 focus는 즉시 전환
+            if (!pointerInitiated.value) {
+                isFocused.value = true;
+            }
+            if (suppressFocusEvents.value) {
+                return;
+            }
             emit('focus', e);
         }
 
         function onBlur(e: FocusEvent): void {
+            isFocused.value = false;
+            pointerInitiated.value = false;
+            pickerOpen.value = false;
+            if (suppressFocusEvents.value) {
+                return;
+            }
             emit('blur', e);
         }
 
+        // text→네이티브 타입 전환 후 picker 열기. click 핸들러 안에서 해야 제스처가 유지돼 첫 click에 열림
         function openPicker(): void {
-            const input = dateInputRef.value?.inputRef;
-            if (!input || computedDisabled.value || computedReadonly.value) {
-                return;
-            }
-            const showPicker = input.showPicker;
-            if (typeof showPicker !== 'function') {
+            if (computedDisabled.value || computedReadonly.value) {
                 return;
             }
 
+            const input = dateInputRef.value?.inputRef;
+            if (!input) {
+                return;
+            }
+
+            isFocused.value = true;
+            if (input.type !== type.value) {
+                input.type = type.value;
+            }
+
             input.focus();
-            showPicker.call(input);
+
+            const showPicker = input.showPicker;
+            if (typeof showPicker === 'function') {
+                showPicker.call(input);
+            }
+            pickerOpen.value = true;
+        }
+
+        // 포커스 유지하며 닫는 API가 없어 blur로 닫고 재포커스
+        function closePicker(input: HTMLInputElement): void {
+            pickerOpen.value = false;
+            suppressFocusEvents.value = true;
+            input.blur();
+            input.focus();
+            suppressFocusEvents.value = false;
+        }
+
+        // 토글: 열린 picker는 mousedown에서 브라우저가 닫으므로 재오픈만 안 하면 됨
+        function onClick(): void {
+            pointerInitiated.value = false;
+
+            if (computedDisabled.value || computedReadonly.value) {
+                return;
+            }
+
+            if (pickerOpen.value) {
+                pickerOpen.value = false;
+                return;
+            }
+
+            openPicker();
+        }
+
+        function onKeydownEnter(e: KeyboardEvent): void {
+            if (computedDisabled.value || computedReadonly.value) {
+                return;
+            }
+
+            const input = dateInputRef.value?.inputRef;
+            if (!input) {
+                return;
+            }
+
+            e.preventDefault();
+
+            if (pickerOpen.value) {
+                closePicker(input);
+                return;
+            }
+
+            openPicker();
         }
 
         watch(
@@ -325,6 +406,9 @@ export default defineComponent({
 
             // Methods
             onDateInput,
+            onPointerDown,
+            onClick,
+            onKeydownEnter,
             onFocus,
             onBlur,
             focus,

--- a/packages/vlossom/src/components/vs-date-picker/__tests__/vs-date-picker.test.ts
+++ b/packages/vlossom/src/components/vs-date-picker/__tests__/vs-date-picker.test.ts
@@ -10,14 +10,18 @@ function findDateInput(wrapper: ReturnType<typeof mount>) {
 
 describe('VsDatePicker', () => {
     describe('datetime 기본 동작', () => {
-        it('type=date에서 VsInput 내부 input의 type 속성이 date여야 한다', () => {
+        it('type=date에서 포커스되면 VsInput 내부 input의 type 속성이 date여야 한다', async () => {
             const wrapper = mount(VsDatePicker, {
                 props: { modelValue: '', type: 'date' },
             });
+            // 빈 값 + 비포커스 상태에서는 placeholder 노출을 위해 text 타입으로 렌더링된다.
+            expect(findDateInput(wrapper).attributes('type')).toBe('text');
+
+            await findDateInput(wrapper).trigger('focus');
             expect(findDateInput(wrapper).attributes('type')).toBe('date');
         });
 
-        it('type 4종 (date/datetime-local/time/month) 전환', () => {
+        it('type 4종 (date/datetime-local/time/month) 전환', async () => {
             const types: Array<'date' | 'datetime-local' | 'time' | 'month'> = [
                 'date',
                 'datetime-local',
@@ -28,6 +32,8 @@ describe('VsDatePicker', () => {
                 const wrapper = mount(VsDatePicker, {
                     props: { modelValue: '', type: t },
                 });
+                // 포커스되면 native picker type으로 전환된다.
+                await findDateInput(wrapper).trigger('focus');
                 expect(findDateInput(wrapper).attributes('type')).toBe(t);
             }
         });
@@ -173,6 +179,151 @@ describe('VsDatePicker', () => {
             ).$refs.formRef;
             const valid = await formRef.validate();
             expect(valid).toBe(false);
+        });
+    });
+
+    describe('placeholder', () => {
+        it('빈 값이면 placeholder가 보이도록 input type이 text가 되고 placeholder가 forward된다', () => {
+            const wrapper = mount(VsDatePicker, {
+                props: { modelValue: '', type: 'date', placeholder: 'Select date' },
+            });
+            const input = findDateInput(wrapper);
+            // native date input은 placeholder를 무시하므로 빈 값일 때는 text 타입으로 노출한다.
+            expect(input.attributes('type')).toBe('text');
+            expect(input.attributes('placeholder')).toBe('Select date');
+        });
+
+        it('포커스 시 native picker type으로 전환되고 blur 후 빈 값이면 다시 text로 돌아간다', async () => {
+            const wrapper = mount(VsDatePicker, {
+                props: { modelValue: '', type: 'date', placeholder: 'Select date' },
+            });
+            await findDateInput(wrapper).trigger('focus');
+            expect(findDateInput(wrapper).attributes('type')).toBe('date');
+
+            await findDateInput(wrapper).trigger('blur');
+            expect(findDateInput(wrapper).attributes('type')).toBe('text');
+        });
+
+        it('값이 있으면 비포커스라도 native picker type을 유지한다', () => {
+            const wrapper = mount(VsDatePicker, {
+                props: { modelValue: '2026-05-18', type: 'date' },
+            });
+            expect(findDateInput(wrapper).attributes('type')).toBe('date');
+        });
+
+        it('pointer로 인한 focus 시에는 click 전까지 text 타입을 유지하고, click 시 native picker로 전환하며 picker를 연다', async () => {
+            // pointerdown -> focus 사이에 type을 바꾸면 브라우저가 click 이벤트를 삼켜
+            // 클릭-투-오픈이 깨진다. 따라서 pointer focus 동안에는 text를 유지해야 한다.
+            const wrapper = mount(VsDatePicker, {
+                props: { modelValue: '', type: 'date', placeholder: 'Select date' },
+            });
+            const inputEl = findDateInput(wrapper).element as HTMLInputElement & {
+                showPicker?: () => void;
+            };
+            const showPicker = vi.fn();
+            inputEl.showPicker = showPicker;
+
+            await findDateInput(wrapper).trigger('pointerdown');
+            await findDateInput(wrapper).trigger('focus');
+            // pointer로 인한 focus 동안에는 click을 삼키지 않도록 text 타입을 유지한다.
+            expect(findDateInput(wrapper).attributes('type')).toBe('text');
+
+            await findDateInput(wrapper).trigger('click');
+            expect(findDateInput(wrapper).attributes('type')).toBe('date');
+            expect(showPicker).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('picker toggle', () => {
+        function withShowPicker(wrapper: ReturnType<typeof mount>) {
+            const inputEl = findDateInput(wrapper).element as HTMLInputElement & {
+                showPicker?: () => void;
+            };
+            const showPicker = vi.fn();
+            inputEl.showPicker = showPicker;
+            return showPicker;
+        }
+
+        it('첫 클릭은 picker를 열고, 다시 클릭하면 다시 열지 않는다 (토글로 닫힘)', async () => {
+            const wrapper = mount(VsDatePicker, {
+                props: { modelValue: '', type: 'date' },
+            });
+            const showPicker = withShowPicker(wrapper);
+
+            await findDateInput(wrapper).trigger('click');
+            expect(showPicker).toHaveBeenCalledTimes(1);
+
+            // 열린 상태에서 다시 클릭하면 재오픈하지 않는다 (브라우저가 mousedown에서 닫음).
+            await findDateInput(wrapper).trigger('click');
+            expect(showPicker).toHaveBeenCalledTimes(1);
+
+            // 닫힌 뒤 다시 클릭하면 다시 열린다.
+            await findDateInput(wrapper).trigger('click');
+            expect(showPicker).toHaveBeenCalledTimes(2);
+        });
+
+        it('blur 후 다시 클릭하면 picker가 다시 열린다', async () => {
+            const wrapper = mount(VsDatePicker, {
+                props: { modelValue: '', type: 'date' },
+            });
+            const showPicker = withShowPicker(wrapper);
+
+            await findDateInput(wrapper).trigger('click');
+            expect(showPicker).toHaveBeenCalledTimes(1);
+
+            await findDateInput(wrapper).trigger('blur');
+            await findDateInput(wrapper).trigger('click');
+            expect(showPicker).toHaveBeenCalledTimes(2);
+        });
+
+        it('Enter 키로 picker를 열고 닫을 수 있다 (포커스 유지)', async () => {
+            const wrapper = mount(VsDatePicker, {
+                props: { modelValue: '', type: 'date' },
+            });
+            const showPicker = withShowPicker(wrapper);
+
+            await findDateInput(wrapper).trigger('focus');
+
+            // Enter로 열기
+            await findDateInput(wrapper).trigger('keydown', { key: 'Enter' });
+            expect(showPicker).toHaveBeenCalledTimes(1);
+
+            // Enter로 닫기 (재오픈 없음)
+            await findDateInput(wrapper).trigger('keydown', { key: 'Enter' });
+            expect(showPicker).toHaveBeenCalledTimes(1);
+
+            // Enter로 다시 열기
+            await findDateInput(wrapper).trigger('keydown', { key: 'Enter' });
+            expect(showPicker).toHaveBeenCalledTimes(2);
+        });
+
+        it('값을 선택하면 picker 상태가 닫힘으로 리셋되어 다음 클릭에 다시 열린다', async () => {
+            const wrapper = mount(VsDatePicker, {
+                props: { modelValue: '', type: 'date' },
+            });
+            const showPicker = withShowPicker(wrapper);
+
+            await findDateInput(wrapper).trigger('click');
+            expect(showPicker).toHaveBeenCalledTimes(1);
+
+            // 값 선택 = picker 닫힘
+            await findDateInput(wrapper).setValue('2026-05-18');
+
+            await findDateInput(wrapper).trigger('click');
+            expect(showPicker).toHaveBeenCalledTimes(2);
+        });
+
+        it('disabled/readonly 상태에서는 클릭/Enter로 picker가 열리지 않는다', async () => {
+            for (const propKey of ['disabled', 'readonly'] as const) {
+                const wrapper = mount(VsDatePicker, {
+                    props: { modelValue: '', type: 'date', [propKey]: true },
+                });
+                const showPicker = withShowPicker(wrapper);
+
+                await findDateInput(wrapper).trigger('click');
+                await findDateInput(wrapper).trigger('keydown', { key: 'Enter' });
+                expect(showPicker).not.toHaveBeenCalled();
+            }
         });
     });
 

--- a/packages/vlossom/src/components/vs-input/VsInput.vue
+++ b/packages/vlossom/src/components/vs-input/VsInput.vue
@@ -201,7 +201,9 @@ export default defineComponent({
 
         const { stateBoxClasses } = useStateClass(computedState);
 
-        const renderClearButton = computed(() => !noClear.value && !computedReadonly.value && !computedDisabled.value);
+        const renderClearButton = computed(
+            () => !!inputValue.value && !noClear.value && !computedReadonly.value && !computedDisabled.value,
+        );
 
         function onInput(event: Event) {
             const target = event.target as HTMLInputElement;


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary
vs-date-picker에 placeholder를 쓸 수 있게 해줘 (#528)

## Description
- 빈 값일 때 type을 text로 해서 placeholder 노출
- 포커스 되거나 값이 생기면 원래 prop으로 전달된 type으로 지정해줌
- 키보드 조작을 위해서 pointerdown, keydown.enter 이벤트 추가
- 기타: vs-input에서 value가 없을 때 x 버튼이 안 보이게 숨겨진 것 때문에 이벤트가 교란되는 이슈 있어서 숨김

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
