### PR TITLE
refactor(input-composable): centralize clear event handling for input components

### DIFF
--- a/packages/vlossom/src/components/vs-checkbox/README.ko.md
+++ b/packages/vlossom/src/components/vs-checkbox/README.ko.md
@@ -190,6 +190,7 @@ interface VsCheckboxSetStyleSet extends CSSProperties {
 | `focus` | `FocusEvent` | 체크박스가 포커스를 받을 때 발생 |
 | `blur` | `FocusEvent` | 체크박스가 포커스를 잃을 때 발생 |
 | `toggle` | `boolean, MouseEvent` | 토글 후 발생; 새로운 체크 상태와 마우스 이벤트가 페이로드 |
+| `clear` | `any` | 값이 초기화될 때 초기화 직전 값과 함께 발생 |
 
 ## Slots
 

--- a/packages/vlossom/src/components/vs-checkbox/README.md
+++ b/packages/vlossom/src/components/vs-checkbox/README.md
@@ -190,6 +190,7 @@ interface VsCheckboxSetStyleSet extends CSSProperties {
 | `focus` | `FocusEvent` | Emitted when the checkbox gains focus |
 | `blur` | `FocusEvent` | Emitted when the checkbox loses focus |
 | `toggle` | `boolean, MouseEvent` | Emitted after toggling; payload is the new checked state and the mouse event |
+| `clear` | `any` | Emitted with the previous value when the value is cleared |
 
 ## Slots
 

--- a/packages/vlossom/src/components/vs-checkbox/VsCheckbox.vue
+++ b/packages/vlossom/src/components/vs-checkbox/VsCheckbox.vue
@@ -97,7 +97,7 @@ export default defineComponent({
         // v-model
         modelValue: { type: null, default: false },
     },
-    emits: ['update:modelValue', 'update:changed', 'update:valid', 'change', 'focus', 'blur', 'toggle'],
+    emits: ['update:modelValue', 'update:changed', 'update:valid', 'change', 'focus', 'blur', 'toggle', 'clear'],
     // expose: ['clear', 'validate', 'focus', 'blur', 'toggle'],
     setup(props, { emit }) {
         const {

--- a/packages/vlossom/src/components/vs-checkbox/VsCheckboxSet.vue
+++ b/packages/vlossom/src/components/vs-checkbox/VsCheckboxSet.vue
@@ -99,7 +99,7 @@ export default defineComponent({
             default: () => [],
         },
     },
-    emits: ['update:modelValue', 'update:changed', 'update:valid', 'change', 'focus', 'blur'],
+    emits: ['update:modelValue', 'update:changed', 'update:valid', 'change', 'focus', 'blur', 'clear'],
     // expose: ['focus', 'blur', 'validate', 'clear'],
     setup(props, { emit }) {
         const {

--- a/packages/vlossom/src/components/vs-checkbox/__tests__/vs-checkbox-set.test.ts
+++ b/packages/vlossom/src/components/vs-checkbox/__tests__/vs-checkbox-set.test.ts
@@ -193,6 +193,7 @@ describe('VsCheckboxSet', () => {
 
             // then
             expect(wrapper.props('modelValue')).toEqual([]);
+            expect(wrapper.emitted('clear')?.[0]).toEqual([['A', 'B']]);
         });
     });
 

--- a/packages/vlossom/src/components/vs-checkbox/__tests__/vs-checkbox.test.ts
+++ b/packages/vlossom/src/components/vs-checkbox/__tests__/vs-checkbox.test.ts
@@ -375,6 +375,7 @@ describe('vs-checkbox', () => {
                 // then
                 expect(wrapper.vm.isChecked).toBe(false);
                 expect(wrapper.props('modelValue')).toEqual([]);
+                expect(wrapper.emitted('clear')?.[0]).toEqual([['A', 'B']]);
             });
         });
 
@@ -396,6 +397,7 @@ describe('vs-checkbox', () => {
                 expect(wrapper.find('input').element.checked).toBe(false);
                 expect(wrapper.vm.isChecked).toBe(false);
                 expect(wrapper.props('modelValue')).toBe(false);
+                expect(wrapper.emitted('clear')?.[0]).toEqual([true]);
             });
         });
     });

--- a/packages/vlossom/src/components/vs-date-picker/README.ko.md
+++ b/packages/vlossom/src/components/vs-date-picker/README.ko.md
@@ -173,7 +173,7 @@ interface VsDatePickerStyleSet extends CSSProperties {
 | `change`            | `string`            | 값이 commit된 후 emit.                           |
 | `focus`             | `FocusEvent`        | 포커스 시 emit.                                  |
 | `blur`              | `FocusEvent`        | 블러 시 emit.                                    |
-| `clear`             | -                   | 지우기 버튼 클릭 시 emit.                        |
+| `clear`             | `string`            | 값이 초기화될 때 초기화 직전 값과 함께 emit.     |
 | `invalid`           | `{ input: string }` | format 불일치 시 emit.                           |
 
 ## Slots

--- a/packages/vlossom/src/components/vs-date-picker/README.md
+++ b/packages/vlossom/src/components/vs-date-picker/README.md
@@ -173,7 +173,7 @@ interface VsDatePickerStyleSet extends CSSProperties {
 | `change`            | `string`            | Emitted after the value is committed.                                 |
 | `focus`             | `FocusEvent`        | Emitted when the input receives focus.                                |
 | `blur`              | `FocusEvent`        | Emitted when the input loses focus.                                   |
-| `clear`             | -                   | Emitted when the clear button is pressed.                             |
+| `clear`             | `string`            | Emitted with the previous value when the value is cleared.             |
 | `invalid`           | `{ input: string }` | Emitted on format mismatch.                                           |
 
 ## Slots

--- a/packages/vlossom/src/components/vs-date-picker/VsDatePicker.vue
+++ b/packages/vlossom/src/components/vs-date-picker/VsDatePicker.vue
@@ -214,9 +214,10 @@ export default defineComponent({
                 defaultRules: computed(() => [requiredCheck, minCheck, maxCheck]),
                 noDefaultRules,
                 state,
-                emitClear: true,
                 callbacks: {
-                    onClear,
+                    onClear: () => {
+                        inputValue.value = '';
+                    },
                 },
             },
         );
@@ -276,10 +277,6 @@ export default defineComponent({
 
         function blur(): void {
             dateInputRef.value?.blur();
-        }
-
-        function onClear(): void {
-            inputValue.value = '';
         }
 
         function onPointerDown(): void {

--- a/packages/vlossom/src/components/vs-date-picker/VsDatePicker.vue
+++ b/packages/vlossom/src/components/vs-date-picker/VsDatePicker.vue
@@ -216,6 +216,7 @@ export default defineComponent({
                 state,
                 callbacks: {
                     onClear,
+                    getClearPayload: (oldValue) => oldValue,
                 },
             },
         );
@@ -257,7 +258,7 @@ export default defineComponent({
                 if (inputValue.value && !isValidFormat(inputValue.value, type.value)) {
                     return;
                 }
-                onClear();
+                clear();
                 return;
             }
 
@@ -279,7 +280,6 @@ export default defineComponent({
 
         function onClear(): void {
             inputValue.value = '';
-            emit('clear');
         }
 
         function onPointerDown(): void {

--- a/packages/vlossom/src/components/vs-date-picker/VsDatePicker.vue
+++ b/packages/vlossom/src/components/vs-date-picker/VsDatePicker.vue
@@ -214,9 +214,9 @@ export default defineComponent({
                 defaultRules: computed(() => [requiredCheck, minCheck, maxCheck]),
                 noDefaultRules,
                 state,
+                emitClear: true,
                 callbacks: {
                     onClear,
-                    getClearPayload: (oldValue) => oldValue,
                 },
             },
         );

--- a/packages/vlossom/src/components/vs-date-picker/__tests__/vs-date-picker.test.ts
+++ b/packages/vlossom/src/components/vs-date-picker/__tests__/vs-date-picker.test.ts
@@ -86,7 +86,7 @@ describe('VsDatePicker', () => {
                 },
             });
             await wrapper.find('.vs-clear-button').trigger('click');
-            expect(wrapper.emitted('clear')).toBeTruthy();
+            expect(wrapper.emitted('clear')?.[0]).toEqual(['2026-05-18T15:30']);
             const updates = wrapper.emitted('update:modelValue') as Array<[string]>;
             expect(updates[updates.length - 1][0]).toBe('');
         });

--- a/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
+++ b/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
@@ -207,12 +207,12 @@ export default defineComponent({
                 rules,
                 defaultRules: computed(() => [requiredCheck, acceptCheck]),
                 state,
+                emitClear: true,
                 callbacks: {
                     onMounted: () => {
                         inputValue.value = modelValue.value ?? [];
                     },
                     onClear,
-                    getClearPayload: (oldValue) => oldValue,
                 },
             },
         );

--- a/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
+++ b/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
@@ -82,7 +82,7 @@
                 :style="componentStyleSet.$closeButton"
                 aria-label="Clear"
                 tabindex="-1"
-                @click.prevent.stop="onClear()"
+                @click.prevent.stop="clear"
             >
                 <XIcon class="vs-file-drop-close-icon" />
             </button>
@@ -212,6 +212,7 @@ export default defineComponent({
                         inputValue.value = modelValue.value ?? [];
                     },
                     onClear,
+                    getClearPayload: (oldValue) => oldValue,
                 },
             },
         );
@@ -330,16 +331,12 @@ export default defineComponent({
         }
 
         function onClear() {
-            const files = inputValue.value;
-
             if (fileDropRef.value) {
                 fileDropRef.value.value = '';
             }
 
             inputValue.value = [];
             componentMessages.value = [];
-
-            emit('clear', files);
         }
 
         function onFocus(e: FocusEvent) {
@@ -385,7 +382,6 @@ export default defineComponent({
             handleFileDialog,
             handleFileDrop,
             handleFileRemove,
-            onClear,
             onFocus,
             onBlur,
             focus,

--- a/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
+++ b/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
@@ -207,12 +207,18 @@ export default defineComponent({
                 rules,
                 defaultRules: computed(() => [requiredCheck, acceptCheck]),
                 state,
-                emitClear: true,
                 callbacks: {
                     onMounted: () => {
                         inputValue.value = modelValue.value ?? [];
                     },
-                    onClear,
+                    onClear: () => {
+                        if (fileDropRef.value) {
+                            fileDropRef.value.value = '';
+                        }
+
+                        inputValue.value = [];
+                        componentMessages.value = [];
+                    },
                 },
             },
         );
@@ -328,15 +334,6 @@ export default defineComponent({
             }
 
             inputValue.value = filteredFiles;
-        }
-
-        function onClear() {
-            if (fileDropRef.value) {
-                fileDropRef.value.value = '';
-            }
-
-            inputValue.value = [];
-            componentMessages.value = [];
         }
 
         function onFocus(e: FocusEvent) {

--- a/packages/vlossom/src/components/vs-input/README.ko.md
+++ b/packages/vlossom/src/components/vs-input/README.ko.md
@@ -148,6 +148,7 @@ interface VsInputStyleSet extends CSSProperties {
 | `change`            | -                          | 값이 확정된 후 발생합니다.                    |
 | `focus`             | `FocusEvent`               | 입력이 포커스를 받을 때 발생합니다.           |
 | `blur`              | `FocusEvent`               | 입력이 포커스를 잃을 때 발생합니다.           |
+| `clear`             | `string \| number \| null` | 값이 초기화될 때 초기화 직전 값과 함께 발생합니다. |
 
 ## Slots
 

--- a/packages/vlossom/src/components/vs-input/README.md
+++ b/packages/vlossom/src/components/vs-input/README.md
@@ -148,6 +148,7 @@ interface VsInputStyleSet extends CSSProperties {
 | `change`            | -                          | Emitted after the value is committed.               |
 | `focus`             | `FocusEvent`               | Emitted when the input receives focus.              |
 | `blur`              | `FocusEvent`               | Emitted when the input loses focus.                 |
+| `clear`             | `string \| number \| null` | Emitted with the previous value when the value is cleared. |
 
 ## Slots
 

--- a/packages/vlossom/src/components/vs-input/VsInput.vue
+++ b/packages/vlossom/src/components/vs-input/VsInput.vue
@@ -177,6 +177,7 @@ export default defineComponent({
                 defaultRules: computed(() => [requiredCheck, maxCheck, minCheck]),
                 noDefaultRules,
                 state,
+                emitClear: true,
                 callbacks: {
                     onMounted: () => {
                         inputValue.value = convertValue(inputValue.value);
@@ -185,7 +186,6 @@ export default defineComponent({
                         inputValue.value = convertValue(inputValue.value);
                     },
                     onClear,
-                    getClearPayload: (oldValue) => oldValue,
                 },
             },
         );

--- a/packages/vlossom/src/components/vs-input/VsInput.vue
+++ b/packages/vlossom/src/components/vs-input/VsInput.vue
@@ -151,10 +151,6 @@ export default defineComponent({
             return modifyStringValue(v.toString());
         }
 
-        function onClear() {
-            inputValue.value = isNumberInput.value ? null : '';
-        }
-
         const {
             computedId,
             computedMessages,
@@ -177,7 +173,6 @@ export default defineComponent({
                 defaultRules: computed(() => [requiredCheck, maxCheck, minCheck]),
                 noDefaultRules,
                 state,
-                emitClear: true,
                 callbacks: {
                     onMounted: () => {
                         inputValue.value = convertValue(inputValue.value);
@@ -185,7 +180,9 @@ export default defineComponent({
                     onChange: () => {
                         inputValue.value = convertValue(inputValue.value);
                     },
-                    onClear,
+                    onClear: () => {
+                        inputValue.value = isNumberInput.value ? null : '';
+                    },
                 },
             },
         );

--- a/packages/vlossom/src/components/vs-input/VsInput.vue
+++ b/packages/vlossom/src/components/vs-input/VsInput.vue
@@ -102,7 +102,7 @@ export default defineComponent({
             default: () => ({}),
         },
     },
-    emits: ['update:modelValue', 'update:changed', 'update:valid', 'change', 'focus', 'blur'],
+    emits: ['update:modelValue', 'update:changed', 'update:valid', 'change', 'focus', 'blur', 'clear'],
     // expose: ['focus', 'blur', 'validate', 'clear', 'select'],
     setup(props, { emit }) {
         const {
@@ -185,6 +185,7 @@ export default defineComponent({
                         inputValue.value = convertValue(inputValue.value);
                     },
                     onClear,
+                    getClearPayload: (oldValue) => oldValue,
                 },
             },
         );
@@ -232,7 +233,7 @@ export default defineComponent({
         }
 
         function clearWithFocus() {
-            onClear();
+            clear();
             focus();
         }
 

--- a/packages/vlossom/src/components/vs-input/__tests__/vs-input.test.ts
+++ b/packages/vlossom/src/components/vs-input/__tests__/vs-input.test.ts
@@ -298,6 +298,7 @@ describe('VsInput', () => {
 
             // then
             expect(wrapper.vm.inputValue).toBe('');
+            expect(wrapper.emitted('clear')?.[0]).toEqual(['test value']);
         });
     });
 

--- a/packages/vlossom/src/components/vs-radio/README.ko.md
+++ b/packages/vlossom/src/components/vs-radio/README.ko.md
@@ -184,6 +184,7 @@ interface VsRadioSetStyleSet extends CSSProperties {
 | `toggle`            | `boolean`                 | 라디오가 토글될 때 발생            |
 | `focus`             | `FocusEvent`              | 라디오가 포커스를 받을 때 발생     |
 | `blur`              | `FocusEvent`              | 라디오가 포커스를 잃을 때 발생     |
+| `clear`             | `any`                     | 값이 초기화될 때 초기화 직전 값과 함께 발생 |
 
 ### VsRadioSet
 
@@ -195,6 +196,7 @@ interface VsRadioSetStyleSet extends CSSProperties {
 | `change`            | `any`                     | 선택이 변경될 때 발생              |
 | `focus`             | `(option: any, event: FocusEvent)` | 라디오가 포커스를 받을 때 발생 |
 | `blur`              | `(option: any, event: FocusEvent)` | 라디오가 포커스를 잃을 때 발생 |
+| `clear`             | `any`                     | 값이 초기화될 때 초기화 직전 값과 함께 발생 |
 
 ## Slots
 

--- a/packages/vlossom/src/components/vs-radio/README.md
+++ b/packages/vlossom/src/components/vs-radio/README.md
@@ -184,6 +184,7 @@ interface VsRadioSetStyleSet extends CSSProperties {
 | `toggle`            | `boolean`                 | Emitted when the radio is toggled        |
 | `focus`             | `FocusEvent`              | Emitted when the radio receives focus    |
 | `blur`              | `FocusEvent`              | Emitted when the radio loses focus       |
+| `clear`             | `any`                     | Emitted with the previous value when the value is cleared |
 
 ### VsRadioSet
 
@@ -195,6 +196,7 @@ interface VsRadioSetStyleSet extends CSSProperties {
 | `change`            | `any`                     | Emitted when the selection changes       |
 | `focus`             | `(option: any, event: FocusEvent)` | Emitted when a radio receives focus |
 | `blur`              | `(option: any, event: FocusEvent)` | Emitted when a radio loses focus   |
+| `clear`             | `any`                     | Emitted with the previous value when the value is cleared |
 
 ## Slots
 

--- a/packages/vlossom/src/components/vs-radio/VsRadio.vue
+++ b/packages/vlossom/src/components/vs-radio/VsRadio.vue
@@ -75,7 +75,7 @@ export default defineComponent({
         // v-model
         modelValue: { type: null, default: null },
     },
-    emits: ['update:modelValue', 'update:changed', 'update:valid', 'change', 'toggle', 'focus', 'blur'],
+    emits: ['update:modelValue', 'update:changed', 'update:valid', 'change', 'toggle', 'focus', 'blur', 'clear'],
     // expose: ['clear', 'validate', 'focus', 'blur'],
     setup(props, { emit }) {
         const {

--- a/packages/vlossom/src/components/vs-radio/VsRadioSet.vue
+++ b/packages/vlossom/src/components/vs-radio/VsRadioSet.vue
@@ -85,7 +85,7 @@ export default defineComponent({
         // v-model
         modelValue: { type: null, default: null },
     },
-    emits: ['update:modelValue', 'update:changed', 'update:valid', 'change', 'focus', 'blur'],
+    emits: ['update:modelValue', 'update:changed', 'update:valid', 'change', 'focus', 'blur', 'clear'],
     // expose: ['focus', 'blur', 'validate', 'clear'],
     setup(props, { emit }) {
         const {

--- a/packages/vlossom/src/components/vs-radio/__tests__/vs-radio-set.test.ts
+++ b/packages/vlossom/src/components/vs-radio/__tests__/vs-radio-set.test.ts
@@ -227,6 +227,7 @@ describe('VsRadioSet', () => {
 
             // then
             expect(wrapper.props('modelValue')).toBe(null);
+            expect(wrapper.emitted('clear')?.[0]).toEqual(['A']);
         });
     });
 });

--- a/packages/vlossom/src/components/vs-radio/__tests__/vs-radio.test.ts
+++ b/packages/vlossom/src/components/vs-radio/__tests__/vs-radio.test.ts
@@ -83,6 +83,7 @@ describe('vs-radio', () => {
             expect(wrapper.props('modelValue')).toBe(null);
             expect(wrapper.vm.isChecked).toBe(false);
             expect(wrapper.find('input').element.checked).toBe(false);
+            expect(wrapper.emitted('clear')?.[0]).toEqual(['test']);
         });
     });
 

--- a/packages/vlossom/src/components/vs-select/README.ko.md
+++ b/packages/vlossom/src/components/vs-select/README.ko.md
@@ -157,7 +157,7 @@ interface VsSelectStyleSet extends CSSProperties {
 | `click-option`      | `OptionItem`  | 옵션이 클릭될 때 발생                      |
 | `open`              | -             | 드롭다운이 열릴 때 발생                    |
 | `close`             | -             | 드롭다운이 닫힐 때 발생                    |
-| `clear`             | -             | 선택 값이 초기화될 때 발생                 |
+| `clear`             | `any`         | 선택 값이 초기화될 때 초기화 직전 값과 함께 발생 |
 
 ## Slots
 

--- a/packages/vlossom/src/components/vs-select/README.md
+++ b/packages/vlossom/src/components/vs-select/README.md
@@ -157,7 +157,7 @@ interface VsSelectStyleSet extends CSSProperties {
 | `click-option`      | `OptionItem`  | Emitted when an option is clicked                |
 | `open`              | -             | Emitted when the dropdown opens                  |
 | `close`             | -             | Emitted when the dropdown closes                 |
-| `clear`             | -             | Emitted when the selected value is cleared       |
+| `clear`             | `any`         | Emitted with the previously selected value when the value is cleared |
 
 ## Slots
 

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -267,7 +267,6 @@ export default defineComponent({
         function onClear() {
             clearSelected();
             searchInputRef.value?.clear();
-            emit('clear');
         }
 
         const optionsListElement = computed(() => optionsListRef.value?.$el as HTMLElement);
@@ -321,6 +320,7 @@ export default defineComponent({
                         inputValue.value = convertValue(inputValue.value);
                     },
                     onClear,
+                    getClearPayload: (oldValue) => oldValue,
                 },
             },
         );

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -312,6 +312,7 @@ export default defineComponent({
                 }),
                 noDefaultRules,
                 state,
+                emitClear: true,
                 callbacks: {
                     onMounted: () => {
                         inputValue.value = convertValue(inputValue.value);
@@ -320,7 +321,6 @@ export default defineComponent({
                         inputValue.value = convertValue(inputValue.value);
                     },
                     onClear,
-                    getClearPayload: (oldValue) => oldValue,
                 },
             },
         );

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -264,11 +264,6 @@ export default defineComponent({
 
         const { isUsingSearch, searchProps } = useSelectSearch(search);
 
-        function onClear() {
-            clearSelected();
-            searchInputRef.value?.clear();
-        }
-
         const optionsListElement = computed(() => optionsListRef.value?.$el as HTMLElement);
 
         const {
@@ -312,7 +307,6 @@ export default defineComponent({
                 }),
                 noDefaultRules,
                 state,
-                emitClear: true,
                 callbacks: {
                     onMounted: () => {
                         inputValue.value = convertValue(inputValue.value);
@@ -320,7 +314,10 @@ export default defineComponent({
                     onChange: () => {
                         inputValue.value = convertValue(inputValue.value);
                     },
-                    onClear,
+                    onClear: () => {
+                        clearSelected();
+                        searchInputRef.value?.clear();
+                    },
                 },
             },
         );

--- a/packages/vlossom/src/components/vs-select/__tests__/vs-select.test.ts
+++ b/packages/vlossom/src/components/vs-select/__tests__/vs-select.test.ts
@@ -724,7 +724,7 @@ describe('VsSelect', () => {
             await nextTick();
 
             // then
-            expect(wrapper.emitted('clear')).toBeTruthy();
+            expect(wrapper.emitted('clear')?.[0]).toEqual(['Apple']);
         });
     });
 

--- a/packages/vlossom/src/components/vs-switch/README.ko.md
+++ b/packages/vlossom/src/components/vs-switch/README.ko.md
@@ -134,6 +134,7 @@ interface VsSwitchStyleSet extends CSSProperties {
 | `change` | `any` | 값 변경 시 발생 |
 | `focus` | `FocusEvent` | 포커스 시 발생 |
 | `blur` | `FocusEvent` | 포커스 해제 시 발생 |
+| `clear` | `any` | 값이 초기화될 때 초기화 직전 값과 함께 발생 |
 
 ## 슬롯
 

--- a/packages/vlossom/src/components/vs-switch/README.md
+++ b/packages/vlossom/src/components/vs-switch/README.md
@@ -134,6 +134,7 @@ interface VsSwitchStyleSet extends CSSProperties {
 | `change` | `any` | Emitted on value change |
 | `focus` | `FocusEvent` | Emitted on focus |
 | `blur` | `FocusEvent` | Emitted on blur |
+| `clear` | `any` | Emitted with the previous value when the value is cleared |
 
 ## Slots
 

--- a/packages/vlossom/src/components/vs-switch/VsSwitch.vue
+++ b/packages/vlossom/src/components/vs-switch/VsSwitch.vue
@@ -96,7 +96,7 @@ export default defineComponent({
         // v-model
         modelValue: { type: null, default: false },
     },
-    emits: ['update:modelValue', 'update:changed', 'update:valid', 'change', 'focus', 'blur'],
+    emits: ['update:modelValue', 'update:changed', 'update:valid', 'change', 'focus', 'blur', 'clear'],
     // expose: ['focus', 'blur', 'validate', 'clear'],
     setup(props, { emit }) {
         const {

--- a/packages/vlossom/src/components/vs-switch/__tests__/vs-switch.test.ts
+++ b/packages/vlossom/src/components/vs-switch/__tests__/vs-switch.test.ts
@@ -348,6 +348,7 @@ describe('VsSwitch', () => {
                 // then
                 expect(wrapper.vm.isChecked).toBe(false);
                 expect(wrapper.props('modelValue')).toEqual([]);
+                expect(wrapper.emitted('clear')?.[0]).toEqual([['A', 'B']]);
             });
         });
 
@@ -368,6 +369,7 @@ describe('VsSwitch', () => {
                 // then
                 expect(wrapper.vm.isChecked).toBe(false);
                 expect(wrapper.props('modelValue')).toBe(false);
+                expect(wrapper.emitted('clear')?.[0]).toEqual([true]);
             });
         });
     });

--- a/packages/vlossom/src/components/vs-textarea/README.ko.md
+++ b/packages/vlossom/src/components/vs-textarea/README.ko.md
@@ -121,6 +121,7 @@ interface VsTextareaStyleSet {
 | `change` | `string` | 값 변경 시 발생 |
 | `focus` | `FocusEvent` | 포커스 시 발생 |
 | `blur` | `FocusEvent` | 포커스 해제 시 발생 |
+| `clear` | `string` | 값이 초기화될 때 초기화 직전 값과 함께 발생 |
 
 ## 슬롯
 

--- a/packages/vlossom/src/components/vs-textarea/README.md
+++ b/packages/vlossom/src/components/vs-textarea/README.md
@@ -121,6 +121,7 @@ interface VsTextareaStyleSet {
 | `change` | `string` | Emitted on value change |
 | `focus` | `FocusEvent` | Emitted on focus |
 | `blur` | `FocusEvent` | Emitted on blur |
+| `clear` | `string` | Emitted with the previous value when the value is cleared |
 
 ## Slots
 

--- a/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
+++ b/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
@@ -73,7 +73,7 @@ export default defineComponent({
             default: () => ({}),
         },
     },
-    emits: ['update:modelValue', 'update:changed', 'update:valid', 'change', 'focus', 'blur'],
+    emits: ['update:modelValue', 'update:changed', 'update:valid', 'change', 'focus', 'blur', 'clear'],
     // expose: ['focus', 'blur', 'validate', 'clear', 'select'],
     setup(props, { emit }) {
         const {
@@ -140,6 +140,9 @@ export default defineComponent({
                     },
                     onChange: () => {
                         inputValue.value = convertValue(inputValue.value);
+                    },
+                    onClear: () => {
+                        inputValue.value = '';
                     },
                 },
             },

--- a/packages/vlossom/src/components/vs-textarea/__tests__/vs-textarea.test.ts
+++ b/packages/vlossom/src/components/vs-textarea/__tests__/vs-textarea.test.ts
@@ -717,4 +717,24 @@ describe('VsTextarea', () => {
             expect(typeof wrapper.vm.inputValue).toBe('string');
         });
     });
+
+    describe('clear', () => {
+        it('clear 함수를 호출하면 값을 초기화하고 clear 이벤트에 이전 값을 전달해야 한다', async () => {
+            // given
+            const wrapper = mount(VsTextarea, {
+                props: {
+                    modelValue: 'test value',
+                    'onUpdate:modelValue': (value) => wrapper.setProps({ modelValue: value }),
+                },
+            });
+
+            // when
+            wrapper.vm.clear();
+            await wrapper.vm.$nextTick();
+
+            // then
+            expect(wrapper.props('modelValue')).toBe('');
+            expect(wrapper.emitted('clear')?.[0]).toEqual(['test value']);
+        });
+    });
 });

--- a/packages/vlossom/src/composables/input/__tests__/input-composable.test.ts
+++ b/packages/vlossom/src/composables/input/__tests__/input-composable.test.ts
@@ -29,7 +29,6 @@ describe('useInput composable', () => {
                     id,
                     disabled,
                     readonly,
-                    emitClear: true,
                     callbacks: {
                         onMounted: onMountedSpy,
                         onChange: onChangeSpy,

--- a/packages/vlossom/src/composables/input/__tests__/input-composable.test.ts
+++ b/packages/vlossom/src/composables/input/__tests__/input-composable.test.ts
@@ -33,6 +33,7 @@ describe('useInput composable', () => {
                         onMounted: onMountedSpy,
                         onChange: onChangeSpy,
                         onClear: onClearSpy,
+                        getClearPayload: (oldValue) => oldValue,
                     },
                     messages,
                     rules,
@@ -616,6 +617,7 @@ describe('useInput composable', () => {
             expect(wrapper.vm.modelValue).toBe('');
             expect(inputValue.value).toBe('');
             expect(onClearSpy).toHaveBeenCalledTimes(1);
+            expect(wrapper.emitted('clear')?.[0]).toEqual(['test']);
         });
     });
 });

--- a/packages/vlossom/src/composables/input/__tests__/input-composable.test.ts
+++ b/packages/vlossom/src/composables/input/__tests__/input-composable.test.ts
@@ -29,11 +29,11 @@ describe('useInput composable', () => {
                     id,
                     disabled,
                     readonly,
+                    emitClear: true,
                     callbacks: {
                         onMounted: onMountedSpy,
                         onChange: onChangeSpy,
                         onClear: onClearSpy,
-                        getClearPayload: (oldValue) => oldValue,
                     },
                     messages,
                     rules,

--- a/packages/vlossom/src/composables/input/input-composable.ts
+++ b/packages/vlossom/src/composables/input/input-composable.ts
@@ -18,6 +18,7 @@ export function useInput<T = unknown>(ctx: any, inputParams: InputComponentParam
         defaultRules = ref([]),
         noDefaultRules = ref(false),
         state = ref('idle'),
+        emitClear = false,
         callbacks = {},
     } = inputParams;
 
@@ -133,13 +134,8 @@ export function useInput<T = unknown>(ctx: any, inputParams: InputComponentParam
             callbacks.onClear();
         }
 
-        if (callbacks.getClearPayload) {
-            const clearPayload = callbacks.getClearPayload(oldValue);
-            if (clearPayload === undefined) {
-                emit('clear');
-            } else {
-                emit('clear', clearPayload);
-            }
+        if (emitClear) {
+            emit('clear', oldValue);
         }
 
         nextTick(() => {

--- a/packages/vlossom/src/composables/input/input-composable.ts
+++ b/packages/vlossom/src/composables/input/input-composable.ts
@@ -127,8 +127,19 @@ export function useInput<T = unknown>(ctx: any, inputParams: InputComponentParam
     }
 
     function clear() {
+        const oldValue = inputValue.value;
+
         if (callbacks.onClear) {
             callbacks.onClear();
+        }
+
+        if (callbacks.getClearPayload) {
+            const clearPayload = callbacks.getClearPayload(oldValue);
+            if (clearPayload === undefined) {
+                emit('clear');
+            } else {
+                emit('clear', clearPayload);
+            }
         }
 
         nextTick(() => {

--- a/packages/vlossom/src/composables/input/input-composable.ts
+++ b/packages/vlossom/src/composables/input/input-composable.ts
@@ -18,7 +18,6 @@ export function useInput<T = unknown>(ctx: any, inputParams: InputComponentParam
         defaultRules = ref([]),
         noDefaultRules = ref(false),
         state = ref('idle'),
-        emitClear = false,
         callbacks = {},
     } = inputParams;
 
@@ -134,9 +133,7 @@ export function useInput<T = unknown>(ctx: any, inputParams: InputComponentParam
             callbacks.onClear();
         }
 
-        if (emitClear) {
-            emit('clear', oldValue);
-        }
+        emit('clear', oldValue);
 
         nextTick(() => {
             checkMessages();

--- a/packages/vlossom/src/declaration/types.ts
+++ b/packages/vlossom/src/declaration/types.ts
@@ -103,6 +103,7 @@ export interface InputComponentParams<T = unknown> {
         onMounted?: () => void;
         onChange?: (newValue: T, oldValue: T) => void;
         onClear?: () => void;
+        getClearPayload?: (oldValue: T) => unknown;
         onBeforeUnmount?: () => void;
         onUnmounted?: () => void;
     };

--- a/packages/vlossom/src/declaration/types.ts
+++ b/packages/vlossom/src/declaration/types.ts
@@ -98,12 +98,12 @@ export interface InputComponentParams<T = unknown> {
     defaultRules?: Ref<Rule<T>[]>;
     noDefaultRules?: Ref<boolean>;
     state?: Ref<UIState>;
+    emitClear?: boolean;
     callbacks?: {
         onBeforeMount?: () => void;
         onMounted?: () => void;
         onChange?: (newValue: T, oldValue: T) => void;
         onClear?: () => void;
-        getClearPayload?: (oldValue: T) => unknown;
         onBeforeUnmount?: () => void;
         onUnmounted?: () => void;
     };

--- a/packages/vlossom/src/declaration/types.ts
+++ b/packages/vlossom/src/declaration/types.ts
@@ -98,7 +98,6 @@ export interface InputComponentParams<T = unknown> {
     defaultRules?: Ref<Rule<T>[]>;
     noDefaultRules?: Ref<boolean>;
     state?: Ref<UIState>;
-    emitClear?: boolean;
     callbacks?: {
         onBeforeMount?: () => void;
         onMounted?: () => void;


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Refactor (refactor)
- [x] Test (test)
- [x] Update Docs (docs)

## Summary

입력 계열 컴포넌트의 `clear` 이벤트가 초기화 직전 값을 전달하도록 정리합니다.

## Description

- `useInput`의 clear 처리에 이전 값을 전달하는 `emitClear`을 추가합니다.
- `VsInput`, `VsDatePicker`, `VsSelect`, `VsFileDrop`의 clear 이벤트 emit을 `useInput` 기반으로 처리하도록 변경합니다.
- 각 입력 컴포넌트의 문서를 업데이트합니다.
- 입력 composable과 관련 컴포넌트 테스트를 업데이트합니다.

## Related Tickets & Documents

- Closes #549