### PR TITLE
fix(VsSelect): stop event bubbling at options slots

### DIFF
--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -68,6 +68,7 @@
                                 :model-value="isSelectedAll"
                                 :color-scheme="computedColorScheme"
                                 :style-set="componentStyleSet.$selectAllCheckbox"
+                                :size
                                 check-label="Select All"
                                 readonly
                                 no-label

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -74,7 +74,9 @@
                                 no-messages
                             />
                         </div>
-                        <slot name="options-header" v-if="$slots['options-header']" />
+                        <div class="vs-select-slot" v-if="$slots['options-header']" @keydown.stop>
+                            <slot name="options-header" />
+                        </div>
                     </template>
                     <template #group="groupSlotProps" v-if="$slots.group">
                         <slot name="group" v-bind="groupSlotProps" />
@@ -97,7 +99,9 @@
                         </div>
                     </template>
                     <template #footer v-if="$slots['options-footer']">
-                        <slot name="options-footer" />
+                        <div class="vs-select-slot" @keydown.stop>
+                            <slot name="options-footer" />
+                        </div>
                     </template>
                 </vs-grouped-list>
             </vs-floating>

--- a/packages/vlossom/src/components/vs-select/__tests__/vs-select.test.ts
+++ b/packages/vlossom/src/components/vs-select/__tests__/vs-select.test.ts
@@ -728,6 +728,42 @@ describe('VsSelect', () => {
         });
     });
 
+    describe('options slot 키 이벤트', () => {
+        it('options-header slot 안에서 발생한 키 이벤트는 select 키 동작에 가로채이지 않는다', async () => {
+            // given
+            vi.useFakeTimers();
+            const wrapper = mount(VsSelect, {
+                attachTo: document.body,
+                props: { options: basicOptions, modelValue: null },
+                slots: { 'options-header': '<input class="slot-input" />' },
+            });
+
+            wrapper.vm.openOptions();
+            await nextTick();
+            vi.advanceTimersByTime(100);
+            await nextTick();
+            await nextTick();
+
+            const slotInput = document.querySelector('.slot-input');
+            expect(slotInput).not.toBeNull();
+
+            // when: slot 내부에서 키 이벤트 발생
+            const slotEvent = new KeyboardEvent('keydown', { code: 'ArrowDown', bubbles: true, cancelable: true });
+            slotInput?.dispatchEvent(slotEvent);
+
+            // then: slot 영역의 키는 preventDefault 되지 않는다
+            expect(slotEvent.defaultPrevented).toBe(false);
+
+            // and: slot 밖에서 발생한 키는 기존대로 select가 처리한다
+            const outsideEvent = new KeyboardEvent('keydown', { code: 'ArrowDown', bubbles: true, cancelable: true });
+            document.dispatchEvent(outsideEvent);
+            expect(outsideEvent.defaultPrevented).toBe(true);
+
+            wrapper.unmount();
+            vi.useRealTimers();
+        });
+    });
+
     describe('deselectOption', () => {
         it('다중 선택 모드에서 선택된 옵션을 해제할 수 있다', async () => {
             // given


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
vs-select options-header, options-footer slot에서 키보드 이벤트 bubbling 막기 (#543)

## Description
- options header, footer에서 올라간 event가 select-keyboard-composable 로직에 의해서 preventDefault 당해버리면서 버그 발생
- @keydown.stop 으로 event 전파를 멈춰서 preventDefault가 불리지 않게 함
- 기타: select-all 체크박스로 select의 size가 전달되지 않던 버그 수정
<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
