### PR TITLE
fix(VsTabs): prevent indicator sub-pixel overflow

### DIFF
--- a/packages/vlossom/src/components/vs-tabs/VsTabs.vue
+++ b/packages/vlossom/src/components/vs-tabs/VsTabs.vue
@@ -232,21 +232,26 @@ export default defineComponent({
 
             const tabItems = getTabItems();
             const selectedTab = tabItems[selectedIndex.value];
+            const tabList = selectedTab.parentElement;
 
-            if (!selectedTab) {
+            if (!tabList || !selectedTab) {
                 indicatorStyle.value = null;
                 return;
             }
 
+            const tabRect = selectedTab.getBoundingClientRect();
+            const tabListRect = tabList.getBoundingClientRect();
+            const hasRenderedRect = tabRect.width > 0 || tabRect.height > 0;
+
             if (vertical.value) {
                 indicatorStyle.value = {
-                    top: `${selectedTab.offsetTop}px`,
-                    height: `${selectedTab.offsetHeight}px`,
+                    top: `${hasRenderedRect ? tabRect.top - tabListRect.top : selectedTab.offsetTop}px`,
+                    height: `${hasRenderedRect ? tabRect.height : selectedTab.offsetHeight}px`,
                 };
             } else {
                 indicatorStyle.value = {
-                    left: `${selectedTab.offsetLeft}px`,
-                    width: `${selectedTab.offsetWidth}px`,
+                    left: `${hasRenderedRect ? tabRect.left - tabListRect.left : selectedTab.offsetLeft}px`,
+                    width: `${hasRenderedRect ? tabRect.width : selectedTab.offsetWidth}px`,
                 };
             }
         }


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Fix Bug (fix)

## Summary

VsTabs의 활성 인디케이터 위치 계산을 실제 렌더링 좌표 기준으로 변경해 소수점 단위의 레이아웃 오차로 인한 불필요한 스크롤바 발생을 방지합니다.

## Description

- 활성 탭 인디케이터의 위치와 크기를 `offsetTop`, `offsetLeft`, `offsetWidth`, `offsetHeight` 대신 `getBoundingClientRect()` 기반 좌표로 계산하도록 변경합니다.
    - `offset` 계열 값들을 사용할 경우 [정수 좌표를 반환하기 때문에](https://drafts.csswg.org/cssom-view/#extension-to-the-element-interface) 소수점 단위의 값이 소실되어 레이아웃 오차가 발생합니다. 이를 위해 [실제 좌표값을 그대로 반환](https://drafts.csswg.org/cssom-view/#extension-to-the-element-interface)하는 [`getBoundingClientRect()`](https://developer.mozilla.org/ko/docs/Web/API/Element/getBoundingClientRect)를 사용합니다.
    - 선택된 탭과 탭 리스트의 위치값 차이를 활용해 인디케이터의 위치를 실제 탭 렌더링 위치와 일치하도록 계산합니다.

## Related Tickets & Documents

- Closes #540 