### PR TITLE
feat(colors): add color tokens (soft, base, strong) & update state color

### DIFF
--- a/packages/vlossom/.vscode/settings.json
+++ b/packages/vlossom/.vscode/settings.json
@@ -4,7 +4,7 @@
         ".env": ".env*",
         "tsconfig.json": "tsconfig.*.json",
         "vite.config.ts": "vite.config.common.ts, vite.config.playground.ts, jsconfig*, vitest.*, cypress.config.*, playwright.config.*, visualizer*",
-        "package.json": "package-lock.json, pnpm*, .yarnrc*, yarn*, .eslint*, eslint*, .oxlint*, oxlint*, .prettier*, prettier*, .editorconfig, postcss*, tailwind*"
+        "package.json": "package-lock.json, pnpm*, .yarnrc*, yarn*, .eslint*, eslint*, .oxlint*, oxlint*, .prettier*, prettier*, .editorconfig, postcss*, tailwind*, stylelint*"
     },
     "editor.codeActionsOnSave": {
         "source.fixAll": "explicit"

--- a/packages/vlossom/playground/views/ColorPalette.vue
+++ b/packages/vlossom/playground/views/ColorPalette.vue
@@ -13,6 +13,13 @@
                 >
                     <span class="text-xs">{{ step }}</span>
                 </vs-avatar>
+                <vs-avatar
+                    v-for="token in tokens"
+                    :key="token.label"
+                    :style-set="{ border: 'none', width: '3rem', height: '1rem' }"
+                >
+                    <span class="text-xs">{{ token.label }}</span>
+                </vs-avatar>
             </div>
             <div v-for="color in COLORS" :key="color" class="flex flex-nowrap gap-3">
                 <vs-avatar :style-set="{ border: 'none', width: '4rem', height: '3rem' }">
@@ -23,6 +30,16 @@
                     :key="`${color}-${step}`"
                     :style-set="{
                         backgroundColor: `var(--vs-${color}-${step})`,
+                        border: 'none',
+                        width: '3rem',
+                        height: '3rem',
+                    }"
+                />
+                <vs-avatar
+                    v-for="token in tokens"
+                    :key="`${color}-${token.label}`"
+                    :style-set="{
+                        backgroundColor: `var(--vs-${color}${token.suffix})`,
                         border: 'none',
                         width: '3rem',
                         height: '3rem',
@@ -40,10 +57,16 @@ import { COLORS } from '@/declaration';
 export default defineComponent({
     setup() {
         const steps = [50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950];
+        const tokens = [
+            { label: 'soft', suffix: '-soft' },
+            { label: 'base', suffix: '' },
+            { label: 'strong', suffix: '-strong' },
+        ];
 
         return {
             COLORS,
             steps,
+            tokens,
         };
     },
 });

--- a/packages/vlossom/src/components/vs-radio/VsRadio.css
+++ b/packages/vlossom/src/components/vs-radio/VsRadio.css
@@ -59,7 +59,7 @@
 
         .vs-radio-label {
             &:before {
-                @apply outline-3 outline-offset-2 outline-(--vs-state-color);
+                @apply outline-3 outline-offset-2 outline-(--vs-sc);
             }
         }
     }

--- a/packages/vlossom/src/components/vs-table/VsTable.css
+++ b/packages/vlossom/src/components/vs-table/VsTable.css
@@ -104,7 +104,8 @@
         }
 
         &.vs-stated {
-            background-color: var(--vs-state-color-bg);
+            background-color: var(--vs-sc-soft);
+            color: var(--vs-sc);
         }
 
         &.vs-selected {

--- a/packages/vlossom/src/components/vs-textarea/VsTextarea.css
+++ b/packages/vlossom/src/components/vs-textarea/VsTextarea.css
@@ -1,7 +1,7 @@
 @reference 'tailwindcss';
 
 .vs-textarea {
-    @apply relative flex w-full resize-y overflow-hidden outline-none;
+    @apply relative flex w-full resize-y overflow-hidden;
 
     border: solid 1px var(--vs-cs-line);
     border-radius: calc(var(--vs-radius-ratio) * var(--vs-radius-md));

--- a/packages/vlossom/src/styles/color-scheme.scss
+++ b/packages/vlossom/src/styles/color-scheme.scss
@@ -3,6 +3,20 @@ $colors:
     'violet', 'purple', 'fuchsia', 'pink', 'rose', 'gray';
 
 :root {
+    @each $color in $colors {
+        --vs-#{$color}-soft: var(--vs-#{$color}-100);
+        --vs-#{$color}: var(--vs-#{$color}-600);
+        --vs-#{$color}-strong: var(--vs-#{$color}-800);
+    }
+
+    &.vs-dark {
+        @each $color in $colors {
+            --vs-#{$color}-soft: var(--vs-#{$color}-950);
+            --vs-#{$color}: var(--vs-#{$color}-600);
+            --vs-#{$color}-strong: var(--vs-#{$color}-200);
+        }
+    }
+
     .vs-cs-default {
         --vs-cs-line: var(--vs-gray-300);
 

--- a/packages/vlossom/src/styles/palette.css
+++ b/packages/vlossom/src/styles/palette.css
@@ -10,10 +10,10 @@
         --vs-gray-400: oklch(68% 0 0);
         --vs-gray-500: oklch(56% 0 0);
         --vs-gray-600: oklch(45% 0 0);
-        --vs-gray-700: oklch(35% 0 0);
-        --vs-gray-800: oklch(25% 0 0);
-        --vs-gray-900: oklch(15% 0 0);
-        --vs-gray-950: oklch(10% 0 0);
+        --vs-gray-700: oklch(37% 0 0);
+        --vs-gray-800: oklch(30% 0 0);
+        --vs-gray-900: oklch(22% 0 0);
+        --vs-gray-950: oklch(14% 0 0);
 
         --vs-red-50: oklch(97% 0.02 25);
         --vs-red-100: oklch(94% 0.04 25);
@@ -22,10 +22,10 @@
         --vs-red-400: oklch(72% 0.16 25);
         --vs-red-500: oklch(66% 0.19 25);
         --vs-red-600: oklch(62% 0.2 25);
-        --vs-red-700: oklch(55% 0.18 25);
-        --vs-red-800: oklch(47% 0.15 25);
-        --vs-red-900: oklch(38% 0.12 25);
-        --vs-red-950: oklch(32% 0.1 25);
+        --vs-red-700: oklch(51% 0.17 25);
+        --vs-red-800: oklch(41% 0.13 25);
+        --vs-red-900: oklch(30% 0.098 25);
+        --vs-red-950: oklch(20% 0.064 25);
 
         --vs-brown-50: oklch(96% 0.02 25);
         --vs-brown-100: oklch(92% 0.04 25);
@@ -34,10 +34,10 @@
         --vs-brown-400: oklch(60% 0.12 25);
         --vs-brown-500: oklch(50% 0.13 25);
         --vs-brown-600: oklch(42% 0.13 25);
-        --vs-brown-700: oklch(35% 0.12 25);
-        --vs-brown-800: oklch(28% 0.1 25);
-        --vs-brown-900: oklch(22% 0.08 25);
-        --vs-brown-950: oklch(18% 0.07 25);
+        --vs-brown-700: oklch(35% 0.11 25);
+        --vs-brown-800: oklch(28% 0.086 25);
+        --vs-brown-900: oklch(21% 0.064 25);
+        --vs-brown-950: oklch(13% 0.042 25);
 
         --vs-orange-50: oklch(97% 0.03 50);
         --vs-orange-100: oklch(94% 0.05 50);
@@ -46,10 +46,10 @@
         --vs-orange-400: oklch(75% 0.17 50);
         --vs-orange-500: oklch(72% 0.19 50);
         --vs-orange-600: oklch(70% 0.19 50);
-        --vs-orange-700: oklch(60% 0.17 50);
-        --vs-orange-800: oklch(50% 0.14 50);
-        --vs-orange-900: oklch(40% 0.11 50);
-        --vs-orange-950: oklch(34% 0.09 50);
+        --vs-orange-700: oklch(58% 0.16 50);
+        --vs-orange-800: oklch(46% 0.13 50);
+        --vs-orange-900: oklch(34% 0.093 50);
+        --vs-orange-950: oklch(22% 0.061 50);
 
         --vs-amber-50: oklch(97% 0.03 70);
         --vs-amber-100: oklch(94% 0.05 70);
@@ -57,11 +57,11 @@
         --vs-amber-300: oklch(84% 0.14 70);
         --vs-amber-400: oklch(80% 0.18 70);
         --vs-amber-500: oklch(79% 0.19 70);
-        --vs-amber-600: oklch(78% 0.19 70);
-        --vs-amber-700: oklch(66% 0.17 70);
-        --vs-amber-800: oklch(54% 0.14 70);
-        --vs-amber-900: oklch(42% 0.11 70);
-        --vs-amber-950: oklch(36% 0.09 70);
+        --vs-amber-600: oklch(74% 0.19 70);
+        --vs-amber-700: oklch(61% 0.16 70);
+        --vs-amber-800: oklch(49% 0.13 70);
+        --vs-amber-900: oklch(36% 0.093 70);
+        --vs-amber-950: oklch(24% 0.061 70);
 
         --vs-yellow-50: oklch(98% 0.02 85);
         --vs-yellow-100: oklch(96% 0.04 85);
@@ -69,11 +69,11 @@
         --vs-yellow-300: oklch(88% 0.12 85);
         --vs-yellow-400: oklch(86% 0.16 85);
         --vs-yellow-500: oklch(85% 0.18 85);
-        --vs-yellow-600: oklch(84% 0.18 85);
-        --vs-yellow-700: oklch(70% 0.16 85);
-        --vs-yellow-800: oklch(56% 0.13 85);
-        --vs-yellow-900: oklch(44% 0.1 85);
-        --vs-yellow-950: oklch(38% 0.08 85);
+        --vs-yellow-600: oklch(80% 0.18 85);
+        --vs-yellow-700: oklch(66% 0.15 85);
+        --vs-yellow-800: oklch(53% 0.12 85);
+        --vs-yellow-900: oklch(39% 0.088 85);
+        --vs-yellow-950: oklch(26% 0.058 85);
 
         --vs-lime-50: oklch(97% 0.03 120);
         --vs-lime-100: oklch(95% 0.06 120);
@@ -81,11 +81,11 @@
         --vs-lime-300: oklch(85% 0.15 120);
         --vs-lime-400: oklch(82% 0.18 120);
         --vs-lime-500: oklch(80% 0.2 120);
-        --vs-lime-600: oklch(78% 0.2 120);
-        --vs-lime-700: oklch(66% 0.17 120);
-        --vs-lime-800: oklch(54% 0.14 120);
-        --vs-lime-900: oklch(42% 0.11 120);
-        --vs-lime-950: oklch(36% 0.09 120);
+        --vs-lime-600: oklch(74% 0.2 120);
+        --vs-lime-700: oklch(61% 0.17 120);
+        --vs-lime-800: oklch(49% 0.13 120);
+        --vs-lime-900: oklch(36% 0.098 120);
+        --vs-lime-950: oklch(24% 0.064 120);
 
         --vs-green-50: oklch(97% 0.02 152.5);
         --vs-green-100: oklch(94% 0.04 152.5);
@@ -93,23 +93,23 @@
         --vs-green-300: oklch(80% 0.1 152.5);
         --vs-green-400: oklch(70% 0.13 152.5);
         --vs-green-500: oklch(64% 0.14 152.5);
-        --vs-green-600: oklch(60.3% 0.139 152.5);
-        --vs-green-700: oklch(52% 0.13 152.5);
-        --vs-green-800: oklch(44% 0.11 152.5);
-        --vs-green-900: oklch(36% 0.09 152.5);
-        --vs-green-950: oklch(30% 0.07 152.5);
+        --vs-green-600: oklch(60% 0.14 152.5);
+        --vs-green-700: oklch(50% 0.12 152.5);
+        --vs-green-800: oklch(40% 0.092 152.5);
+        --vs-green-900: oklch(29% 0.069 152.5);
+        --vs-green-950: oklch(19% 0.045 152.5);
 
         --vs-emerald-50: oklch(97% 0.02 151.5);
         --vs-emerald-100: oklch(94% 0.04 151.5);
         --vs-emerald-200: oklch(90% 0.07 151.5);
         --vs-emerald-300: oklch(84% 0.1 151.5);
         --vs-emerald-400: oklch(76% 0.13 151.5);
-        --vs-emerald-500: oklch(72% 0.134 151.5);
-        --vs-emerald-600: oklch(70% 0.134 151.5);
-        --vs-emerald-700: oklch(60% 0.12 151.5);
-        --vs-emerald-800: oklch(50% 0.1 151.5);
-        --vs-emerald-900: oklch(40% 0.08 151.5);
-        --vs-emerald-950: oklch(34% 0.07 151.5);
+        --vs-emerald-500: oklch(72% 0.13 151.5);
+        --vs-emerald-600: oklch(70% 0.13 151.5);
+        --vs-emerald-700: oklch(58% 0.11 151.5);
+        --vs-emerald-800: oklch(46% 0.086 151.5);
+        --vs-emerald-900: oklch(34% 0.064 151.5);
+        --vs-emerald-950: oklch(22% 0.042 151.5);
 
         --vs-teal-50: oklch(97% 0.02 185);
         --vs-teal-100: oklch(94% 0.04 185);
@@ -118,10 +118,10 @@
         --vs-teal-400: oklch(68% 0.1 185);
         --vs-teal-500: oklch(60% 0.1 185);
         --vs-teal-600: oklch(55% 0.1 185);
-        --vs-teal-700: oklch(48% 0.09 185);
-        --vs-teal-800: oklch(40% 0.08 185);
-        --vs-teal-900: oklch(32% 0.07 185);
-        --vs-teal-950: oklch(26% 0.06 185);
+        --vs-teal-700: oklch(46% 0.083 185);
+        --vs-teal-800: oklch(36% 0.066 185);
+        --vs-teal-900: oklch(27% 0.049 185);
+        --vs-teal-950: oklch(18% 0.032 185);
 
         --vs-cyan-50: oklch(97% 0.02 194.8);
         --vs-cyan-100: oklch(95% 0.04 194.8);
@@ -129,11 +129,11 @@
         --vs-cyan-300: oklch(85% 0.07 194.8);
         --vs-cyan-400: oklch(83% 0.08 194.8);
         --vs-cyan-500: oklch(82% 0.08 194.8);
-        --vs-cyan-600: oklch(81% 0.08 194.8);
-        --vs-cyan-700: oklch(68% 0.07 194.8);
-        --vs-cyan-800: oklch(56% 0.06 194.8);
-        --vs-cyan-900: oklch(44% 0.05 194.8);
-        --vs-cyan-950: oklch(38% 0.04 194.8);
+        --vs-cyan-600: oklch(77% 0.08 194.8);
+        --vs-cyan-700: oklch(64% 0.066 194.8);
+        --vs-cyan-800: oklch(51% 0.053 194.8);
+        --vs-cyan-900: oklch(38% 0.039 194.8);
+        --vs-cyan-950: oklch(25% 0.026 194.8);
 
         --vs-sky-50: oklch(97% 0.03 240);
         --vs-sky-100: oklch(94% 0.06 240);
@@ -141,11 +141,11 @@
         --vs-sky-300: oklch(80% 0.13 240);
         --vs-sky-400: oklch(75% 0.15 240);
         --vs-sky-500: oklch(73% 0.15 240);
-        --vs-sky-600: oklch(72% 0.15 240);
-        --vs-sky-700: oklch(62% 0.13 240);
-        --vs-sky-800: oklch(50% 0.11 240);
-        --vs-sky-900: oklch(40% 0.09 240);
-        --vs-sky-950: oklch(34% 0.07 240);
+        --vs-sky-600: oklch(68% 0.15 240);
+        --vs-sky-700: oklch(56% 0.12 240);
+        --vs-sky-800: oklch(45% 0.1 240);
+        --vs-sky-900: oklch(33% 0.074 240);
+        --vs-sky-950: oklch(22% 0.048 240);
 
         --vs-blue-50: oklch(97% 0.03 262);
         --vs-blue-100: oklch(94% 0.06 262);
@@ -153,11 +153,11 @@
         --vs-blue-300: oklch(78% 0.13 262);
         --vs-blue-400: oklch(65% 0.15 262);
         --vs-blue-500: oklch(58% 0.15 262);
-        --vs-blue-600: oklch(54.5% 0.15 262);
-        --vs-blue-700: oklch(48% 0.13 262);
-        --vs-blue-800: oklch(40% 0.11 262);
-        --vs-blue-900: oklch(32% 0.09 262);
-        --vs-blue-950: oklch(26% 0.07 262);
+        --vs-blue-600: oklch(55% 0.15 262);
+        --vs-blue-700: oklch(46% 0.12 262);
+        --vs-blue-800: oklch(36% 0.1 262);
+        --vs-blue-900: oklch(27% 0.074 262);
+        --vs-blue-950: oklch(18% 0.048 262);
 
         --vs-indigo-50: oklch(97% 0.03 275);
         --vs-indigo-100: oklch(94% 0.06 275);
@@ -166,10 +166,10 @@
         --vs-indigo-400: oklch(65% 0.16 275);
         --vs-indigo-500: oklch(58% 0.16 275);
         --vs-indigo-600: oklch(55% 0.16 275);
-        --vs-indigo-700: oklch(48% 0.14 275);
-        --vs-indigo-800: oklch(40% 0.12 275);
-        --vs-indigo-900: oklch(32% 0.1 275);
-        --vs-indigo-950: oklch(26% 0.08 275);
+        --vs-indigo-700: oklch(46% 0.13 275);
+        --vs-indigo-800: oklch(36% 0.11 275);
+        --vs-indigo-900: oklch(27% 0.078 275);
+        --vs-indigo-950: oklch(18% 0.051 275);
 
         --vs-violet-50: oklch(97% 0.03 295);
         --vs-violet-100: oklch(94% 0.06 295);
@@ -177,11 +177,11 @@
         --vs-violet-300: oklch(80% 0.14 295);
         --vs-violet-400: oklch(70% 0.17 295);
         --vs-violet-500: oklch(65% 0.17 295);
-        --vs-violet-600: oklch(62.8% 0.171 295);
-        --vs-violet-700: oklch(54% 0.15 295);
-        --vs-violet-800: oklch(45% 0.13 295);
-        --vs-violet-900: oklch(36% 0.11 295);
-        --vs-violet-950: oklch(30% 0.09 295);
+        --vs-violet-600: oklch(63% 0.17 295);
+        --vs-violet-700: oklch(52% 0.14 295);
+        --vs-violet-800: oklch(42% 0.11 295);
+        --vs-violet-900: oklch(31% 0.083 295);
+        --vs-violet-950: oklch(20% 0.054 295);
 
         --vs-purple-50: oklch(97% 0.04 310);
         --vs-purple-100: oklch(94% 0.08 310);
@@ -190,10 +190,10 @@
         --vs-purple-400: oklch(62% 0.21 310);
         --vs-purple-500: oklch(55% 0.22 310);
         --vs-purple-600: oklch(50% 0.22 310);
-        --vs-purple-700: oklch(44% 0.2 310);
-        --vs-purple-800: oklch(36% 0.17 310);
-        --vs-purple-900: oklch(28% 0.14 310);
-        --vs-purple-950: oklch(24% 0.12 310);
+        --vs-purple-700: oklch(42% 0.18 310);
+        --vs-purple-800: oklch(33% 0.15 310);
+        --vs-purple-900: oklch(25% 0.11 310);
+        --vs-purple-950: oklch(16% 0.07 310);
 
         --vs-fuchsia-50: oklch(97% 0.04 335);
         --vs-fuchsia-100: oklch(94% 0.08 335);
@@ -201,11 +201,11 @@
         --vs-fuchsia-300: oklch(80% 0.18 335);
         --vs-fuchsia-400: oklch(70% 0.21 335);
         --vs-fuchsia-500: oklch(65% 0.21 335);
-        --vs-fuchsia-600: oklch(62.8% 0.21 335);
-        --vs-fuchsia-700: oklch(54% 0.18 335);
-        --vs-fuchsia-800: oklch(45% 0.15 335);
-        --vs-fuchsia-900: oklch(36% 0.12 335);
-        --vs-fuchsia-950: oklch(30% 0.1 335);
+        --vs-fuchsia-600: oklch(63% 0.21 335);
+        --vs-fuchsia-700: oklch(52% 0.17 335);
+        --vs-fuchsia-800: oklch(42% 0.14 335);
+        --vs-fuchsia-900: oklch(31% 0.1 335);
+        --vs-fuchsia-950: oklch(20% 0.067 335);
 
         --vs-pink-50: oklch(97% 0.03 350);
         --vs-pink-100: oklch(94% 0.06 350);
@@ -214,10 +214,10 @@
         --vs-pink-400: oklch(72% 0.18 350);
         --vs-pink-500: oklch(70% 0.2 350);
         --vs-pink-600: oklch(68% 0.2 350);
-        --vs-pink-700: oklch(58% 0.18 350);
-        --vs-pink-800: oklch(48% 0.15 350);
-        --vs-pink-900: oklch(38% 0.12 350);
-        --vs-pink-950: oklch(32% 0.1 350);
+        --vs-pink-700: oklch(56% 0.17 350);
+        --vs-pink-800: oklch(45% 0.13 350);
+        --vs-pink-900: oklch(33% 0.098 350);
+        --vs-pink-950: oklch(22% 0.064 350);
 
         --vs-rose-50: oklch(97% 0.03 10);
         --vs-rose-100: oklch(94% 0.06 10);
@@ -225,10 +225,10 @@
         --vs-rose-300: oklch(80% 0.14 10);
         --vs-rose-400: oklch(72% 0.17 10);
         --vs-rose-500: oklch(70% 0.18 10);
-        --vs-rose-600: oklch(67.9% 0.187 10);
-        --vs-rose-700: oklch(58% 0.16 10);
-        --vs-rose-800: oklch(48% 0.13 10);
-        --vs-rose-900: oklch(38% 0.11 10);
-        --vs-rose-950: oklch(32% 0.09 10);
+        --vs-rose-600: oklch(68% 0.19 10);
+        --vs-rose-700: oklch(56% 0.16 10);
+        --vs-rose-800: oklch(45% 0.13 10);
+        --vs-rose-900: oklch(33% 0.093 10);
+        --vs-rose-950: oklch(22% 0.061 10);
     }
 }

--- a/packages/vlossom/src/styles/state.css
+++ b/packages/vlossom/src/styles/state.css
@@ -1,46 +1,45 @@
 @layer utilities {
     :root {
-        --vs-state-color-info: var(--vs-blue-600);
-        --vs-state-color-success: var(--vs-green-600);
-        --vs-state-color-warning: var(--vs-yellow-600);
-        --vs-state-color-error: var(--vs-red-600);
+        --vs-sc-info: var(--vs-sky);
+        --vs-sc-success: var(--vs-green);
+        --vs-sc-warning: var(--vs-yellow);
+        --vs-sc-error: var(--vs-red);
 
-        --vs-state-color-bg-info: var(--vs-blue-100);
-        --vs-state-color-bg-success: var(--vs-green-100);
-        --vs-state-color-bg-warning: var(--vs-yellow-100);
-        --vs-state-color-bg-error: var(--vs-red-100);
+        --vs-sc-soft-info: var(--vs-sky-soft);
+        --vs-sc-soft-success: var(--vs-green-soft);
+        --vs-sc-soft-warning: var(--vs-yellow-soft);
+        --vs-sc-soft-error: var(--vs-red-soft);
 
-        @variant dark {
-            --vs-state-color-info: var(--vs-blue-700);
-            --vs-state-color-success: var(--vs-green-700);
-            --vs-state-color-warning: var(--vs-yellow-700);
-            --vs-state-color-error: var(--vs-red-700);
-
-            --vs-state-color-bg-info: var(--vs-blue-950);
-            --vs-state-color-bg-success: var(--vs-green-950);
-            --vs-state-color-bg-warning: var(--vs-yellow-950);
-            --vs-state-color-bg-error: var(--vs-red-950);
-        }
+        --vs-sc-strong-info: var(--vs-sky-strong);
+        --vs-sc-strong-success: var(--vs-green-strong);
+        --vs-sc-strong-warning: var(--vs-yellow-strong);
+        --vs-sc-strong-error: var(--vs-red-strong);
 
         .vs-state-info {
-            --vs-state-color: var(--vs-state-color-info);
-            --vs-state-color-bg: var(--vs-state-color-bg-info);
+            --vs-sc: var(--vs-sc-info);
+            --vs-sc-soft: var(--vs-sc-soft-info);
+            --vs-sc-strong: var(--vs-sc-strong-info);
         }
         .vs-state-success {
-            --vs-state-color: var(--vs-state-color-success);
-            --vs-state-color-bg: var(--vs-state-color-bg-success);
+            --vs-sc: var(--vs-sc-success);
+            --vs-sc-soft: var(--vs-sc-soft-success);
+            --vs-sc-strong: var(--vs-sc-strong-success);
         }
         .vs-state-warning {
-            --vs-state-color: var(--vs-state-color-warning);
-            --vs-state-color-bg: var(--vs-state-color-bg-warning);
+            --vs-sc: var(--vs-sc-warning);
+            --vs-sc-soft: var(--vs-sc-soft-warning);
+            --vs-sc-strong: var(--vs-sc-strong-warning);
         }
         .vs-state-error {
-            --vs-state-color: var(--vs-state-color-error);
-            --vs-state-color-bg: var(--vs-state-color-bg-error);
+            --vs-sc: var(--vs-sc-error);
+            --vs-sc-soft: var(--vs-sc-soft-error);
+            --vs-sc-strong: var(--vs-sc-strong-error);
         }
     }
 
     .vs-state-box {
-        @apply outline-3 outline-offset-2 outline-(--vs-state-color);
+        @apply outline-3 outline-offset-2;
+
+        outline-color: var(--vs-sc);
     }
 }

--- a/packages/vlossom/stylelint.config.js
+++ b/packages/vlossom/stylelint.config.js
@@ -11,11 +11,11 @@ export default {
         '**/*.vue',
         // SCSS files with dynamic variable interpolation
         '**/color-scheme.scss',
+        '**/state.css',
         // Tailwind CSS color variables (--color-*) reference
         '**/pallete.css',
         // Dynamic CSS variables set via inline styles from JS
         '**/vs-responsive/VsResponsive.css',
-        '**/vs-steps/VsSteps.css',
     ],
     rules: {
         // CSS variable validation - main purpose of this config


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)

## Summary

## Description
- color-scheme에서 각 색상에 맞는 token 생성
  - 약한 색은 soft, 강한 색을 strong으로 접미사 붙임
  - ex: --vs-red-soft, --vs-red, --vs-red-strong
  - dark 모드에서는 색상 반전됨
- state color 색상 조정 -> 위에서 만든 color token 이용하도록 변경함
- palette 색상 전체 조정
- state.css stylelint ignore 지정: 다른 파일에서 동적으로 선언한 변수 사용 때문
- 기타: vs-textarea에 state outline 안 나오는 버그 수정

### Color Palette에 soft, base, strong 추가
<img width="925" height="803" alt="image" src="https://github.com/user-attachments/assets/4eed7ac3-9ec1-4092-a774-675ac0813194" />


### vs-table (dark mode) 스크린샷

#### before
<img width="807" height="328" alt="image" src="https://github.com/user-attachments/assets/7945b810-2df1-4bc1-9f90-39a19c664c52" />

#### after
<img width="835" height="386" alt="image" src="https://github.com/user-attachments/assets/2dda1921-1683-4035-a09d-963332859cfa" />

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
