### PR TITLE
fix(VsTable): fix table pagination, reactivity issues

### DIFF
--- a/packages/vlossom/src/components/vs-chip/README.ko.md
+++ b/packages/vlossom/src/components/vs-chip/README.ko.md
@@ -11,7 +11,7 @@
 - `closable` prop으로 닫기 버튼 활성화 및 `close` 이벤트 발생
 - 시각적 지시자를 위한 선행 아이콘 슬롯
 - 다양한 시각적 변형: `primary`, `outline`
-- 5가지 크기 옵션: `xs`, `sm` (기본값), `md`, `lg`, `xl`
+- 5가지 크기 옵션: `xs`, `sm`, `md`, `lg`, `xl`
 - CSSProperties를 통한 아이콘 및 닫기 버튼 개별 스타일 제어
 
 ## Basic Usage
@@ -64,14 +64,14 @@
 
 ## Props
 
-| Prop | Type | Default | Required | Description |
-| ---- | ---- | ------- | -------- | ----------- |
-| `colorScheme` | `ColorScheme` | | | 컴포넌트 색상 테마 |
-| `styleSet` | `string \| VsChipStyleSet` | | | 커스텀 스타일 세트 |
-| `closable` | `boolean` | `false` | | 닫기 버튼 표시 |
-| `outline` | `boolean` | `false` | | 외곽선 스타일 적용 |
-| `primary` | `boolean` | `false` | | Primary 색상 테마 적용 |
-| `size` | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | `'sm'` | | Chip 크기 |
+| Prop          | Type                                   | Default | Required | Description            |
+| ------------- | -------------------------------------- | ------- | -------- | ---------------------- |
+| `colorScheme` | `ColorScheme`                          |         |          | 컴포넌트 색상 테마     |
+| `styleSet`    | `string \| VsChipStyleSet`             |         |          | 커스텀 스타일 세트     |
+| `closable`    | `boolean`                              | `false` |          | 닫기 버튼 표시         |
+| `outline`     | `boolean`                              | `false` |          | 외곽선 스타일 적용     |
+| `primary`     | `boolean`                              | `false` |          | Primary 색상 테마 적용 |
+| `size`        | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'`  |          | Chip 크기              |
 
 ## Types
 
@@ -110,16 +110,16 @@ interface VsChipStyleSet extends CSSProperties {
 
 ## Events
 
-| Event | Payload | Description |
-| ----- | ------- | ----------- |
-| `close` | — | 닫기 버튼이 클릭될 때 발생 |
+| Event   | Payload | Description                |
+| ------- | ------- | -------------------------- |
+| `close` | —       | 닫기 버튼이 클릭될 때 발생 |
 
 ## Slots
 
-| Slot | Description |
-| ---- | ----------- |
-| `default` | Chip 라벨 콘텐츠 |
-| `icon` | 라벨 앞에 표시되는 선행 아이콘 |
+| Slot      | Description                    |
+| --------- | ------------------------------ |
+| `default` | Chip 라벨 콘텐츠               |
+| `icon`    | 라벨 앞에 표시되는 선행 아이콘 |
 
 ## Methods
 

--- a/packages/vlossom/src/components/vs-chip/README.md
+++ b/packages/vlossom/src/components/vs-chip/README.md
@@ -11,7 +11,7 @@ A compact element for displaying tags, labels, or status indicators with optiona
 - Optional close button via `closable` prop that emits a `close` event
 - Optional leading icon slot for visual indicators
 - Multiple visual variants: `primary`, `outline`
-- Five size options: `xs`, `sm` (default), `md`, `lg`, `xl`
+- Five size options: `xs`, `sm`, `md`, `lg`, `xl`
 - Separate style control for icon and close button via CSSProperties
 
 ## Basic Usage
@@ -64,14 +64,14 @@ A compact element for displaying tags, labels, or status indicators with optiona
 
 ## Props
 
-| Prop | Type | Default | Required | Description |
-| ---- | ---- | ------- | -------- | ----------- |
-| `colorScheme` | `ColorScheme` | | | Color scheme for the component |
-| `styleSet` | `string \| VsChipStyleSet` | | | Custom style set |
-| `closable` | `boolean` | `false` | | Shows a close button |
-| `outline` | `boolean` | `false` | | Applies outlined style |
-| `primary` | `boolean` | `false` | | Applies primary color scheme |
-| `size` | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | `'sm'` | | Chip size |
+| Prop          | Type                                   | Default | Required | Description                    |
+| ------------- | -------------------------------------- | ------- | -------- | ------------------------------ |
+| `colorScheme` | `ColorScheme`                          |         |          | Color scheme for the component |
+| `styleSet`    | `string \| VsChipStyleSet`             |         |          | Custom style set               |
+| `closable`    | `boolean`                              | `false` |          | Shows a close button           |
+| `outline`     | `boolean`                              | `false` |          | Applies outlined style         |
+| `primary`     | `boolean`                              | `false` |          | Applies primary color scheme   |
+| `size`        | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'`  |          | Chip size                      |
 
 ## Types
 
@@ -110,16 +110,16 @@ interface VsChipStyleSet extends CSSProperties {
 
 ## Events
 
-| Event | Payload | Description |
-| ----- | ------- | ----------- |
-| `close` | — | Emitted when the close button is clicked |
+| Event   | Payload | Description                              |
+| ------- | ------- | ---------------------------------------- |
+| `close` | —       | Emitted when the close button is clicked |
 
 ## Slots
 
-| Slot | Description |
-| ---- | ----------- |
-| `default` | Chip label content |
-| `icon` | Leading icon displayed before the label |
+| Slot      | Description                             |
+| --------- | --------------------------------------- |
+| `default` | Chip label content                      |
+| `icon`    | Leading icon displayed before the label |
 
 ## Methods
 

--- a/packages/vlossom/src/components/vs-chip/VsChip.vue
+++ b/packages/vlossom/src/components/vs-chip/VsChip.vue
@@ -44,7 +44,7 @@ export default defineComponent({
         closable: { type: Boolean, default: false },
         outline: { type: Boolean, default: false },
         primary: { type: Boolean, default: false },
-        size: { type: String as PropType<Size>, default: 'sm' },
+        size: { type: String as PropType<Size>, default: 'md' },
     },
     emits: ['close'],
     setup(props) {

--- a/packages/vlossom/src/components/vs-table/README.ko.md
+++ b/packages/vlossom/src/components/vs-table/README.ko.md
@@ -201,7 +201,7 @@ interface VsTablePaginationOptions {
 | `expand-row`           | `(row: VsTableBodyCell[], event: MouseEvent)` | 행 확장 시 발생                  |
 | `drag`                 | `SortableEvent`                               | 드래그 앤 드롭 재정렬 후 발생    |
 | `search`               | `(items: VsTableItem[], searchText: string)`  | 검색 시 발생                     |
-| `paginate`             | `(nextPage: number, pageSize: number)`        | 페이지 변경 시 발생              |
+| `paginate`             | `(nextPage: number, pageSize: number)`        | 페이지 또는 page size 변경 시 발생 (page size 변경 시 페이지는 0으로 초기화) |
 | `update:selectedItems` | `VsTableItem[]`                               | 선택된 행 변경 시 발생           |
 | `update:page`          | `number`                                      | 현재 페이지 변경 시 발생         |
 | `update:pageSize`      | `number`                                      | 페이지 크기 변경 시 발생         |

--- a/packages/vlossom/src/components/vs-table/README.md
+++ b/packages/vlossom/src/components/vs-table/README.md
@@ -201,7 +201,7 @@ interface VsTablePaginationOptions {
 | `expand-row`           | `(row: VsTableBodyCell[], event: MouseEvent)` | Emitted when a row is expanded        |
 | `drag`                 | `SortableEvent`                               | Emitted after a drag-and-drop reorder |
 | `search`               | `(items: VsTableItem[], searchText: string)`  | Emitted on search                     |
-| `paginate`             | `(nextPage: number, pageSize: number)`        | Emitted when page changes             |
+| `paginate`             | `(nextPage: number, pageSize: number)`        | Emitted when the page or page size changes (page size changes reset the page to 0) |
 | `update:selectedItems` | `VsTableItem[]`                               | Emitted when selected rows change     |
 | `update:page`          | `number`                                      | Emitted when the current page changes |
 | `update:pageSize`      | `number`                                      | Emitted when the page size changes    |

--- a/packages/vlossom/src/components/vs-table/VsTable.vue
+++ b/packages/vlossom/src/components/vs-table/VsTable.vue
@@ -173,15 +173,25 @@ export default defineComponent({
             default: false,
             validator: (serverMode: boolean, props: unknown) => {
                 const { pagination } = props as PropsOf<VsComponent.VsTable>;
-                if (serverMode && typeof pagination === 'object') {
-                    if (!pagination.totalItemCount) {
-                        logUtil.propError(
-                            componentName,
-                            'serverMode',
-                            'totalItemCount is required when serverMode is true',
-                        );
-                        return false;
-                    }
+                if (!serverMode || !pagination) {
+                    return true;
+                }
+                const totalItemCount = typeof pagination === 'object' ? pagination.totalItemCount : undefined;
+                if (totalItemCount === undefined || totalItemCount === null) {
+                    logUtil.propError(
+                        componentName,
+                        'serverMode',
+                        'totalItemCount is required when serverMode is true',
+                    );
+                    return false;
+                }
+                if (totalItemCount < 0) {
+                    logUtil.propError(
+                        componentName,
+                        'serverMode',
+                        'totalItemCount must be greater than or equal to 0',
+                    );
+                    return false;
                 }
                 return true;
             },
@@ -284,7 +294,8 @@ export default defineComponent({
         'update:totalItems',
     ],
     setup(props, { slots, emit }) {
-        const { colorScheme, styleSet, responsive, stickyHeader, size, primary } = toRefs(props);
+        const { colorScheme, styleSet, responsive, stickyHeader, size, primary, serverMode, pagination } =
+            toRefs(props);
 
         const searchInputRef = useTemplateRef<VsSearchInputRef>('searchInputRef');
         const headerRef = useTemplateRef<HTMLTableSectionElement>('headerRef');
@@ -296,7 +307,10 @@ export default defineComponent({
         const { header: vsLayoutHeader } = inject(LAYOUT_STORE_KEY, LayoutStore.getDefaultLayoutStore());
         const { colorSchemeClass, computedColorScheme } = useColorScheme(componentName, colorScheme);
         const { componentStyleSet, componentInlineStyle } = useStyleSet<VsTableStyleSet>(componentName, styleSet);
+
+        const tableId = stringUtil.createID();
         const table: TableComposable = useTable(
+            tableId,
             props,
             { searchInputRef },
             { updateSelectedItems, updatePage, updatePageSize, updatePagedItems, updateTotalItems },
@@ -370,6 +384,9 @@ export default defineComponent({
             emit('search', items, searchText);
         }
         function paginate(nextPage: number): void {
+            if (!serverMode.value) {
+                return;
+            }
             emit('paginate', nextPage, table.pageSize.value);
         }
         function updateSelectedItems(items: VsTableItem[]): void {
@@ -415,6 +432,10 @@ export default defineComponent({
 
         onMounted(() => {
             scrollWrapperRef.value?.addEventListener('scroll', syncStickyScroll, { passive: true });
+
+            if (serverMode.value && pagination.value) {
+                emit('paginate', table.page.value, table.pageSize.value);
+            }
         });
 
         onBeforeUnmount(() => {

--- a/packages/vlossom/src/components/vs-table/VsTable.vue
+++ b/packages/vlossom/src/components/vs-table/VsTable.vue
@@ -71,7 +71,7 @@
             </vs-visible-render>
         </div>
 
-        <vs-table-pagination v-if="pagination && totalPages" @paginate="paginate" />
+        <vs-table-pagination v-if="pagination && totalPages" />
     </div>
 </template>
 
@@ -313,7 +313,7 @@ export default defineComponent({
             tableId,
             props,
             { searchInputRef },
-            { updateSelectedItems, updatePage, updatePageSize, updatePagedItems, updateTotalItems },
+            { updateSelectedItems, updatePage, updatePageSize, updatePagedItems, updateTotalItems, paginate },
         );
 
         provide<ComputedRef<VsTableStyleSet>>(TABLE_STYLE_SET_TOKEN, componentStyleSet);
@@ -383,11 +383,8 @@ export default defineComponent({
             const items = table.bodyCells.value.map((row) => getRowItem(row));
             emit('search', items, searchText);
         }
-        function paginate(nextPage: number): void {
-            if (!serverMode.value) {
-                return;
-            }
-            emit('paginate', nextPage, table.pageSize.value);
+        function paginate(page: number, pageSize: number): void {
+            emit('paginate', page, pageSize);
         }
         function updateSelectedItems(items: VsTableItem[]): void {
             emit('update:selectedItems', items);
@@ -434,7 +431,7 @@ export default defineComponent({
             scrollWrapperRef.value?.addEventListener('scroll', syncStickyScroll, { passive: true });
 
             if (serverMode.value && pagination.value) {
-                emit('paginate', table.page.value, table.pageSize.value);
+                paginate(table.page.value, table.pageSize.value);
             }
         });
 
@@ -465,7 +462,6 @@ export default defineComponent({
             selectRow,
             expandRow,
             searchRows,
-            paginate,
             dragRow,
             updateSelectedItems,
             updatePage,

--- a/packages/vlossom/src/components/vs-table/VsTableBodyRow.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableBodyRow.vue
@@ -14,7 +14,7 @@
                 :data-label="getHeaderLabel(cell.colIdx, cell.colKey)"
                 @click.stop="clickCell(cell, $event)"
             >
-                <vs-skeleton v-if="loading" :color-scheme :style-set="skeletonStyleSet" />
+                <vs-skeleton v-if="loading" :color-scheme :style-set="{ height: '1lh' }" />
                 <template v-else>
                     <slot
                         :name="findMatchingSlotName(cell)"
@@ -46,7 +46,6 @@ import { defineComponent, inject, computed, type ComputedRef, type PropType, toR
 import { objectUtil, stringUtil } from '@/utils';
 import { useStateClass } from '@/composables';
 import type { ColorScheme, UIState } from '@/declaration';
-import type { VsSkeletonStyleSet } from './../vs-skeleton/types';
 import {
     TABLE_COLOR_SCHEME_TOKEN,
     TABLE_STYLE_SET_TOKEN,
@@ -140,7 +139,6 @@ export default defineComponent({
             const statedRowStyle = isSelected.value ? objectUtil.assign(baseRow, $selected) : baseRow;
             return objectUtil.assign(statedRowStyle, gridStyle.value ?? {});
         });
-        const skeletonStyleSet = computed<VsSkeletonStyleSet>(() => ({ height: '100%' }));
 
         function getGridColumnWidth(column?: VsTableColumnDef): string {
             if (!column) {
@@ -232,7 +230,6 @@ export default defineComponent({
             classObj,
             rowStyle,
             showExpand,
-            skeletonStyleSet,
             getCellStyle,
             stateClasses,
             clickCell,

--- a/packages/vlossom/src/components/vs-table/VsTablePagination.vue
+++ b/packages/vlossom/src/components/vs-table/VsTablePagination.vue
@@ -29,7 +29,6 @@
             :showing-length="pagination.showingLength"
             :edge-buttons="pagination.edgeButtons"
             :size
-            @change="paginate"
         />
     </div>
 </template>
@@ -50,8 +49,7 @@ import VsSelect from '@/components/vs-select/VsSelect.vue';
 
 export default defineComponent({
     components: { VsPagination, VsSelect },
-    emits: ['paginate'],
-    setup(_, { emit }) {
+    setup() {
         const {
             pagination,
             totalPages,
@@ -71,10 +69,6 @@ export default defineComponent({
             return pagination.value.pageSizeOptions ?? [];
         });
 
-        function paginate(nextPage: number): void {
-            emit('paginate', nextPage, pageSize.value);
-        }
-
         return {
             pagination,
             page,
@@ -84,7 +78,6 @@ export default defineComponent({
             totalItems,
             pageStartIndex,
             pageEndIndex,
-            paginate,
             loading,
             primary,
             size,

--- a/packages/vlossom/src/components/vs-table/__tests__/table-cell-builder.test.ts
+++ b/packages/vlossom/src/components/vs-table/__tests__/table-cell-builder.test.ts
@@ -1,21 +1,11 @@
-import { describe, it, expect, expectTypeOf, beforeEach, afterEach, vi } from 'vitest';
-import { stringUtil } from '@/utils';
+import { describe, it, expect, expectTypeOf } from 'vitest';
 import { TableCellBuilder } from './../models/table-cell-builder';
 import type { VsTableColumnDef } from './../types';
 
 describe('TableCellBuilder', () => {
-    beforeEach(() => {
-        let seq = 0;
-        vi.spyOn(stringUtil, 'createID').mockImplementation(() => `id-${seq++}`);
-    });
-
-    afterEach(() => {
-        vi.restoreAllMocks();
-    });
-
     it('컬럼 정의가 없을 때 아이템 키를 기반으로 헤더/바디 셀을 생성한다', () => {
         const items = [{ id: '1', name: 'Alice', age: 24 }];
-        const builder = new TableCellBuilder(items, []);
+        const builder = new TableCellBuilder('test-table-id', items, []);
 
         const [header, ...body] = builder.build();
 
@@ -42,7 +32,7 @@ describe('TableCellBuilder', () => {
             { id: '1', name: 'Alice', meta: { age: 27 } },
             { id: '2', name: 'Bob', meta: { age: 31 } },
         ];
-        const builder = new TableCellBuilder(items, ['name', 'meta.age']);
+        const builder = new TableCellBuilder('test-table-id', items, ['name', 'meta.age']);
 
         const [header, ...body] = builder.build();
 
@@ -58,7 +48,7 @@ describe('TableCellBuilder', () => {
             { key: 'age', label: '나이' },
         ];
         const items = [{ id: '1', name: 'Alice', age: 24 }];
-        const builder = new TableCellBuilder(items, columnDefs);
+        const builder = new TableCellBuilder('test-table-id', items, columnDefs);
 
         const [header] = builder.build();
         expect(header.map((h) => h.value)).toEqual(['이름', '나이']);

--- a/packages/vlossom/src/components/vs-table/__tests__/table-composable.test.ts
+++ b/packages/vlossom/src/components/vs-table/__tests__/table-composable.test.ts
@@ -29,7 +29,7 @@ function setupUseTable(
 ) {
     const reactiveProps = reactive(props);
     const searchInputRef = options?.searchInputRef ?? ref<VsSearchInputRef | null>(null);
-    const table = useTable(reactiveProps as any, { searchInputRef } as any);
+    const table = useTable('test-table-id', reactiveProps as any, { searchInputRef } as any);
     table.initialize();
     return { table, reactiveProps, searchInputRef };
 }
@@ -269,7 +269,7 @@ describe('useTable', () => {
                 expect(table.bodyCells.value[9][0].value).toBe('User 29');
             });
 
-            it('서버 모드에서 totalItemCount가 없으면 에러를 발생시킨다', async () => {
+            it('서버 모드에서 totalItemCount가 없으면 총 페이지를 0으로 계산한다', async () => {
                 const items = Array.from({ length: 10 }, (_, i) => ({ id: `${i}`, name: `User ${i}` }));
                 const { table } = setupUseTable({
                     columns: ['name'],
@@ -282,7 +282,23 @@ describe('useTable', () => {
 
                 await nextTick();
 
-                expect(table.totalPages.value).toBe(-1);
+                expect(table.totalPages.value).toBe(0);
+            });
+
+            it('서버 모드에서 totalItemCount가 0이면 총 페이지를 0으로 계산한다', async () => {
+                const items = Array.from({ length: 10 }, (_, i) => ({ id: `${i}`, name: `User ${i}` }));
+                const { table } = setupUseTable({
+                    columns: ['name'],
+                    items,
+                    pagination: { totalItemCount: 0 },
+                    serverMode: true,
+                    page: 0,
+                    pageSize: 10,
+                });
+
+                await nextTick();
+
+                expect(table.totalPages.value).toBe(0);
             });
 
             it('서버 모드에서 pageSize 변경 시에도 totalItemCount 기반으로 총 페이지를 재계산한다', async () => {

--- a/packages/vlossom/src/components/vs-table/__tests__/vs-table.test.ts
+++ b/packages/vlossom/src/components/vs-table/__tests__/vs-table.test.ts
@@ -1,10 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { h, nextTick } from 'vue';
-import { stringUtil } from '@/utils';
+import { stringUtil, logUtil } from '@/utils';
 import VsTable from './../VsTable.vue';
 import type { VsTableBodyCell, VsTableItem, VsTableColumnDef } from './../types';
-import { DEFAULT_PAGE_SIZE } from './../constants';
 
 const defaultColumns = ['name', 'age'];
 const labeledColumns = [
@@ -158,9 +157,12 @@ describe('VsTable', () => {
         });
 
         it('`header-${id}` Slot이 `header-${colKey}` Slot보다 우선한다', async () => {
+            // 셀 id는 `${tableId}-${colKey}` 형태로 결정적이다. tableId를 고정해 id 슬롯명을 예측한다.
+            vi.mocked(stringUtil.createID).mockReturnValue('tid');
+
             const wrapper = mountTable({
                 slots: {
-                    'header-name-id-6': ({ value }: { value: unknown }) => `ID-${value}`,
+                    'header-tid-name': ({ value }: { value: unknown }) => `ID-${value}`,
                     'header-name': ({ item }: { item: VsTableColumnDef }) => `COL-${item.key}`,
                 },
             });
@@ -400,7 +402,7 @@ describe('VsTable', () => {
             expect(wrapper.find('[data-testid="vs-select"]').exists()).toBe(true);
         });
 
-        it('vs-pagination change 이벤트를 paginate로 전달한다', async () => {
+        it('페이지를 변경하면 paginate 이벤트를 발생시킨다', async () => {
             const wrapper = mountTable({
                 props: { pagination: true },
             });
@@ -408,11 +410,106 @@ describe('VsTable', () => {
             await nextTick();
             await wrapper.get('[data-testid="vs-pagination"]').trigger('click');
 
-            const emitted = wrapper.emitted('paginate');
-            expect(emitted).toHaveLength(1);
-            const [page, pageSize] = emitted![0] as [number, number];
-            expect(page).toBe(1);
-            expect(pageSize).toBe(DEFAULT_PAGE_SIZE);
+            expect(wrapper.emitted('paginate')).toEqual([[1, 50]]);
+        });
+
+        it('page size를 변경하면 paginate를 (0, 새 size)로 발생시킨다', async () => {
+            const wrapper = mount(VsTable, {
+                props: {
+                    columns: defaultColumns,
+                    items: tableItems,
+                    pagination: true,
+                },
+                global: {
+                    stubs: {
+                        ...defaultGlobal.stubs,
+                        'vs-select': {
+                            props: ['modelValue', 'options'],
+                            emits: ['update:modelValue'],
+                            template:
+                                '<button data-testid="vs-select" @click="$emit(\'update:modelValue\', 20)">size</button>',
+                        },
+                    },
+                },
+            });
+
+            await nextTick();
+            await wrapper.get('[data-testid="vs-select"]').trigger('click');
+
+            expect(wrapper.emitted('paginate')).toEqual([[0, 20]]);
+        });
+
+        it('page 이동 후 page size를 변경하면 page 리셋과 합쳐져 paginate가 (0, 새 size)로 한 번만 발생한다', async () => {
+            const items = Array.from({ length: 6 }, (_, i) => ({ id: `${i}`, name: `User ${i}`, age: i }));
+            const wrapper = mount(VsTable, {
+                props: {
+                    columns: defaultColumns,
+                    items,
+                    pagination: {
+                        pageSizeOptions: [
+                            { label: '2', value: 2 },
+                            { label: '4', value: 4 },
+                        ],
+                    },
+                },
+                global: {
+                    stubs: {
+                        ...defaultGlobal.stubs,
+                        'vs-select': {
+                            props: ['modelValue', 'options'],
+                            emits: ['update:modelValue'],
+                            template:
+                                '<button data-testid="vs-select" @click="$emit(\'update:modelValue\', 4)">size</button>',
+                        },
+                    },
+                },
+            });
+
+            await nextTick();
+            await wrapper.get('[data-testid="vs-pagination"]').trigger('click');
+            await wrapper.get('[data-testid="vs-select"]').trigger('click');
+
+            expect(wrapper.emitted('paginate')).toEqual([
+                [1, 2],
+                [0, 4],
+            ]);
+        });
+
+        it('서버 모드에서는 마운트 시 초기 데이터 로드를 위해 paginate를 발생시킨다', async () => {
+            const serverItems = Array.from({ length: 10 }, (_, i) => ({
+                id: `${i}`,
+                name: `User ${i}`,
+                age: 20 + i,
+            }));
+
+            const wrapper = mountTable({
+                props: {
+                    items: serverItems,
+                    pagination: { totalItemCount: 100 },
+                    serverMode: true,
+                    page: 2,
+                    pageSize: 10,
+                },
+            });
+
+            await nextTick();
+
+            expect(wrapper.emitted('paginate')).toEqual([[2, 10]]);
+        });
+
+        it('클라이언트 모드에서는 마운트 시 paginate를 발생시키지 않는다', async () => {
+            const wrapper = mountTable({
+                props: {
+                    items: Array.from({ length: 40 }, (_, i) => ({ id: `${i}`, name: `User ${i}`, age: i })),
+                    pagination: true,
+                    page: 0,
+                    pageSize: 10,
+                },
+            });
+
+            await nextTick();
+
+            expect(wrapper.emitted('paginate')).toBeUndefined();
         });
 
         it('초기 pageSize가 없으면 pageSizeOptions의 첫 번째 값을 사용한다', async () => {
@@ -433,13 +530,6 @@ describe('VsTable', () => {
             await nextTick();
 
             expect(wrapper.findAll('tbody tr')).toHaveLength(5);
-
-            await wrapper.get('[data-testid="vs-pagination"]').trigger('click');
-
-            const emitted = wrapper.emitted('paginate');
-            expect(emitted).toHaveLength(1);
-            const [, pageSize] = emitted![0] as [number, number];
-            expect(pageSize).toBe(5);
         });
 
         describe('server mode', () => {
@@ -467,36 +557,8 @@ describe('VsTable', () => {
                 expect(wrapper.findAll('tbody tr')).toHaveLength(10);
             });
 
-            it('서버 모드에서 페이지 변경 시 paginate 이벤트를 발생시킨다', async () => {
-                const serverItems = Array.from({ length: 10 }, (_, i) => ({
-                    id: `${i}`,
-                    name: `User ${i}`,
-                    age: 20 + i,
-                }));
-
-                const wrapper = mountTable({
-                    props: {
-                        items: serverItems,
-                        pagination: {
-                            totalItemCount: 100,
-                        },
-                        serverMode: true,
-                        page: 0,
-                        pageSize: 10,
-                    },
-                });
-
-                await nextTick();
-                await wrapper.get('[data-testid="vs-pagination"]').trigger('click');
-
-                const emitted = wrapper.emitted('paginate');
-                expect(emitted).toHaveLength(1);
-                const [page, pageSize] = emitted![0] as [number, number];
-                expect(page).toBe(1);
-                expect(pageSize).toBe(10);
-            });
-
-            it('서버 모드에서 totalItemCount가 없으면 pagination을 렌더링하지 않는다', async () => {
+            it('서버 모드에서 totalItemCount가 없으면 prop 에러를 남기고 pagination을 렌더링하지 않는다', async () => {
+                const propError = vi.spyOn(logUtil, 'propError').mockImplementation(() => {});
                 const serverItems = Array.from({ length: 10 }, (_, i) => ({
                     id: `${i}`,
                     name: `User ${i}`,
@@ -515,6 +577,44 @@ describe('VsTable', () => {
 
                 await nextTick();
 
+                expect(propError).toHaveBeenCalled();
+                expect(wrapper.vm.$el.querySelector('.vs-table-pagination')).toBeFalsy();
+            });
+
+            it('서버 모드에서 totalItemCount가 음수면 prop 에러를 남긴다', async () => {
+                const propError = vi.spyOn(logUtil, 'propError').mockImplementation(() => {});
+
+                mountTable({
+                    props: {
+                        items: [],
+                        pagination: { totalItemCount: -1 },
+                        serverMode: true,
+                        page: 0,
+                        pageSize: 10,
+                    },
+                });
+
+                await nextTick();
+
+                expect(propError).toHaveBeenCalled();
+            });
+
+            it('서버 모드에서 totalItemCount가 0이면 prop 에러 없이 pagination을 렌더링하지 않는다', async () => {
+                const propError = vi.spyOn(logUtil, 'propError').mockImplementation(() => {});
+
+                const wrapper = mountTable({
+                    props: {
+                        items: [],
+                        pagination: { totalItemCount: 0 },
+                        serverMode: true,
+                        page: 0,
+                        pageSize: 10,
+                    },
+                });
+
+                await nextTick();
+
+                expect(propError).not.toHaveBeenCalled();
                 expect(wrapper.vm.$el.querySelector('.vs-table-pagination')).toBeFalsy();
             });
 
@@ -757,6 +857,31 @@ describe('VsTable', () => {
             const paginationBtn = wrapper.find('[data-testid="vs-pagination"]');
             expect(paginationBtn.exists()).toBe(true);
             expect(paginationBtn.attributes('disabled')).toBeDefined();
+        });
+
+        it('loading이 true면 데이터가 있던 셀이 스켈레톤으로 표시된다', async () => {
+            const wrapper = mount(VsTable, {
+                props: { columns: defaultColumns, items: tableItems, loading: true },
+                global: defaultGlobal,
+            });
+
+            await nextTick();
+
+            const skeleton = wrapper.find('.vs-skeleton');
+            expect(skeleton.exists()).toBe(true);
+        });
+
+        it('스켈레톤은 확정 높이를 가져 보이지 않게 무너지지 않는다', async () => {
+            const wrapper = mount(VsTable, {
+                props: { columns: defaultColumns, items: tableItems, loading: true },
+                global: defaultGlobal,
+            });
+
+            await nextTick();
+
+            const style = wrapper.find('.vs-skeleton').attributes('style') ?? '';
+            expect(style).toContain('height');
+            expect(style).not.toContain('100%');
         });
     });
 

--- a/packages/vlossom/src/components/vs-table/__tests__/vs-table.test.ts
+++ b/packages/vlossom/src/components/vs-table/__tests__/vs-table.test.ts
@@ -496,7 +496,7 @@ describe('VsTable', () => {
                 expect(pageSize).toBe(10);
             });
 
-            it('서버 모드에서 totalItemCount가 없으면 에러가 발생한다', async () => {
+            it('서버 모드에서 totalItemCount가 없으면 pagination을 렌더링하지 않는다', async () => {
                 const serverItems = Array.from({ length: 10 }, (_, i) => ({
                     id: `${i}`,
                     name: `User ${i}`,
@@ -515,7 +515,7 @@ describe('VsTable', () => {
 
                 await nextTick();
 
-                expect(wrapper.vm.$el.querySelector('.vs-table-pagination')).toBeTruthy();
+                expect(wrapper.vm.$el.querySelector('.vs-table-pagination')).toBeFalsy();
             });
 
             it('서버 모드에서는 client-side pagination을 수행하지 않고 모든 items를 렌더링한다', async () => {

--- a/packages/vlossom/src/components/vs-table/composables/table-composable.ts
+++ b/packages/vlossom/src/components/vs-table/composables/table-composable.ts
@@ -47,6 +47,7 @@ export function useTable(
         updatePageSize: (pageSize: number) => void;
         updatePagedItems: (items: VsTableItem[]) => void;
         updateTotalItems: (items: VsTableItem[]) => void;
+        paginate: (page: number, pageSize: number) => void;
     },
 ) {
     const {
@@ -235,6 +236,11 @@ export function useTable(
             return firstCell?.item || {};
         });
         cb?.updateTotalItems(nextTotalItems);
+    });
+
+    // pageSize 변경은 page를 0으로 리셋하지만 두 변경이 같은 tick에 일어나므로 콜백은 한 번만 실행된다.
+    watch([page, pageSize], ([nextPage, nextPageSize]) => {
+        cb?.paginate(nextPage, nextPageSize);
     });
 
     return {

--- a/packages/vlossom/src/components/vs-table/composables/table-composable.ts
+++ b/packages/vlossom/src/components/vs-table/composables/table-composable.ts
@@ -1,4 +1,13 @@
-import { computed, ref, toRefs, watch, type ComputedRef, type Ref, type TemplateRef } from 'vue';
+import {
+    computed,
+    ref,
+    toRefs,
+    watch,
+    type ComputedRef,
+    type Ref,
+    type TemplateRef,
+    type WritableComputedRef,
+} from 'vue';
 import { functionUtil, objectUtil } from '@/utils';
 import { type UIState, type VsComponent, type PropsOf, type SearchProps, type Size } from '@/declaration';
 import type { VsSearchInputRef } from '@/components';
@@ -29,6 +38,7 @@ import {
 
 export const TABLE_COMPOSABLE_TOKEN = Symbol('TABLE_COMPOSABLE_TOKEN');
 export function useTable(
+    tableId: string,
     props: PropsOf<VsComponent.VsTable>,
     refs: { searchInputRef: TemplateRef<VsSearchInputRef> },
     cb?: {
@@ -151,7 +161,7 @@ export function useTable(
         },
     });
 
-    const tableCellBuilder = new TableCellBuilder(items.value, columns.value);
+    const tableCellBuilder = new TableCellBuilder(tableId, items.value, columns.value);
     const { anyExpandable, isExpanded, toggleExpand, setExpand } = useTableExpand(expandable, items);
     const { sortType, sortColumn, compareRows, updateSortType } = useTableSort(columns);
     const { matchBySearch } = useTableSearch(refs.searchInputRef, columns);
@@ -285,8 +295,8 @@ export type TableComposable = {
     size: Ref<Size | undefined> | undefined;
     search: ComputedRef<Exclude<SearchProps, boolean>>;
     pagination: ComputedRef<VsTablePaginationOptions>;
-    page: ComputedRef<number>;
-    pageSize: ComputedRef<number>;
+    page: WritableComputedRef<number>;
+    pageSize: WritableComputedRef<number>;
     totalPages: ComputedRef<number>;
     totalItems: ComputedRef<number>;
     pageStartIndex: ComputedRef<number>;

--- a/packages/vlossom/src/components/vs-table/composables/table-pagination-composable.ts
+++ b/packages/vlossom/src/components/vs-table/composables/table-pagination-composable.ts
@@ -40,10 +40,8 @@ export function useTablePagination(
             return 1;
         }
         if (serverMode.value) {
-            if (!options.value.totalItemCount) {
-                return -1;
-            }
-            return Math.ceil(options.value.totalItemCount / currentPageSize);
+            const serverTotalItemCount = options.value.totalItemCount ?? 0;
+            return serverTotalItemCount > 0 ? Math.ceil(serverTotalItemCount / currentPageSize) : 0;
         }
         return Math.ceil(totalItemsCount.value / currentPageSize);
     });

--- a/packages/vlossom/src/components/vs-table/models/strategy/no-column-def-cell-strategy.ts
+++ b/packages/vlossom/src/components/vs-table/models/strategy/no-column-def-cell-strategy.ts
@@ -3,14 +3,17 @@ import type { VsTableBodyCell, VsTableHeaderCell, VsTableItem } from './../../ty
 import { HEADER_ROW_INDEX, type TableCellStrategy } from './index';
 
 export default class NoColumnDefCellStrategy implements TableCellStrategy {
-    public constructor(private items: VsTableItem[]) {}
+    public constructor(
+        private tableId: string,
+        private items: VsTableItem[],
+    ) {}
 
     public createHeaderCell(): VsTableHeaderCell[] {
         const tag = 'th';
         const itemKeys = this.items.length > 0 ? Object.keys(this.items[0]) : [];
         return itemKeys.map((key: string, idx: number) => ({
             tag,
-            id: `${key}-${stringUtil.createID()}`,
+            id: `${this.tableId}-${stringUtil.kebabCase(key)}`,
             value: key,
             colKey: key,
             colIdx: idx,
@@ -24,7 +27,7 @@ export default class NoColumnDefCellStrategy implements TableCellStrategy {
         return this.items.map((item: VsTableItem, rowIdx: number) => {
             return Object.keys(item).map((key: string, colIdx: number) => ({
                 tag,
-                id: `${key}-${stringUtil.createID()}`,
+                id: `${this.tableId}-${stringUtil.kebabCase(key)}-${rowIdx}`,
                 value: item[key],
                 item,
                 colKey: key,

--- a/packages/vlossom/src/components/vs-table/models/strategy/object-column-def-cell-strategy.ts
+++ b/packages/vlossom/src/components/vs-table/models/strategy/object-column-def-cell-strategy.ts
@@ -4,6 +4,7 @@ import { HEADER_ROW_INDEX, type TableCellStrategy } from './index';
 
 export default class ObjectColumnDefCellStrategy implements TableCellStrategy {
     public constructor(
+        private tableId: string,
         private items: VsTableItem[],
         private columnDefs: VsTableColumnDef[],
     ) {}
@@ -13,7 +14,7 @@ export default class ObjectColumnDefCellStrategy implements TableCellStrategy {
         return this.columnDefs.map((header: VsTableColumnDef, idx: number) => ({
             ...header,
             tag,
-            id: `${stringUtil.kebabCase(header.key)}-${stringUtil.createID()}`,
+            id: `${this.tableId}-${stringUtil.kebabCase(header.key)}`,
             value: header.label,
             colKey: header.key,
             colIdx: idx,
@@ -27,7 +28,7 @@ export default class ObjectColumnDefCellStrategy implements TableCellStrategy {
         return this.items.map((item: VsTableItem, rowIdx: number) => {
             return this.columnDefs.map((header: VsTableColumnDef, colIdx: number) => ({
                 tag,
-                id: `${stringUtil.kebabCase(header.key)}-${stringUtil.createID()}`,
+                id: `${this.tableId}-${stringUtil.kebabCase(header.key)}-${rowIdx}`,
                 value: header.transform
                     ? header.transform(objectUtil.get(item, header.key), item)
                     : objectUtil.get(item, header.key),

--- a/packages/vlossom/src/components/vs-table/models/strategy/string-column-def-cell-strategy.ts
+++ b/packages/vlossom/src/components/vs-table/models/strategy/string-column-def-cell-strategy.ts
@@ -4,6 +4,7 @@ import { HEADER_ROW_INDEX, type TableCellStrategy } from './index';
 
 export default class StringKeyColumnDefCellStrategy implements TableCellStrategy {
     public constructor(
+        private tableId: string,
         private items: VsTableItem[],
         private columnDefs: string[],
     ) {}
@@ -12,7 +13,7 @@ export default class StringKeyColumnDefCellStrategy implements TableCellStrategy
         const tag = 'th';
         return this.columnDefs.map((headerKey: string, idx: number) => ({
             tag,
-            id: `${stringUtil.kebabCase(headerKey)}-${stringUtil.createID()}`,
+            id: `${this.tableId}-${stringUtil.kebabCase(headerKey)}`,
             value: headerKey,
             colKey: headerKey,
             colIdx: idx,
@@ -26,7 +27,7 @@ export default class StringKeyColumnDefCellStrategy implements TableCellStrategy
         return this.items.map((item: VsTableItem, rowIdx: number) => {
             return this.columnDefs.map((headerKey: string, colIdx: number) => ({
                 tag,
-                id: `${stringUtil.kebabCase(headerKey)}-${stringUtil.createID()}`,
+                id: `${this.tableId}-${stringUtil.kebabCase(headerKey)}-${rowIdx}`,
                 value: objectUtil.get(item, headerKey),
                 item,
                 colKey: headerKey,

--- a/packages/vlossom/src/components/vs-table/models/table-cell-builder.ts
+++ b/packages/vlossom/src/components/vs-table/models/table-cell-builder.ts
@@ -9,9 +9,10 @@ import {
 } from './strategy';
 
 export class TableCellBuilder {
-    private cellStrategy: TableCellStrategy = new NoColumnDefCellStrategy([]);
+    private cellStrategy: TableCellStrategy;
 
     public constructor(
+        private readonly tableId: string,
         private items: VsTableItem[],
         private columnDefs: VsTableColumnDef[] | string[],
     ) {
@@ -20,12 +21,12 @@ export class TableCellBuilder {
 
     private getCellStrategy(): TableCellStrategy {
         if (!this.columnDefs?.length) {
-            return new NoColumnDefCellStrategy(this.items);
+            return new NoColumnDefCellStrategy(this.tableId, this.items);
         }
         if (isVsTableColumnDefArray(this.columnDefs)) {
-            return new ObjectColumnDefCellStrategy(this.items, this.columnDefs);
+            return new ObjectColumnDefCellStrategy(this.tableId, this.items, this.columnDefs);
         }
-        return new StringKeyColumnDefCellStrategy(this.items, this.columnDefs);
+        return new StringKeyColumnDefCellStrategy(this.tableId, this.items, this.columnDefs);
     }
 
     public updateItems(items: VsTableItem[]): TableCellBuilder {


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
vs-table이 갖고 있던 pagination, reactivity 이슈를 수정

## Description
- pagination totalItemCount가 0일 때 warning 뜨는 이슈 수정
- paginate 이벤트가 pageSize 변경에도 emit 되도록 수정
- loading 때 vs-skeleton이 제대로 노출되지 않던 이슈 수정
- 고정된 table ID를 CellBuilder에 전달해서 id 변동이 cell reactivity에 영향을 주지 않게 수정

### 기타 수정
- vs-chip 기본 사이즈 md로 변경

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
