### PR TITLE
feat(number-util): add clamp utility for numeric value limits

### DIFF
--- a/packages/vlossom/src/components/vs-progress/VsProgress.vue
+++ b/packages/vlossom/src/components/vs-progress/VsProgress.vue
@@ -13,6 +13,7 @@ import { computed, defineComponent, toRefs } from 'vue';
 import { useColorScheme, useStyleSet } from '@/composables';
 import { VsComponent } from '@/declaration';
 import { getColorSchemeProps, getStyleSetProps } from '@/props';
+import { numberUtil } from '@/utils';
 import type { VsProgressStyleSet } from './types';
 
 const componentName = VsComponent.VsProgress;
@@ -50,23 +51,14 @@ export default defineComponent({
 
         const computedMax = computed(() => {
             const num = Number(max.value);
-            if (!isFinite(num) || num <= 0) {
-                return 1;
-            }
 
-            return num;
+            return numberUtil.clamp(num, 1, Number.MAX_SAFE_INTEGER);
         });
 
         const computedValue = computed(() => {
             const num = Number(value.value);
-            if (!isFinite(num) || num < 0) {
-                return 0;
-            }
-            if (num > computedMax.value) {
-                return computedMax.value;
-            }
 
-            return num;
+            return numberUtil.clamp(num, 0, computedMax.value);
         });
 
         return {

--- a/packages/vlossom/src/components/vs-progress/VsProgress.vue
+++ b/packages/vlossom/src/components/vs-progress/VsProgress.vue
@@ -27,6 +27,11 @@ export default defineComponent({
             default: 1,
             validator: (value: number | string) => {
                 const num = Number(value);
+
+                if (!isFinite(num) || num <= 0) {
+                    logUtil.warning(componentName, 'Max value should be a finite number and greater than 0');
+                }
+
                 return isFinite(num) && num > 0;
             },
         },
@@ -35,6 +40,11 @@ export default defineComponent({
             default: 0,
             validator: (value: number | string) => {
                 const num = Number(value);
+
+                if (!isFinite(num) || num < 0) {
+                    logUtil.warning(componentName, 'Value should be a finite number and greater than or equal to 0');
+                }
+
                 return isFinite(num) && num >= 0;
             },
         },
@@ -52,23 +62,11 @@ export default defineComponent({
         const computedMax = computed(() => {
             const num = Number(max.value);
 
-            if (isNaN(num)) {
-                logUtil.warning(componentName, 'Max value should be a number');
-            }
-
             return numberUtil.clamp(num, 1, Number.MAX_SAFE_INTEGER);
         });
 
         const computedValue = computed(() => {
             const num = Number(value.value);
-
-            if (isNaN(num)) {
-                logUtil.warning(componentName, 'Value should be a number');
-            }
-
-            if (num > computedMax.value || num < 0) {
-                logUtil.warning(componentName, `Value should be in the range of 0 to ${computedMax.value}`);
-            }
 
             return numberUtil.clamp(num, 0, computedMax.value);
         });

--- a/packages/vlossom/src/components/vs-progress/VsProgress.vue
+++ b/packages/vlossom/src/components/vs-progress/VsProgress.vue
@@ -13,7 +13,7 @@ import { computed, defineComponent, toRefs } from 'vue';
 import { useColorScheme, useStyleSet } from '@/composables';
 import { VsComponent } from '@/declaration';
 import { getColorSchemeProps, getStyleSetProps } from '@/props';
-import { numberUtil } from '@/utils';
+import { logUtil, numberUtil } from '@/utils';
 import type { VsProgressStyleSet } from './types';
 
 const componentName = VsComponent.VsProgress;
@@ -52,11 +52,23 @@ export default defineComponent({
         const computedMax = computed(() => {
             const num = Number(max.value);
 
+            if (isNaN(num)) {
+                logUtil.warning(componentName, 'Max value should be a number');
+            }
+
             return numberUtil.clamp(num, 1, Number.MAX_SAFE_INTEGER);
         });
 
         const computedValue = computed(() => {
             const num = Number(value.value);
+
+            if (isNaN(num)) {
+                logUtil.warning(componentName, 'Value should be a number');
+            }
+
+            if (num > computedMax.value || num < 0) {
+                logUtil.warning(componentName, `Value should be in the range of 0 to ${computedMax.value}`);
+            }
 
             return numberUtil.clamp(num, 0, computedMax.value);
         });

--- a/packages/vlossom/src/stores/options-store.ts
+++ b/packages/vlossom/src/stores/options-store.ts
@@ -1,6 +1,6 @@
 import { ref, type Ref, computed } from 'vue';
 import type { GlobalColorSchemes, GlobalStyleSets, Theme, VsComponent } from '@/declaration';
-import { numberUtil } from '@/utils';
+import { logUtil, numberUtil } from '@/utils';
 
 export class OptionsStore {
     private _colorScheme: Ref<GlobalColorSchemes> = ref({});
@@ -29,6 +29,14 @@ export class OptionsStore {
     public radiusRatio = computed(() => this._radiusRatio.value);
 
     public setRadiusRatio(radiusRatio: number) {
+        if (isNaN(radiusRatio)) {
+            logUtil.warning('OptionsStore', 'Radius ratio should be a number');
+        }
+
+        if (radiusRatio < 0 || radiusRatio > 1) {
+            logUtil.warning('OptionsStore', 'Radius ratio should be in the range of 0 to 1');
+        }
+
         this._radiusRatio.value = numberUtil.clamp(radiusRatio, 0, 1);
     }
 

--- a/packages/vlossom/src/stores/options-store.ts
+++ b/packages/vlossom/src/stores/options-store.ts
@@ -1,5 +1,6 @@
 import { ref, type Ref, computed } from 'vue';
 import type { GlobalColorSchemes, GlobalStyleSets, Theme, VsComponent } from '@/declaration';
+import { numberUtil } from '@/utils';
 
 export class OptionsStore {
     private _colorScheme: Ref<GlobalColorSchemes> = ref({});
@@ -28,7 +29,7 @@ export class OptionsStore {
     public radiusRatio = computed(() => this._radiusRatio.value);
 
     public setRadiusRatio(radiusRatio: number) {
-        this._radiusRatio.value = Math.max(0, Math.min(1, radiusRatio));
+        this._radiusRatio.value = numberUtil.clamp(radiusRatio, 0, 1);
     }
 
     public getComponentStyleSet<T extends { [key: string]: any }>(

--- a/packages/vlossom/src/utils/README.ko.md
+++ b/packages/vlossom/src/utils/README.ko.md
@@ -9,7 +9,7 @@ Vlossom 내부에서 사용되며 애플리케이션 코드에서도 사용할 �
 ## 기본 사용법
 
 ```typescript
-import { clipboardUtil, compareUtil, deviceUtil, domUtil, functionUtil, logUtil, objectUtil, propsUtil, stringUtil } from 'vlossom';
+import { clipboardUtil, compareUtil, deviceUtil, domUtil, functionUtil, logUtil, numberUtil, objectUtil, propsUtil, stringUtil } from 'vlossom';
 ```
 
 또는 개별 유틸리티를 가져옵니다:
@@ -66,6 +66,12 @@ const size = stringUtil.toStringSize(100); // '100px'
 | logUtil  | `warning`     | `target: string, message: string`                              | `[Vlossom] {target}:` 접두사가 붙은 경고 메시지를 기록합니다.         |
 | logUtil  | `propError`   | `componentName: string, property: string, message: string`     | `error`를 사용하여 컴포넌트 속성에 대한 오류를 기록합니다.            |
 | logUtil  | `propWarning` | `componentName: string, property: string, message: string`     | `warning`을 사용하여 컴포넌트 속성에 대한 경고를 기록합니다.          |
+
+### numberUtil
+
+| 카테고리   | 메서드  | 파라미터                                  | 설명                                      |
+| ---------- | ------- | ----------------------------------------- | ----------------------------------------- |
+| numberUtil | `clamp` | `value: number, min: number, max: number` | `value`를 `min` 이상 `max` 이하 범위로 제한합니다. |
 
 ### objectUtil
 

--- a/packages/vlossom/src/utils/README.ko.md
+++ b/packages/vlossom/src/utils/README.ko.md
@@ -9,7 +9,18 @@ Vlossom 내부에서 사용되며 애플리케이션 코드에서도 사용할 �
 ## 기본 사용법
 
 ```typescript
-import { clipboardUtil, compareUtil, deviceUtil, domUtil, functionUtil, logUtil, numberUtil, objectUtil, propsUtil, stringUtil } from 'vlossom';
+import {
+    clipboardUtil,
+    compareUtil,
+    deviceUtil,
+    domUtil,
+    functionUtil,
+    logUtil,
+    numberUtil,
+    objectUtil,
+    propsUtil,
+    stringUtil,
+} from 'vlossom';
 ```
 
 또는 개별 유틸리티를 가져옵니다:
@@ -25,83 +36,83 @@ const size = stringUtil.toStringSize(100); // '100px'
 
 ### clipboardUtil
 
-| 카테고리      | 메서드  | 파라미터            | 설명                                                                                                         |
-| ------------- | ------- | ------------------- | ------------------------------------------------------------------------------------------------------------ |
-| clipboardUtil | `copy`  | `text: string`      | `text`를 시스템 클립보드에 복사합니다. 성공 시 `true`, 실패 또는 Clipboard API를 지원하지 않는 경우 `false`를 반환하는 `Promise<boolean>`을 반환합니다. |
+| 카테고리      | 메서드 | 파라미터       | 설명                                                                                                                                                    |
+| ------------- | ------ | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| clipboardUtil | `copy` | `text: string` | `text`를 시스템 클립보드에 복사합니다. 성공 시 `true`, 실패 또는 Clipboard API를 지원하지 않는 경우 `false`를 반환하는 `Promise<boolean>`을 반환합니다. |
 
 ### compareUtil
 
-| 카테고리    | 메서드          | 파라미터                          | 설명                                                                                                                                       |
-| ----------- | --------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| 카테고리    | 메서드          | 파라미터                           | 설명                                                                                                                                                           |
+| ----------- | --------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | compareUtil | `compareValues` | `aValue: unknown, bValue: unknown` | 두 값을 비교하여 숫자를 반환합니다: `a < b`이면 음수, `a > b`이면 양수, 같으면 `0`. `null`, `string`, `number`, `Date`, `boolean`, `object` 타입을 처리합니다. |
 
 ### deviceUtil
 
-| 카테고리   | 메서드          | 파라미터 | 설명                                                                                             |
-| ---------- | --------------- | -------- | ------------------------------------------------------------------------------------------------ |
+| 카테고리   | 메서드          | 파라미터 | 설명                                                                                                                     |
+| ---------- | --------------- | -------- | ------------------------------------------------------------------------------------------------------------------------ |
 | deviceUtil | `isTouchDevice` | —        | 현재 기기가 터치 입력을 지원하는 경우 `true`를 반환합니다 (`ontouchstart`, `maxTouchPoints`, 포인터 미디어 쿼리를 확인). |
 
 ### domUtil
 
-| 카테고리 | 메서드          | 파라미터               | 설명                                                                                             |
-| -------- | --------------- | ---------------------- | ------------------------------------------------------------------------------------------------ |
-| domUtil  | `isBrowser`     | —                      | 브라우저 환경(`window`가 정의된 경우)에서 실행 중이면 `true`를 반환합니다.                       |
-| domUtil  | `getClientRect` | `element: HTMLElement` | `getBoundingClientRect()`를 통해 요소의 `DOMRect`를 반환합니다.                                  |
-| domUtil  | `isScrollableX` | `element: HTMLElement` | 요소가 수평 스크롤이 가능한 경우 `true`를 반환합니다 (`overflow-x` 및 콘텐츠 너비 기반).         |
-| domUtil  | `isScrollableY` | `element: HTMLElement` | 요소가 수직 스크롤이 가능한 경우 `true`를 반환합니다 (`overflow-y` 및 콘텐츠 높이 기반).         |
+| 카테고리 | 메서드          | 파라미터               | 설명                                                                                     |
+| -------- | --------------- | ---------------------- | ---------------------------------------------------------------------------------------- |
+| domUtil  | `isBrowser`     | —                      | 브라우저 환경(`window`가 정의된 경우)에서 실행 중이면 `true`를 반환합니다.               |
+| domUtil  | `getClientRect` | `element: HTMLElement` | `getBoundingClientRect()`를 통해 요소의 `DOMRect`를 반환합니다.                          |
+| domUtil  | `isScrollableX` | `element: HTMLElement` | 요소가 수평 스크롤이 가능한 경우 `true`를 반환합니다 (`overflow-x` 및 콘텐츠 너비 기반). |
+| domUtil  | `isScrollableY` | `element: HTMLElement` | 요소가 수직 스크롤이 가능한 경우 `true`를 반환합니다 (`overflow-y` 및 콘텐츠 높이 기반). |
 
 ### functionUtil
 
-| 카테고리     | 메서드       | 파라미터                                                                          | 설명                                                                                                                                 |
-| ------------ | ------------ | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| functionUtil | `throttle`   | *(radash에서 가져옴)* `fn, interval`                                              | `interval` 밀리초당 최대 한 번 실행되는 스로틀된 버전의 함수를 반환합니다.                                                          |
-| functionUtil | `debounce`   | *(radash에서 가져옴)* `fn, delay`                                                 | 마지막 호출 후 `delay` 밀리초가 지날 때까지 실행을 지연하는 디바운스된 버전의 함수를 반환합니다.                                     |
+| 카테고리     | 메서드       | 파라미터                                                         | 설명                                                                                                                                   |
+| ------------ | ------------ | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| functionUtil | `throttle`   | _(radash에서 가져옴)_ `fn, interval`                             | `interval` 밀리초당 최대 한 번 실행되는 스로틀된 버전의 함수를 반환합니다.                                                             |
+| functionUtil | `debounce`   | _(radash에서 가져옴)_ `fn, delay`                                | 마지막 호출 후 `delay` 밀리초가 지날 때까지 실행을 지연하는 디바운스된 버전의 함수를 반환합니다.                                       |
 | functionUtil | `toCallable` | `maybeFn: undefined \| TResult \| ((...args: TArgs) => TResult)` | 값 또는 함수를 호출 가능한 함수로 정규화합니다. `undefined`이면 `undefined`를 반환하는 함수를 반환합니다. 일반 값이면 함수로 감쌉니다. |
 
 ### logUtil
 
-| 카테고리 | 메서드        | 파라미터                                                       | 설명                                                                  |
-| -------- | ------------- | -------------------------------------------------------------- | --------------------------------------------------------------------- |
-| logUtil  | `error`       | `target: string, message: string`                              | `[Vlossom] {target}:` 접두사가 붙은 오류 메시지를 기록합니다.         |
-| logUtil  | `warning`     | `target: string, message: string`                              | `[Vlossom] {target}:` 접두사가 붙은 경고 메시지를 기록합니다.         |
-| logUtil  | `propError`   | `componentName: string, property: string, message: string`     | `error`를 사용하여 컴포넌트 속성에 대한 오류를 기록합니다.            |
-| logUtil  | `propWarning` | `componentName: string, property: string, message: string`     | `warning`을 사용하여 컴포넌트 속성에 대한 경고를 기록합니다.          |
+| 카테고리 | 메서드        | 파라미터                                                   | 설명                                                          |
+| -------- | ------------- | ---------------------------------------------------------- | ------------------------------------------------------------- |
+| logUtil  | `error`       | `target: string, message: string`                          | `[Vlossom] {target}:` 접두사가 붙은 오류 메시지를 기록합니다. |
+| logUtil  | `warning`     | `target: string, message: string`                          | `[Vlossom] {target}:` 접두사가 붙은 경고 메시지를 기록합니다. |
+| logUtil  | `propError`   | `componentName: string, property: string, message: string` | `error`를 사용하여 컴포넌트 속성에 대한 오류를 기록합니다.    |
+| logUtil  | `propWarning` | `componentName: string, property: string, message: string` | `warning`을 사용하여 컴포넌트 속성에 대한 경고를 기록합니다.  |
 
 ### numberUtil
 
-| 카테고리   | 메서드  | 파라미터                                  | 설명                                      |
-| ---------- | ------- | ----------------------------------------- | ----------------------------------------- |
+| 카테고리   | 메서드  | 파라미터                                  | 설명                                               |
+| ---------- | ------- | ----------------------------------------- | -------------------------------------------------- |
 | numberUtil | `clamp` | `value: number, min: number, max: number` | `value`를 `min` 이상 `max` 이하 범위로 제한합니다. |
 
 ### objectUtil
 
-| 카테고리   | 메서드     | 파라미터            | 설명                                                                                                     |
-| ---------- | ---------- | ------------------- | -------------------------------------------------------------------------------------------------------- |
-| objectUtil | `assign`   | *(radash에서 가져옴)* | 소스 객체의 속성을 대상 객체에 깊은 복사로 할당합니다.                                                  |
-| objectUtil | `crush`    | *(radash에서 가져옴)* | 중첩된 객체를 점 표기법 키를 사용하는 단일 레벨 객체로 평탄화합니다.                                    |
-| objectUtil | `get`      | *(radash에서 가져옴)* | 점 표기법 경로를 통해 객체에서 중첩된 값을 안전하게 가져옵니다.                                         |
-| objectUtil | `isEmpty`  | *(radash에서 가져옴)* | 값이 빈 객체, 배열, 문자열, `null` 또는 `undefined`이면 `true`를 반환합니다.                            |
-| objectUtil | `isEqual`  | *(radash에서 가져옴)* | 두 값 간의 깊은 동등성 비교를 수행합니다.                                                               |
-| objectUtil | `isObject` | *(radash에서 가져옴)* | 값이 일반 객체(배열이나 null이 아닌)인 경우 `true`를 반환합니다.                                        |
-| objectUtil | `omit`     | *(radash에서 가져옴)* | 지정된 키가 제거된 객체의 복사본을 반환합니다.                                                          |
-| objectUtil | `shake`    | *(radash에서 가져옴)* | 모든 falsy 값(또는 조건자와 일치하는 값)이 제거된 객체의 복사본을 반환합니다.                           |
+| 카테고리   | 메서드     | 파라미터              | 설명                                                                          |
+| ---------- | ---------- | --------------------- | ----------------------------------------------------------------------------- |
+| objectUtil | `assign`   | _(radash에서 가져옴)_ | 소스 객체의 속성을 대상 객체에 깊은 복사로 할당합니다.                        |
+| objectUtil | `crush`    | _(radash에서 가져옴)_ | 중첩된 객체를 점 표기법 키를 사용하는 단일 레벨 객체로 평탄화합니다.          |
+| objectUtil | `get`      | _(radash에서 가져옴)_ | 점 표기법 경로를 통해 객체에서 중첩된 값을 안전하게 가져옵니다.               |
+| objectUtil | `isEmpty`  | _(radash에서 가져옴)_ | 값이 빈 객체, 배열, 문자열, `null` 또는 `undefined`이면 `true`를 반환합니다.  |
+| objectUtil | `isEqual`  | _(radash에서 가져옴)_ | 두 값 간의 깊은 동등성 비교를 수행합니다.                                     |
+| objectUtil | `isObject` | _(radash에서 가져옴)_ | 값이 일반 객체(배열이나 null이 아닌)인 경우 `true`를 반환합니다.              |
+| objectUtil | `omit`     | _(radash에서 가져옴)_ | 지정된 키가 제거된 객체의 복사본을 반환합니다.                                |
+| objectUtil | `shake`    | _(radash에서 가져옴)_ | 모든 falsy 값(또는 조건자와 일치하는 값)이 제거된 객체의 복사본을 반환합니다. |
 
 ### propsUtil
 
-| 카테고리  | 메서드              | 파라미터                                                         | 설명                                                                                                          |
-| --------- | ------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| propsUtil | `checkValidNumber`  | `componentName: string, property: string, value: number \| string` | 값이 안전한 JavaScript 숫자인지 유효성을 검사합니다. 유효하지 않으면 `logUtil`을 통해 prop 오류를 기록하고 `false`를 반환합니다. |
+| 카테고리  | 메서드             | 파라미터                                                           | 설명                                                                                                                             |
+| --------- | ------------------ | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| propsUtil | `checkValidNumber` | `componentName: string, property: string, value: number \| string` | 값이 안전한 JavaScript 숫자인지 유효성을 검사합니다. 유효하지 않으면 `logUtil`을 통해 prop 오류를 기록하고 `false`를 반환합니다. |
 
 ### stringUtil
 
-| 카테고리   | 메서드              | 파라미터                            | 설명                                                                                                            |
-| ---------- | ------------------- | ----------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| stringUtil | `createID`          | `size?: number` (기본값 10)         | 주어진 길이의 무작위 알파벳 문자열 ID를 생성합니다. ID는 숫자로 시작하지 않습니다.                              |
-| stringUtil | `convertToString`   | `value: any`                        | 임의의 값을 문자열로 변환합니다. 객체는 `JSON.stringify`로 직렬화되고, 다른 타입은 `String()`을 사용합니다.    |
-| stringUtil | `toStringSize`      | `value: number \| string`           | 순수한 숫자를 픽셀 문자열로 변환합니다 (예: `100` → `'100px'`). 기존 단위가 있는 문자열은 그대로 반환됩니다.   |
-| stringUtil | `toFileSizeFormat`  | `bytes: number`                     | 바이트 수를 사람이 읽기 쉬운 문자열로 포맷합니다 (예: `1024` → `'1 KB'`).                                     |
-| stringUtil | `hash`              | `str: string`                       | `vs-` 접두사가 붙은 짧은 결정론적 해시 문자열을 계산합니다 (base-36 인코딩).                                   |
-| stringUtil | `kebabCase`         | *(change-case에서 가져옴)*          | 문자열을 kebab-case로 변환합니다 (예: `'fooBar'` → `'foo-bar'`).                                               |
+| 카테고리   | 메서드             | 파라미터                    | 설명                                                                                                         |
+| ---------- | ------------------ | --------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| stringUtil | `createID`         | `size?: number` (기본값 10) | 주어진 길이의 무작위 알파벳 문자열 ID를 생성합니다. ID는 숫자로 시작하지 않습니다.                           |
+| stringUtil | `convertToString`  | `value: any`                | 임의의 값을 문자열로 변환합니다. 객체는 `JSON.stringify`로 직렬화되고, 다른 타입은 `String()`을 사용합니다.  |
+| stringUtil | `toStringSize`     | `value: number \| string`   | 순수한 숫자를 픽셀 문자열로 변환합니다 (예: `100` → `'100px'`). 기존 단위가 있는 문자열은 그대로 반환됩니다. |
+| stringUtil | `toFileSizeFormat` | `bytes: number`             | 바이트 수를 사람이 읽기 쉬운 문자열로 포맷합니다 (예: `1024` → `'1 KB'`).                                    |
+| stringUtil | `hash`             | `str: string`               | `vs-` 접두사가 붙은 짧은 결정론적 해시 문자열을 계산합니다 (base-36 인코딩).                                 |
+| stringUtil | `kebabCase`        | _(change-case에서 가져옴)_  | 문자열을 kebab-case로 변환합니다 (예: `'fooBar'` → `'foo-bar'`).                                             |
 
 ## 주의사항
 

--- a/packages/vlossom/src/utils/README.md
+++ b/packages/vlossom/src/utils/README.md
@@ -9,7 +9,7 @@ A collection of utility modules used internally by Vlossom and available for use
 ## Basic Usage
 
 ```typescript
-import { clipboardUtil, compareUtil, deviceUtil, domUtil, functionUtil, logUtil, objectUtil, propsUtil, stringUtil } from 'vlossom';
+import { clipboardUtil, compareUtil, deviceUtil, domUtil, functionUtil, logUtil, numberUtil, objectUtil, propsUtil, stringUtil } from 'vlossom';
 ```
 
 Or import individual utilities:
@@ -66,6 +66,12 @@ const size = stringUtil.toStringSize(100); // '100px'
 | logUtil  | `warning`     | `target: string, message: string`                       | Logs a warning message prefixed with `[Vlossom] {target}:`.                     |
 | logUtil  | `propError`   | `componentName: string, property: string, message: string` | Logs an error for a component property using `error`.                           |
 | logUtil  | `propWarning` | `componentName: string, property: string, message: string` | Logs a warning for a component property using `warning`.                        |
+
+### numberUtil
+
+| Category   | Method  | Parameters                                  | Description                                      |
+| ---------- | ------- | ------------------------------------------- | ------------------------------------------------ |
+| numberUtil | `clamp` | `value: number, min: number, max: number`   | Restricts `value` to the inclusive `min`-`max` range. |
 
 ### objectUtil
 

--- a/packages/vlossom/src/utils/README.md
+++ b/packages/vlossom/src/utils/README.md
@@ -9,7 +9,18 @@ A collection of utility modules used internally by Vlossom and available for use
 ## Basic Usage
 
 ```typescript
-import { clipboardUtil, compareUtil, deviceUtil, domUtil, functionUtil, logUtil, numberUtil, objectUtil, propsUtil, stringUtil } from 'vlossom';
+import {
+    clipboardUtil,
+    compareUtil,
+    deviceUtil,
+    domUtil,
+    functionUtil,
+    logUtil,
+    numberUtil,
+    objectUtil,
+    propsUtil,
+    stringUtil,
+} from 'vlossom';
 ```
 
 Or import individual utilities:
@@ -25,83 +36,83 @@ const size = stringUtil.toStringSize(100); // '100px'
 
 ### clipboardUtil
 
-| Category      | Method  | Parameters          | Description                                                                                        |
-| ------------- | ------- | ------------------- | -------------------------------------------------------------------------------------------------- |
-| clipboardUtil | `copy`  | `text: string`      | Copies `text` to the system clipboard. Returns `Promise<boolean>` — `true` on success, `false` on failure or if the Clipboard API is unsupported. |
+| Category      | Method | Parameters     | Description                                                                                                                                       |
+| ------------- | ------ | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| clipboardUtil | `copy` | `text: string` | Copies `text` to the system clipboard. Returns `Promise<boolean>` — `true` on success, `false` on failure or if the Clipboard API is unsupported. |
 
 ### compareUtil
 
-| Category    | Method          | Parameters                        | Description                                                                                                                          |
-| ----------- | --------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Category    | Method          | Parameters                         | Description                                                                                                                                                                  |
+| ----------- | --------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | compareUtil | `compareValues` | `aValue: unknown, bValue: unknown` | Compares two values and returns a number: negative if `a < b`, positive if `a > b`, `0` if equal. Handles `null`, `string`, `number`, `Date`, `boolean`, and `object` types. |
 
 ### deviceUtil
 
-| Category   | Method          | Parameters | Description                                                                                    |
-| ---------- | --------------- | ---------- | ---------------------------------------------------------------------------------------------- |
+| Category   | Method          | Parameters | Description                                                                                                                   |
+| ---------- | --------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | deviceUtil | `isTouchDevice` | —          | Returns `true` if the current device supports touch input (checks `ontouchstart`, `maxTouchPoints`, and pointer media query). |
 
 ### domUtil
 
-| Category | Method          | Parameters                  | Description                                                                                    |
-| -------- | --------------- | --------------------------- | ---------------------------------------------------------------------------------------------- |
-| domUtil  | `isBrowser`     | —                           | Returns `true` if the code is running in a browser environment (`window` is defined).          |
-| domUtil  | `getClientRect` | `element: HTMLElement`      | Returns the `DOMRect` of the element via `getBoundingClientRect()`.                            |
-| domUtil  | `isScrollableX` | `element: HTMLElement`      | Returns `true` if the element can scroll horizontally (based on `overflow-x` and content width). |
-| domUtil  | `isScrollableY` | `element: HTMLElement`      | Returns `true` if the element can scroll vertically (based on `overflow-y` and content height). |
+| Category | Method          | Parameters             | Description                                                                                      |
+| -------- | --------------- | ---------------------- | ------------------------------------------------------------------------------------------------ |
+| domUtil  | `isBrowser`     | —                      | Returns `true` if the code is running in a browser environment (`window` is defined).            |
+| domUtil  | `getClientRect` | `element: HTMLElement` | Returns the `DOMRect` of the element via `getBoundingClientRect()`.                              |
+| domUtil  | `isScrollableX` | `element: HTMLElement` | Returns `true` if the element can scroll horizontally (based on `overflow-x` and content width). |
+| domUtil  | `isScrollableY` | `element: HTMLElement` | Returns `true` if the element can scroll vertically (based on `overflow-y` and content height).  |
 
 ### functionUtil
 
-| Category     | Method       | Parameters                                                                        | Description                                                                                                                   |
-| ------------ | ------------ | --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| functionUtil | `throttle`   | *(from radash)* `fn, interval`                                                    | Returns a throttled version of the function that executes at most once per `interval` milliseconds.                           |
-| functionUtil | `debounce`   | *(from radash)* `fn, delay`                                                       | Returns a debounced version of the function that delays execution until `delay` milliseconds after the last invocation.       |
-| functionUtil | `toCallable` | `maybeFn: undefined \| TResult \| ((...args: TArgs) => TResult)`   | Normalizes a value or function into a callable function. If `undefined`, returns a function that returns `undefined`. If a plain value, wraps it in a function. |
+| Category     | Method       | Parameters                                                       | Description                                                                                                                                                     |
+| ------------ | ------------ | ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| functionUtil | `throttle`   | _(from radash)_ `fn, interval`                                   | Returns a throttled version of the function that executes at most once per `interval` milliseconds.                                                             |
+| functionUtil | `debounce`   | _(from radash)_ `fn, delay`                                      | Returns a debounced version of the function that delays execution until `delay` milliseconds after the last invocation.                                         |
+| functionUtil | `toCallable` | `maybeFn: undefined \| TResult \| ((...args: TArgs) => TResult)` | Normalizes a value or function into a callable function. If `undefined`, returns a function that returns `undefined`. If a plain value, wraps it in a function. |
 
 ### logUtil
 
-| Category | Method        | Parameters                                              | Description                                                                     |
-| -------- | ------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| logUtil  | `error`       | `target: string, message: string`                       | Logs an error message prefixed with `[Vlossom] {target}:`.                      |
-| logUtil  | `warning`     | `target: string, message: string`                       | Logs a warning message prefixed with `[Vlossom] {target}:`.                     |
-| logUtil  | `propError`   | `componentName: string, property: string, message: string` | Logs an error for a component property using `error`.                           |
-| logUtil  | `propWarning` | `componentName: string, property: string, message: string` | Logs a warning for a component property using `warning`.                        |
+| Category | Method        | Parameters                                                 | Description                                                 |
+| -------- | ------------- | ---------------------------------------------------------- | ----------------------------------------------------------- |
+| logUtil  | `error`       | `target: string, message: string`                          | Logs an error message prefixed with `[Vlossom] {target}:`.  |
+| logUtil  | `warning`     | `target: string, message: string`                          | Logs a warning message prefixed with `[Vlossom] {target}:`. |
+| logUtil  | `propError`   | `componentName: string, property: string, message: string` | Logs an error for a component property using `error`.       |
+| logUtil  | `propWarning` | `componentName: string, property: string, message: string` | Logs a warning for a component property using `warning`.    |
 
 ### numberUtil
 
-| Category   | Method  | Parameters                                  | Description                                      |
-| ---------- | ------- | ------------------------------------------- | ------------------------------------------------ |
-| numberUtil | `clamp` | `value: number, min: number, max: number`   | Restricts `value` to the inclusive `min`-`max` range. |
+| Category   | Method  | Parameters                                | Description                                           |
+| ---------- | ------- | ----------------------------------------- | ----------------------------------------------------- |
+| numberUtil | `clamp` | `value: number, min: number, max: number` | Restricts `value` to the inclusive `min`-`max` range. |
 
 ### objectUtil
 
-| Category   | Method     | Parameters                           | Description                                                                                                |
-| ---------- | ---------- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
-| objectUtil | `assign`   | *(from radash)*                      | Deep assigns properties from source objects to a target object.                                            |
-| objectUtil | `crush`    | *(from radash)*                      | Flattens a nested object into a single-level object with dot-notation keys.                                |
-| objectUtil | `get`      | *(from radash)*                      | Safely retrieves a nested value from an object by dot-notation path.                                       |
-| objectUtil | `isEmpty`  | *(from radash)*                      | Returns `true` if the value is an empty object, array, string, `null`, or `undefined`.                    |
-| objectUtil | `isEqual`  | *(from radash)*                      | Performs a deep equality comparison between two values.                                                    |
-| objectUtil | `isObject` | *(from radash)*                      | Returns `true` if the value is a plain object (not an array or null).                                      |
-| objectUtil | `omit`     | *(from radash)*                      | Returns a copy of the object with the specified keys removed.                                              |
-| objectUtil | `shake`    | *(from radash)*                      | Returns a copy of the object with all falsy values (or values matching a predicate) removed.               |
+| Category   | Method     | Parameters      | Description                                                                                  |
+| ---------- | ---------- | --------------- | -------------------------------------------------------------------------------------------- |
+| objectUtil | `assign`   | _(from radash)_ | Deep assigns properties from source objects to a target object.                              |
+| objectUtil | `crush`    | _(from radash)_ | Flattens a nested object into a single-level object with dot-notation keys.                  |
+| objectUtil | `get`      | _(from radash)_ | Safely retrieves a nested value from an object by dot-notation path.                         |
+| objectUtil | `isEmpty`  | _(from radash)_ | Returns `true` if the value is an empty object, array, string, `null`, or `undefined`.       |
+| objectUtil | `isEqual`  | _(from radash)_ | Performs a deep equality comparison between two values.                                      |
+| objectUtil | `isObject` | _(from radash)_ | Returns `true` if the value is a plain object (not an array or null).                        |
+| objectUtil | `omit`     | _(from radash)_ | Returns a copy of the object with the specified keys removed.                                |
+| objectUtil | `shake`    | _(from radash)_ | Returns a copy of the object with all falsy values (or values matching a predicate) removed. |
 
 ### propsUtil
 
-| Category  | Method              | Parameters                                                  | Description                                                                                                   |
-| --------- | ------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| propsUtil | `checkValidNumber`  | `componentName: string, property: string, value: number \| string` | Validates that the value is a safe JavaScript number. Logs a prop error via `logUtil` and returns `false` if invalid. |
+| Category  | Method             | Parameters                                                         | Description                                                                                                           |
+| --------- | ------------------ | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| propsUtil | `checkValidNumber` | `componentName: string, property: string, value: number \| string` | Validates that the value is a safe JavaScript number. Logs a prop error via `logUtil` and returns `false` if invalid. |
 
 ### stringUtil
 
-| Category   | Method              | Parameters                   | Description                                                                                                        |
-| ---------- | ------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| stringUtil | `createID`          | `size?: number` (default 10) | Generates a random alphabetic string ID of the given length. IDs never start with a digit.                        |
-| stringUtil | `convertToString`   | `value: any`                 | Converts any value to a string. Objects are serialized with `JSON.stringify`; other types use `String()`.          |
-| stringUtil | `toStringSize`      | `value: number \| string`    | Converts a bare number to a pixel string (e.g. `100` → `'100px'`). Strings with existing units are returned as-is. |
-| stringUtil | `toFileSizeFormat`  | `bytes: number`              | Formats a byte count into a human-readable string (e.g. `1024` → `'1 KB'`).                                       |
-| stringUtil | `hash`              | `str: string`                | Computes a short deterministic hash string prefixed with `vs-` (base-36 encoded).                                  |
-| stringUtil | `kebabCase`         | *(from change-case)*         | Converts a string to kebab-case (e.g. `'fooBar'` → `'foo-bar'`).                                                  |
+| Category   | Method             | Parameters                   | Description                                                                                                        |
+| ---------- | ------------------ | ---------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| stringUtil | `createID`         | `size?: number` (default 10) | Generates a random alphabetic string ID of the given length. IDs never start with a digit.                         |
+| stringUtil | `convertToString`  | `value: any`                 | Converts any value to a string. Objects are serialized with `JSON.stringify`; other types use `String()`.          |
+| stringUtil | `toStringSize`     | `value: number \| string`    | Converts a bare number to a pixel string (e.g. `100` → `'100px'`). Strings with existing units are returned as-is. |
+| stringUtil | `toFileSizeFormat` | `bytes: number`              | Formats a byte count into a human-readable string (e.g. `1024` → `'1 KB'`).                                        |
+| stringUtil | `hash`             | `str: string`                | Computes a short deterministic hash string prefixed with `vs-` (base-36 encoded).                                  |
+| stringUtil | `kebabCase`        | _(from change-case)_         | Converts a string to kebab-case (e.g. `'fooBar'` → `'foo-bar'`).                                                   |
 
 ## Caution
 

--- a/packages/vlossom/src/utils/__tests__/number-util.test.ts
+++ b/packages/vlossom/src/utils/__tests__/number-util.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { logUtil } from './../log-util';
+import { numberUtil } from './../number-util';
+
+describe('number-util', () => {
+    describe('clamp()', () => {
+        beforeEach(() => {
+            vi.spyOn(logUtil, 'warning').mockImplementation(() => {});
+        });
+
+        afterEach(() => {
+            vi.restoreAllMocks();
+        });
+
+        it('범위 안의 값은 그대로 반환한다', () => {
+            expect(numberUtil.clamp(5, 0, 10)).toBe(5);
+            expect(logUtil.warning).not.toHaveBeenCalled();
+        });
+
+        it('min보다 작은 값은 경고를 남기고 min을 반환한다', () => {
+            expect(numberUtil.clamp(-1, 0, 10)).toBe(0);
+            expect(logUtil.warning).toHaveBeenCalledWith('numberUtil', 'value should be in the range of 0 to 10');
+        });
+
+        it('max보다 큰 값은 경고를 남기고 max를 반환한다', () => {
+            expect(numberUtil.clamp(11, 0, 10)).toBe(10);
+            expect(logUtil.warning).toHaveBeenCalledWith('numberUtil', 'value should be in the range of 0 to 10');
+        });
+
+        it('min과 같은 값은 그대로 반환한다', () => {
+            expect(numberUtil.clamp(0, 0, 10)).toBe(0);
+            expect(logUtil.warning).not.toHaveBeenCalled();
+        });
+
+        it('max와 같은 값은 그대로 반환한다', () => {
+            expect(numberUtil.clamp(10, 0, 10)).toBe(10);
+            expect(logUtil.warning).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/vlossom/src/utils/__tests__/number-util.test.ts
+++ b/packages/vlossom/src/utils/__tests__/number-util.test.ts
@@ -1,30 +1,19 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { logUtil } from './../log-util';
+import { describe, expect, it } from 'vitest';
 import { numberUtil } from './../number-util';
 
 describe('number-util', () => {
     describe('clamp()', () => {
-        beforeEach(() => {
-            vi.spyOn(logUtil, 'warning').mockImplementation(() => {});
-        });
-
-        afterEach(() => {
-            vi.restoreAllMocks();
-        });
-
         it('범위 안의 값은 그대로 반환한다', () => {
             expect(numberUtil.clamp(5, 0, 10)).toBe(5);
-            expect(logUtil.warning).not.toHaveBeenCalled();
         });
 
-        it('min과 같은 값은 그대로 반환한다', () => {
-            expect(numberUtil.clamp(0, 0, 10)).toBe(0);
-            expect(logUtil.warning).not.toHaveBeenCalled();
+        it('범위를 벗어난 값은 min 또는 max로 제한한다', () => {
+            expect(numberUtil.clamp(-1, 0, 10)).toBe(0);
+            expect(numberUtil.clamp(11, 0, 10)).toBe(10);
         });
 
-        it('max와 같은 값은 그대로 반환한다', () => {
-            expect(numberUtil.clamp(10, 0, 10)).toBe(10);
-            expect(logUtil.warning).not.toHaveBeenCalled();
+        it('NaN은 min을 반환한다', () => {
+            expect(numberUtil.clamp(NaN, 0, 10)).toBe(0);
         });
     });
 });

--- a/packages/vlossom/src/utils/__tests__/number-util.test.ts
+++ b/packages/vlossom/src/utils/__tests__/number-util.test.ts
@@ -17,16 +17,6 @@ describe('number-util', () => {
             expect(logUtil.warning).not.toHaveBeenCalled();
         });
 
-        it('min보다 작은 값은 경고를 남기고 min을 반환한다', () => {
-            expect(numberUtil.clamp(-1, 0, 10)).toBe(0);
-            expect(logUtil.warning).toHaveBeenCalledWith('numberUtil', 'value should be in the range of 0 to 10');
-        });
-
-        it('max보다 큰 값은 경고를 남기고 max를 반환한다', () => {
-            expect(numberUtil.clamp(11, 0, 10)).toBe(10);
-            expect(logUtil.warning).toHaveBeenCalledWith('numberUtil', 'value should be in the range of 0 to 10');
-        });
-
         it('min과 같은 값은 그대로 반환한다', () => {
             expect(numberUtil.clamp(0, 0, 10)).toBe(0);
             expect(logUtil.warning).not.toHaveBeenCalled();

--- a/packages/vlossom/src/utils/index.ts
+++ b/packages/vlossom/src/utils/index.ts
@@ -4,6 +4,7 @@ export * from './device-util';
 export * from './dom-util';
 export * from './function-util';
 export * from './log-util';
+export * from './number-util';
 export * from './object-util';
 export * from './props-util';
 export * from './string-util';

--- a/packages/vlossom/src/utils/number-util.ts
+++ b/packages/vlossom/src/utils/number-util.ts
@@ -1,16 +1,11 @@
-import { logUtil } from './log-util';
+import { clamp } from '@vueuse/core';
 
 export const numberUtil = {
     clamp(value: number, min: number, max: number): number {
         if (isNaN(value)) {
-            logUtil.warning('numberUtil', 'value should be a number');
             return min;
         }
 
-        if (value < min || value > max) {
-            logUtil.warning('numberUtil', `value should be in the range of ${min} to ${max}`);
-        }
-
-        return Math.min(Math.max(value, min), max);
+        return clamp(value, min, max);
     },
 };

--- a/packages/vlossom/src/utils/number-util.ts
+++ b/packages/vlossom/src/utils/number-util.ts
@@ -1,0 +1,16 @@
+import { logUtil } from './log-util';
+
+export const numberUtil = {
+    clamp(value: number, min: number, max: number): number {
+        if (isNaN(value)) {
+            logUtil.warning('numberUtil', 'value should be a number');
+            return min;
+        }
+
+        if (value < min || value > max) {
+            logUtil.warning('numberUtil', `value should be in the range of ${min} to ${max}`);
+        }
+
+        return Math.min(Math.max(value, min), max);
+    },
+};


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)
-   [x] Refactor (refactor)
-   [x] Test (test)
-   [x] Update Docs (docs)

## Summary

숫자 범위 제한을 위한 `numberUtil.clamp`를 추가하고 기존 코드에서 관련 로직들에 적용합니다.

## Description

- `value`를 지정된 최소값과 최대값 사이로 제한하는 `numberUtil.clamp` 유틸리티를 추가합니다.
- `numberUtil`을 유틸리티 공개 export에 포함합니다.
- `numberUtil.clamp`의 정상 범위, 최소값, 최대값, 경고 동작 테스트를 추가합니다.
- `VsProgress`의 `value`와 `max` 보정 로직을 `numberUtil.clamp` 를 적용합니다.
- `OptionsStore`의 `radiusRatio` 보정 로직에 `numberUtil.clamp`를 적합니다.
- 영문/국문 유틸리티 README에 `numberUtil.clamp` 사용 정보를 추가합니다.

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

## Related Tickets & Documents

- Closes #235 
