### PR TITLE
feat(VsFileDrop): add 'clear' event to emit

### DIFF
--- a/packages/vlossom/src/components/vs-file-drop/README.ko.md
+++ b/packages/vlossom/src/components/vs-file-drop/README.ko.md
@@ -134,6 +134,7 @@ interface VsFileDropStyleSet extends CSSProperties {
 | `update:changed` | `File[]` | 파일이 변경될 때 발생 |
 | `update:valid` | `boolean` | 유효성 검사 상태가 변경될 때 발생 |
 | `change` | `File[]` | 파일 선택이 변경될 때 발생 |
+| `clear` | `File[]` | 모든 파일이 삭제될 때 삭제 직전의 파일 목록과 함께 발생 |
 | `drop` | `File[]` | 파일이 드롭될 때 발생 |
 | `focus` | `FocusEvent` | 파일 드롭 영역이 포커스를 받을 때 발생 |
 | `blur` | `FocusEvent` | 파일 드롭 영역이 포커스를 잃을 때 발생 |

--- a/packages/vlossom/src/components/vs-file-drop/README.md
+++ b/packages/vlossom/src/components/vs-file-drop/README.md
@@ -134,6 +134,7 @@ interface VsFileDropStyleSet extends CSSProperties {
 | `update:changed` | `File[]` | Emitted when files are changed |
 | `update:valid` | `boolean` | Emitted when the validation state changes |
 | `change` | `File[]` | Emitted on file selection change |
+| `clear` | `File[]` | Emitted with the previously selected files when all files are cleared |
 | `drop` | `File[]` | Emitted when files are dropped |
 | `focus` | `FocusEvent` | Emitted when the file drop area gains focus |
 | `blur` | `FocusEvent` | Emitted when the file drop area loses focus |

--- a/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
+++ b/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
@@ -129,7 +129,7 @@ export default defineComponent({
             default: () => [],
         },
     },
-    emits: ['update:modelValue', 'update:changed', 'update:valid', 'change', 'drop', 'focus', 'blur'],
+    emits: ['update:modelValue', 'update:changed', 'update:valid', 'change', 'drop', 'focus', 'blur', 'clear'],
     // expose: ['focus', 'blur', 'validate', 'clear'],
     setup(props, { emit }) {
         const {
@@ -330,12 +330,16 @@ export default defineComponent({
         }
 
         function onClear() {
+            const files = inputValue.value;
+
             if (fileDropRef.value) {
                 fileDropRef.value.value = '';
             }
 
             inputValue.value = [];
             componentMessages.value = [];
+
+            emit('clear', files);
         }
 
         function onFocus(e: FocusEvent) {

--- a/packages/vlossom/src/components/vs-file-drop/__tests__/vs-file-drop.test.ts
+++ b/packages/vlossom/src/components/vs-file-drop/__tests__/vs-file-drop.test.ts
@@ -33,6 +33,14 @@ describe('vs-file-drop', () => {
             expect(emittedEvents).toBeTruthy();
             expect(emittedEvents?.length).toBe(2);
             expect(emittedEvents?.[1][0]).toEqual([]);
+
+            const clearEvents = wrapper.emitted('clear');
+            expect(clearEvents).toBeTruthy();
+            expect(clearEvents?.[0][0]).toEqual(files);
+
+            const changeEvents = wrapper.emitted('change');
+            expect(changeEvents).toBeTruthy();
+            expect(changeEvents?.[0][0]).toEqual([]);
         });
     });
 
@@ -309,6 +317,14 @@ describe('vs-file-drop', () => {
             const emittedEvents = wrapper.emitted('update:modelValue');
             expect(emittedEvents).toBeTruthy();
             expect(emittedEvents?.[1][0]).toEqual([]);
+
+            const clearEvents = wrapper.emitted('clear');
+            expect(clearEvents).toBeTruthy();
+            expect(clearEvents?.[0][0]).toEqual(files);
+
+            const changeEvents = wrapper.emitted('change');
+            expect(changeEvents).toBeTruthy();
+            expect(changeEvents?.[0][0]).toEqual([]);
         });
 
         it('clear 메서드 호출 시 file input의 value도 초기화된다', async () => {


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Feature (feat)
- [x] Test (test)
- [x] Update Docs (docs)

## Summary

VsFileDrop에서 전체 파일 삭제 시 삭제되는 파일 목록을 확인할 수 있는 `clear` 이벤트를 추가합니다.

## Description

- VsFileDrop의 emit 목록에 `clear` 이벤트를 추가합니다.
- 전체 파일 삭제 시 삭제하는 파일 목록을 `clear` 이벤트 payload로 전달합니다.
- 전체 파일 삭제 시 `clear` 이벤트를 통해 삭제하는 파일 목록을 전달되는 지 확인하도록 테스트를 수정합니다.
- 전체 파일 삭제 시 `change` 이벤트를 통해 빈 파일 목록이 전달되는 지 확인하도록 테스트를 수정합니다.
- `clear()` 메서드 호출 시에도 동일한 `clear` 이벤트 계약을 검증합니다.
- 영어/한국어 README의 이벤트 표에 `clear` 이벤트와 payload 설명을 추가합니다.

## Related Tickets & Documents

- Closes #536 