### PR TITLE
fix(VsTable): fix column styles & fix vs-visible-render usage

### DIFF
--- a/packages/vlossom/src/components/vs-block/VsBlock.css
+++ b/packages/vlossom/src/components/vs-block/VsBlock.css
@@ -21,7 +21,7 @@
     }
 
     .vs-block-content {
-        @apply relative h-full w-full;
+        @apply relative w-full;
 
         padding: 0.8rem 1.2rem;
     }

--- a/packages/vlossom/src/components/vs-table/README.ko.md
+++ b/packages/vlossom/src/components/vs-table/README.ko.md
@@ -137,7 +137,9 @@ const selected = ref([]);
 interface VsTableStyleSet extends CSSProperties {
     $toolbar?: CSSProperties;
     $search?: VsSearchInputStyleSet;
+    $caption?: CSSProperties;
     $header?: CSSProperties;
+    $stickyHeaderTop?: string;
     $row?: CSSProperties & {
         $selected?: CSSProperties;
     };
@@ -181,6 +183,7 @@ interface VsTablePaginationOptions {
         :style-set="{
             borderRadius: '0.5rem', overflow: 'hidden',
             $header: { fontSize: '0.875rem', fontWeight: 700 },
+            $stickyHeaderTop: '60px',
             $row: {
                 height: '3rem',
                 $selected: { backgroundColor: '#e3f2fd' },
@@ -190,6 +193,8 @@ interface VsTablePaginationOptions {
     />
 </template>
 ```
+
+`$stickyHeaderTop`은 `stickyHeader`가 켜졌을 때 떠 있는 헤더의 `top` 오프셋입니다. 기본적으로 뷰포트 상단(`0`)에 붙으며, 앱 고정 헤더 아래로 내리고 싶을 때 값을 지정합니다(예: `'60px'`).
 
 ## 이벤트
 

--- a/packages/vlossom/src/components/vs-table/README.md
+++ b/packages/vlossom/src/components/vs-table/README.md
@@ -137,7 +137,9 @@ Provide an `empty` slot to replace the default "NO DATA" placeholder when `items
 interface VsTableStyleSet extends CSSProperties {
     $toolbar?: CSSProperties;
     $search?: VsSearchInputStyleSet;
+    $caption?: CSSProperties;
     $header?: CSSProperties;
+    $stickyHeaderTop?: string;
     $row?: CSSProperties & {
         $selected?: CSSProperties;
     };
@@ -181,6 +183,7 @@ interface VsTablePaginationOptions {
         :style-set="{
             borderRadius: '0.5rem', overflow: 'hidden',
             $header: { fontSize: '0.875rem', fontWeight: 700 },
+            $stickyHeaderTop: '60px',
             $row: {
                 height: '3rem',
                 $selected: { backgroundColor: '#e3f2fd' },
@@ -190,6 +193,8 @@ interface VsTablePaginationOptions {
     />
 </template>
 ```
+
+`$stickyHeaderTop` sets the `top` offset of the floating header shown while `stickyHeader` is enabled. It sticks to the top of the viewport (`0`) by default; set this to offset it below a fixed app header (e.g. `'60px'`).
 
 ## Events
 

--- a/packages/vlossom/src/components/vs-table/VsTable.css
+++ b/packages/vlossom/src/components/vs-table/VsTable.css
@@ -39,16 +39,25 @@
         @apply min-w-full overflow-x-auto;
     }
 
-    /* ── Table structure ── */
+    /* ── Table structure ──
+       table을 grid로, thead/tbody는 display:contents로 펼쳐서 모든 행을 같은 grid의 아이템으로 만든다.
+       각 행은 subgrid로 table이 정의한 컬럼 트랙을 공유하므로 행 간 컬럼 폭이 항상 일치한다.
+       트랙은 컨테이너 폭(definite)에 맞춰 계산된다. 내용이 좁으면 1fr이 남는 공간을 나눠 채워 꽉 차고,
+       내용이 넓으면 각 컬럼이 max-content를 유지한 채 넘쳐 가로 스크롤이 생긴다(행이 트랙 전체를 span). */
     .vs-table-table {
-        @apply mx-auto min-w-full;
-        border-collapse: separate;
-        border-spacing: 0;
+        @apply mx-auto grid min-w-full;
+    }
+
+    .vs-table-thead,
+    .vs-table-tbody {
+        display: contents;
     }
 
     .vs-table-header-row,
     .vs-table-body-row {
         @apply grid;
+        grid-template-columns: subgrid;
+        grid-column: 1 / -1;
     }
 
     .vs-table-thead > .vs-table-header-row {
@@ -64,10 +73,17 @@
         border-bottom: 1px solid var(--vs-cs-line);
         padding: calc(var(--vs-size-padding, var(--vs-padding-md)) * 0.5)
             calc(var(--vs-size-padding, var(--vs-padding-md)) * 0.8);
+
+        /* min-width: auto 무력화 */
+        min-width: 0;
         color: var(--vs-cs-font-colored);
         font-weight: var(--vs-font-weight);
         font-size: var(--vs-size-font, var(--vs-font-size-md));
         text-align: left;
+
+        /* width/minWidth/maxWidth로 폭을 제한한 컬럼에서 긴 토큰이 옆 칸으로 삐져나오지(bleeding) 않도록 줄바꿈.
+           기본(max-content) 컬럼은 트랙이 내용 폭을 확보하므로 줄바꿈되지 않는다. */
+        overflow-wrap: anywhere;
 
         &:first-child {
             border-left: 1px solid var(--vs-cs-line);
@@ -85,8 +101,12 @@
         grid-row: 1;
         padding: calc(var(--vs-size-padding, var(--vs-padding-md)) * 0.5)
             calc(var(--vs-size-padding, var(--vs-padding-md)) * 0.8);
+
+        /* min-width: auto 무력화 */
+        min-width: 0;
         font-size: var(--vs-size-font, var(--vs-font-size-md));
         text-align: left;
+        overflow-wrap: anywhere;
     }
 
     /* ── Body rows ── */
@@ -109,7 +129,7 @@
         }
 
         &.vs-selected {
-            background-color: var(--vs-cs-bg-comp-colored);
+            background-color: var(--vs-cs-bg-colored);
             color: var(--vs-cs-font);
         }
 
@@ -221,7 +241,8 @@
     }
 
     .vs-table-caption {
-        @apply caption-bottom;
+        grid-column: 1 / -1;
+        order: 1;
     }
 
     /* ── Modifiers ── */
@@ -248,7 +269,8 @@
         }
 
         .vs-table-table {
-            @apply min-w-full;
+            @apply block min-w-full;
+            width: auto;
         }
 
         .vs-table-draggable-wrapper,
@@ -258,6 +280,8 @@
         .vs-table-body-row,
         .vs-table-header-row {
             @apply block w-full border-x-0;
+            grid-template-columns: revert;
+            grid-column: revert;
         }
 
         .vs-table-thead {
@@ -272,6 +296,9 @@
         .vs-table-td {
             @apply grid gap-2 border-r-0 border-b border-l-0 border-dashed p-3;
             grid-column: minmax(6rem, 9rem) 1fr;
+
+            /* 구분선 색을 카드 외곽선과 동일하게 고정. (명시하지 않으면 currentColor를 따라 셀 텍스트색에 따라 달라진다) */
+            border-bottom-color: var(--vs-cs-line);
         }
 
         .vs-table-td:first-child {
@@ -282,13 +309,13 @@
             @apply border-b-0;
         }
 
-        .vs-table-td::before {
+        .vs-table-td[data-label]::before {
             @apply font-bold;
             content: attr(data-label);
         }
 
         .vs-table-td.vs-table-drag-handle {
-            @apply w-6 px-0 py-1;
+            @apply w-full px-2!;
         }
 
         .vs-table {
@@ -323,7 +350,7 @@
                 @apply border-b-0;
             }
 
-            .vs-table-td::before {
+            .vs-table-td[data-label]::before {
                 content: none;
             }
         }

--- a/packages/vlossom/src/components/vs-table/VsTable.css
+++ b/packages/vlossom/src/components/vs-table/VsTable.css
@@ -20,7 +20,7 @@
     }
 
     > .vs-table-sticky-wrapper {
-        @apply pointer-events-none sticky w-full overflow-hidden;
+        @apply pointer-events-none sticky top-0 w-full overflow-hidden;
         z-index: var(--vs-table-sticky-header-z-index);
         padding-bottom: 1rem;
 
@@ -37,6 +37,12 @@
 
     > .vs-table-content {
         @apply min-w-full overflow-x-auto;
+
+        /* sticky 헤더 노출 여부를 판단하기 위한 IntersectionObserver 관측용 마커.
+           콘텐츠 최상단(=헤더 상단)에 위치하며, 레이아웃에 영향을 주지 않도록 높이를 갖지 않는다. */
+        > .vs-table-header-sentinel {
+            height: 0;
+        }
     }
 
     /* ── Table structure ──

--- a/packages/vlossom/src/components/vs-table/VsTable.vue
+++ b/packages/vlossom/src/components/vs-table/VsTable.vue
@@ -38,7 +38,7 @@
 
         <div class="vs-table-content" ref="scrollWrapperRef">
             <div ref="headerSentinelRef" class="vs-table-header-sentinel" aria-hidden="true" />
-            <vs-visible-render :disabled="noVirtualScroll" root-margin="150px">
+            <vs-visible-render :selector="`#${bodyId}`" :disabled="noVirtualScroll" root-margin="150px">
                 <table ref="contentTableRef" class="vs-table-table" :style="tableColumnStyle">
                     <caption v-if="$slots['caption']" class="vs-table-caption" :style="componentStyleSet.$caption">
                         <slot name="caption" />
@@ -49,6 +49,7 @@
                         </template>
                     </vs-table-header>
                     <vs-table-body
+                        :id="bodyId"
                         @click-cell="clickCell"
                         @click-row="clickRow"
                         @select-row="selectRow"
@@ -286,6 +287,7 @@ export default defineComponent({
         const { componentStyleSet, componentInlineStyle } = useStyleSet<VsTableStyleSet>(componentName, styleSet);
 
         const tableId = stringUtil.createID();
+        const bodyId = computed(() => `${tableId}-body`);
         const hasExpandSlot = computed<boolean>(() => !!slots.expand);
         const table: TableComposable = useTable(
             tableId,
@@ -431,6 +433,7 @@ export default defineComponent({
 
         return {
             TABLE_DRAG_WRAPPER_CLASS,
+            bodyId,
             colorSchemeClass,
             computedColorScheme,
             componentStyleSet,

--- a/packages/vlossom/src/components/vs-table/VsTable.vue
+++ b/packages/vlossom/src/components/vs-table/VsTable.vue
@@ -27,7 +27,7 @@
             class="vs-table-sticky-wrapper"
             :style="{ top: stickyHeaderTop }"
         >
-            <table class="vs-table-table">
+            <table class="vs-table-table" :style="tableColumnStyle">
                 <vs-table-header class="vs-table-sticky-header" @click-cell="clickCell" @select-row="selectRow">
                     <template v-for="name in headerSlots" #[name]="slotData">
                         <slot :name v-bind="slotData || {}" />
@@ -42,7 +42,7 @@
                 :selector="`.${TABLE_DRAG_WRAPPER_CLASS}`"
                 root-margin="150px"
             >
-                <table class="vs-table-table">
+                <table class="vs-table-table" :style="tableColumnStyle">
                     <caption v-if="$slots['caption']" class="vs-table-caption">
                         <slot name="caption" />
                     </caption>
@@ -186,11 +186,7 @@ export default defineComponent({
                     return false;
                 }
                 if (totalItemCount < 0) {
-                    logUtil.propError(
-                        componentName,
-                        'serverMode',
-                        'totalItemCount must be greater than or equal to 0',
-                    );
+                    logUtil.propError(componentName, 'serverMode', 'totalItemCount must be greater than or equal to 0');
                     return false;
                 }
                 return true;
@@ -309,10 +305,11 @@ export default defineComponent({
         const { componentStyleSet, componentInlineStyle } = useStyleSet<VsTableStyleSet>(componentName, styleSet);
 
         const tableId = stringUtil.createID();
+        const hasExpandSlot = computed<boolean>(() => !!slots.expand);
         const table: TableComposable = useTable(
             tableId,
             props,
-            { searchInputRef },
+            { searchInputRef, hasExpandSlot },
             { updateSelectedItems, updatePage, updatePageSize, updatePagedItems, updateTotalItems, paginate },
         );
 
@@ -338,6 +335,7 @@ export default defineComponent({
             [sizeClass.value]: !!sizeClass.value,
         }));
         const searchOptions = computed<Exclude<SearchProps, boolean>>(() => table.search.value);
+        const tableColumnStyle = computed(() => ({ gridTemplateColumns: table.gridTemplateColumns.value }));
         const useStickyHeader = computed<boolean>(() => stickyHeader.value && isHeaderOutOfView.value);
 
         const { pause: pauseHeaderObserver } = useIntersectionObserver(
@@ -455,6 +453,7 @@ export default defineComponent({
             useStickyHeader,
             stickyHeaderTop,
             searchOptions,
+            tableColumnStyle,
             table,
             totalPages: table.totalPages,
             clickCell,

--- a/packages/vlossom/src/components/vs-table/VsTable.vue
+++ b/packages/vlossom/src/components/vs-table/VsTable.vue
@@ -25,7 +25,7 @@
             v-if="useStickyHeader"
             ref="stickyScrollRef"
             class="vs-table-sticky-wrapper"
-            :style="{ top: stickyHeaderTop }"
+            :style="{ top: componentStyleSet.$stickyHeaderTop }"
         >
             <table class="vs-table-table" :style="stickyTableColumnStyle">
                 <vs-table-header class="vs-table-sticky-header" @click-cell="clickCell" @select-row="selectRow">
@@ -37,17 +37,13 @@
         </div>
 
         <div class="vs-table-content" ref="scrollWrapperRef">
+            <div ref="headerSentinelRef" class="vs-table-header-sentinel" aria-hidden="true" />
             <vs-visible-render :disabled="noVirtualScroll" root-margin="150px">
                 <table ref="contentTableRef" class="vs-table-table" :style="tableColumnStyle">
-                    <caption v-if="$slots['caption']" class="vs-table-caption">
+                    <caption v-if="$slots['caption']" class="vs-table-caption" :style="componentStyleSet.$caption">
                         <slot name="caption" />
                     </caption>
-                    <vs-table-header
-                        ref="headerRef"
-                        class="vs-table-original-header"
-                        @click-cell="clickCell"
-                        @select-row="selectRow"
-                    >
+                    <vs-table-header class="vs-table-original-header" @click-cell="clickCell" @select-row="selectRow">
                         <template v-for="name in headerSlots" #[name]="slotData">
                             <slot :name v-bind="slotData || {}" />
                         </template>
@@ -85,25 +81,15 @@ import {
     onBeforeUnmount,
     watch,
     nextTick,
-    inject,
     type ComputedRef,
     type Ref,
 } from 'vue';
 import { useIntersectionObserver, useResizeObserver } from '@vueuse/core';
 import type { SortableEvent } from 'sortablejs';
-import {
-    LAYOUT_STORE_KEY,
-    type SearchProps,
-    type UIState,
-    VsComponent,
-    type PropsOf,
-    type ColorScheme,
-    type Size,
-} from '@/declaration';
+import { type SearchProps, type UIState, VsComponent, type PropsOf, type ColorScheme, type Size } from '@/declaration';
 import { logUtil, stringUtil } from '@/utils';
 import { getColorSchemeProps, getStyleSetProps, getSearchProps } from '@/props';
 import { useColorScheme, useSizeClass, useStyleSet } from '@/composables';
-import { LayoutStore } from '@/stores';
 
 import { TABLE_COMPOSABLE_TOKEN, useTable, type TableComposable } from './composables/table-composable';
 import {
@@ -290,14 +276,12 @@ export default defineComponent({
             toRefs(props);
 
         const searchInputRef = useTemplateRef<VsSearchInputRef>('searchInputRef');
-        const headerRef = useTemplateRef<HTMLTableSectionElement>('headerRef');
+        const headerSentinelRef = useTemplateRef<HTMLDivElement>('headerSentinelRef');
         const contentTableRef = useTemplateRef<HTMLTableElement>('contentTableRef');
         const scrollWrapperRef = useTemplateRef<HTMLDivElement>('scrollWrapperRef');
         const stickyScrollRef = useTemplateRef<HTMLDivElement>('stickyScrollRef');
 
         const isHeaderOutOfView = ref<boolean>(true);
-        const stickyHeaderTop = ref<string>('0px');
-        const { header: vsLayoutHeader } = inject(LAYOUT_STORE_KEY, LayoutStore.getDefaultLayoutStore());
         const { colorSchemeClass, computedColorScheme } = useColorScheme(componentName, colorScheme);
         const { componentStyleSet, componentInlineStyle } = useStyleSet<VsTableStyleSet>(componentName, styleSet);
 
@@ -349,19 +333,12 @@ export default defineComponent({
 
         useResizeObserver(contentTableRef, syncStickyColumns);
 
+        // thead(.vs-table-thead)는 display:contents라 박스가 없어 직접 관측할 수 없다.
+        // 콘텐츠 최상단(=헤더 상단)에 둔 sentinel을 관측해, 헤더가 화면 위로 벗어났는지를 판단한다.
         const { pause: pauseHeaderObserver } = useIntersectionObserver(
-            headerRef,
-            ([{ isIntersecting, boundingClientRect }]) => {
+            headerSentinelRef,
+            ([{ isIntersecting }]) => {
                 isHeaderOutOfView.value = !isIntersecting;
-                if (!isIntersecting) {
-                    const headerHeight = vsLayoutHeader.value.height;
-                    // sticky header has to be positioned at the bottom of the vs-header when the table is hidden by vs-header
-                    if (boundingClientRect.top < Number(headerHeight)) {
-                        stickyHeaderTop.value = stringUtil.toStringSize(headerHeight);
-                        return;
-                    }
-                    stickyHeaderTop.value = '0px';
-                }
             },
             // The '999999px' value for rootMargin ensures that the header visibility is considered partially hidden when an x-overflow occurs.
             { threshold: 0, rootMargin: '0px 999999px' },
@@ -459,14 +436,13 @@ export default defineComponent({
             componentStyleSet,
             componentInlineStyle,
             classObj,
-            headerRef,
+            headerSentinelRef,
             contentTableRef,
             scrollWrapperRef,
             stickyScrollRef,
             headerSlots,
             bodySlots,
             useStickyHeader,
-            stickyHeaderTop,
             searchOptions,
             tableColumnStyle,
             stickyTableColumnStyle,

--- a/packages/vlossom/src/components/vs-table/VsTable.vue
+++ b/packages/vlossom/src/components/vs-table/VsTable.vue
@@ -27,7 +27,7 @@
             class="vs-table-sticky-wrapper"
             :style="{ top: stickyHeaderTop }"
         >
-            <table class="vs-table-table" :style="tableColumnStyle">
+            <table class="vs-table-table" :style="stickyTableColumnStyle">
                 <vs-table-header class="vs-table-sticky-header" @click-cell="clickCell" @select-row="selectRow">
                     <template v-for="name in headerSlots" #[name]="slotData">
                         <slot :name v-bind="slotData || {}" />
@@ -37,12 +37,8 @@
         </div>
 
         <div class="vs-table-content" ref="scrollWrapperRef">
-            <vs-visible-render
-                :disabled="noVirtualScroll"
-                :selector="`.${TABLE_DRAG_WRAPPER_CLASS}`"
-                root-margin="150px"
-            >
-                <table class="vs-table-table" :style="tableColumnStyle">
+            <vs-visible-render :disabled="noVirtualScroll" root-margin="150px">
+                <table ref="contentTableRef" class="vs-table-table" :style="tableColumnStyle">
                     <caption v-if="$slots['caption']" class="vs-table-caption">
                         <slot name="caption" />
                     </caption>
@@ -93,7 +89,7 @@ import {
     type ComputedRef,
     type Ref,
 } from 'vue';
-import { useIntersectionObserver } from '@vueuse/core';
+import { useIntersectionObserver, useResizeObserver } from '@vueuse/core';
 import type { SortableEvent } from 'sortablejs';
 import {
     LAYOUT_STORE_KEY,
@@ -295,6 +291,7 @@ export default defineComponent({
 
         const searchInputRef = useTemplateRef<VsSearchInputRef>('searchInputRef');
         const headerRef = useTemplateRef<HTMLTableSectionElement>('headerRef');
+        const contentTableRef = useTemplateRef<HTMLTableElement>('contentTableRef');
         const scrollWrapperRef = useTemplateRef<HTMLDivElement>('scrollWrapperRef');
         const stickyScrollRef = useTemplateRef<HTMLDivElement>('stickyScrollRef');
 
@@ -337,6 +334,20 @@ export default defineComponent({
         const searchOptions = computed<Exclude<SearchProps, boolean>>(() => table.search.value);
         const tableColumnStyle = computed(() => ({ gridTemplateColumns: table.gridTemplateColumns.value }));
         const useStickyHeader = computed<boolean>(() => stickyHeader.value && isHeaderOutOfView.value);
+
+        // sticky 헤더는 복제본이라 column의 폭이 실제 table과 달라져서 일치 시키는 작업이 필요
+        const stickyColumnTracks = ref<string>('');
+        const stickyTableColumnStyle = computed(() => ({
+            gridTemplateColumns: stickyColumnTracks.value || table.gridTemplateColumns.value,
+        }));
+
+        function syncStickyColumns() {
+            if (contentTableRef.value) {
+                stickyColumnTracks.value = getComputedStyle(contentTableRef.value).gridTemplateColumns;
+            }
+        }
+
+        useResizeObserver(contentTableRef, syncStickyColumns);
 
         const { pause: pauseHeaderObserver } = useIntersectionObserver(
             headerRef,
@@ -417,7 +428,10 @@ export default defineComponent({
 
         watch(useStickyHeader, (visible) => {
             if (visible) {
-                nextTick(syncStickyScroll);
+                nextTick(() => {
+                    syncStickyColumns();
+                    syncStickyScroll();
+                });
             }
         });
 
@@ -446,6 +460,7 @@ export default defineComponent({
             componentInlineStyle,
             classObj,
             headerRef,
+            contentTableRef,
             scrollWrapperRef,
             stickyScrollRef,
             headerSlots,
@@ -454,6 +469,7 @@ export default defineComponent({
             stickyHeaderTop,
             searchOptions,
             tableColumnStyle,
+            stickyTableColumnStyle,
             table,
             totalPages: table.totalPages,
             clickCell,

--- a/packages/vlossom/src/components/vs-table/VsTableBody.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableBody.vue
@@ -3,6 +3,7 @@
         tag="tbody"
         v-model="displayedBodyCells"
         v-bind="DEFAULT_SORTABLE_OPTIONS"
+        :id
         :class="[TABLE_DRAG_WRAPPER_CLASS, 'vs-table-body']"
         :item-key="getRowId"
         :disabled="loading"
@@ -64,6 +65,9 @@ export default defineComponent({
         VsTableBodyRow,
         BanIcon,
         draggable,
+    },
+    props: {
+        id: { type: String, default: '' },
     },
     emits: ['click-cell', 'click-row', 'select-row', 'expand-row', 'drag'],
     setup(props, { slots, emit }) {

--- a/packages/vlossom/src/components/vs-table/VsTableBodyRow.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableBodyRow.vue
@@ -43,7 +43,7 @@
 
 <script lang="ts">
 import { defineComponent, inject, computed, type ComputedRef, type PropType, toRefs, type CSSProperties } from 'vue';
-import { objectUtil, stringUtil } from '@/utils';
+import { objectUtil } from '@/utils';
 import { useStateClass } from '@/composables';
 import type { ColorScheme, UIState } from '@/declaration';
 import {
@@ -51,7 +51,6 @@ import {
     TABLE_STYLE_SET_TOKEN,
     type VsTableBodyCell,
     type VsTableStyleSet,
-    type VsTableColumnDef,
 } from './types';
 import { TABLE_COMPOSABLE_TOKEN, type TableComposable } from './composables/table-composable';
 import { getRowItem } from './models/table-model';
@@ -86,7 +85,6 @@ export default defineComponent({
         const {
             anyExpandable,
             anySelectable,
-            draggable,
             headerCells,
             loading,
             selectedItems,
@@ -116,51 +114,10 @@ export default defineComponent({
         }));
 
         const cellStyle = computed<CSSProperties | undefined>(() => tableStyleSet?.value?.$cell);
-        const gridStyle = computed<CSSProperties | undefined>(() => {
-            const cols: string[] = [];
-            if (draggable?.value) {
-                cols.push('auto');
-            }
-            if (anySelectable.value) {
-                cols.push('auto');
-            }
-            props.cells.forEach((_, index) => {
-                cols.push(getGridColumnWidth(columns.value?.[index]));
-            });
-            if (anyExpandable.value) {
-                cols.push('auto');
-            }
-            return {
-                gridTemplateColumns: cols.join(' '),
-            };
-        });
         const rowStyle = computed<CSSProperties | undefined>(() => {
             const { $selected = {}, ...baseRow } = tableStyleSet?.value?.$row ?? {};
-            const statedRowStyle = isSelected.value ? objectUtil.assign(baseRow, $selected) : baseRow;
-            return objectUtil.assign(statedRowStyle, gridStyle.value ?? {});
+            return isSelected.value ? objectUtil.assign(baseRow, $selected) : baseRow;
         });
-
-        function getGridColumnWidth(column?: VsTableColumnDef): string {
-            if (!column) {
-                return '1fr';
-            }
-            const { width, minWidth, maxWidth } = column;
-            if (width) {
-                return stringUtil.toStringSize(width);
-            }
-            const min = minWidth ? stringUtil.toStringSize(minWidth) : null;
-            const max = maxWidth ? stringUtil.toStringSize(maxWidth) : null;
-            if (min && max) {
-                return `minmax(${min}, ${max})`;
-            }
-            if (min) {
-                return `minmax(${min}, 1fr)`;
-            }
-            if (max) {
-                return `minmax(auto, ${max})`;
-            }
-            return '1fr';
-        }
 
         function getCellStyle(index: number): CSSProperties {
             const { align, verticalAlign } = columns.value?.[index] ?? {};
@@ -225,7 +182,6 @@ export default defineComponent({
         return {
             anyExpandable,
             colorScheme,
-            draggable,
             loading,
             classObj,
             rowStyle,

--- a/packages/vlossom/src/components/vs-table/VsTableExpandedPanel.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableExpandedPanel.vue
@@ -1,5 +1,5 @@
 <template>
-    <vs-expandable :open="isExpanded(cells)" :size="size ?? 'md'" :style-set="expandableStyleSet">
+    <vs-expandable :open="isExpanded(cells)" :size :style-set="expandableStyleSet">
         <slot name="expand" :item="getRowItem(cells)" :value="isExpanded(cells)" :rowIdx />
     </vs-expandable>
 </template>

--- a/packages/vlossom/src/components/vs-table/VsTableHeader.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableHeader.vue
@@ -42,13 +42,12 @@
 
 <script lang="ts">
 import { defineComponent, inject, computed, type Component, type ComputedRef, type CSSProperties } from 'vue';
-import { objectUtil, stringUtil } from '@/utils';
+import { objectUtil } from '@/utils';
 import {
     VsTableSortType,
     TABLE_STYLE_SET_TOKEN,
     type VsTableHeaderCell,
     type VsTableStyleSet,
-    type VsTableColumnDef,
 } from './types';
 import { HEADER_ROW_INDEX } from './models/strategy';
 import { TABLE_COMPOSABLE_TOKEN, type TableComposable } from './composables/table-composable';
@@ -66,57 +65,16 @@ export default defineComponent({
     },
     emits: ['click-cell', 'select-row'],
     setup(props, { slots, emit }) {
-        const { headerCells, columns, anyExpandable, anySelectable, draggable, sortType, sortColumn, updateSortType } =
+        const { headerCells, columns, anyExpandable, sortType, sortColumn, updateSortType } =
             inject<TableComposable>(TABLE_COMPOSABLE_TOKEN)!;
         const tableStyleSet = inject<ComputedRef<VsTableStyleSet>>(TABLE_STYLE_SET_TOKEN);
 
         const showExpand = computed(() => anyExpandable.value && !!slots.expand);
         const cellStyle = computed<CSSProperties | undefined>(() => tableStyleSet?.value?.$cell);
-        const gridStyle = computed<CSSProperties | undefined>(() => {
-            const cols: string[] = [];
-            if (draggable?.value) {
-                cols.push('auto');
-            }
-            if (anySelectable.value) {
-                cols.push('auto');
-            }
-            headerCells.value.forEach((_, index) => {
-                cols.push(getGridColumnWidth(columns.value?.[index]));
-            });
-            if (anyExpandable.value) {
-                cols.push('auto');
-            }
-            return {
-                gridTemplateColumns: cols.join(' '),
-            };
-        });
         const headerStyle = computed<CSSProperties | undefined>(() => {
             const { $selected, ...baseRow } = tableStyleSet?.value?.$row ?? {};
-            const baseRowStyle = objectUtil.assign(baseRow, tableStyleSet?.value?.$header ?? {});
-            return objectUtil.assign(baseRowStyle, gridStyle.value ?? {});
+            return objectUtil.assign(baseRow, tableStyleSet?.value?.$header ?? {});
         });
-
-        function getGridColumnWidth(column?: VsTableColumnDef): string {
-            if (!column) {
-                return '1fr';
-            }
-            const { width, minWidth, maxWidth } = column;
-            if (width) {
-                return stringUtil.toStringSize(width);
-            }
-            const min = minWidth ? stringUtil.toStringSize(minWidth) : null;
-            const max = maxWidth ? stringUtil.toStringSize(maxWidth) : null;
-            if (min && max) {
-                return `minmax(${min}, ${max})`;
-            }
-            if (min) {
-                return `minmax(${min}, 1fr)`;
-            }
-            if (max) {
-                return `minmax(auto, ${max})`;
-            }
-            return '1fr';
-        }
 
         function getCellStyle(index: number): CSSProperties {
             const align = columns.value?.[index]?.headerAlign;

--- a/packages/vlossom/src/components/vs-table/__tests__/table-composable.test.ts
+++ b/packages/vlossom/src/components/vs-table/__tests__/table-composable.test.ts
@@ -25,11 +25,12 @@ function setupUseTable(
         pageSize?: number;
         serverMode?: boolean;
     },
-    options?: { searchInputRef?: Ref<VsSearchInputRef | null> },
+    options?: { searchInputRef?: Ref<VsSearchInputRef | null>; hasExpandSlot?: Ref<boolean> },
 ) {
     const reactiveProps = reactive(props);
     const searchInputRef = options?.searchInputRef ?? ref<VsSearchInputRef | null>(null);
-    const table = useTable('test-table-id', reactiveProps as any, { searchInputRef } as any);
+    const hasExpandSlot = options?.hasExpandSlot ?? ref(false);
+    const table = useTable('test-table-id', reactiveProps as any, { searchInputRef, hasExpandSlot } as any);
     table.initialize();
     return { table, reactiveProps, searchInputRef };
 }

--- a/packages/vlossom/src/components/vs-table/__tests__/vs-table.test.ts
+++ b/packages/vlossom/src/components/vs-table/__tests__/vs-table.test.ts
@@ -82,6 +82,19 @@ describe('VsTable', () => {
             expect(wrapper.find('caption').text()).toBe('사용자 목록');
         });
 
+        it('styleSet의 $caption을 caption 요소에 적용한다', async () => {
+            const wrapper = mountTable({
+                props: { styleSet: { $caption: { color: 'rgb(255, 0, 0)' } } },
+                slots: {
+                    caption: '<span>사용자 목록</span>',
+                },
+            });
+
+            await nextTick();
+
+            expect(wrapper.find('caption').attributes('style')).toContain('color: rgb(255, 0, 0)');
+        });
+
         it('컬럼 정의와 아이템을 기반으로 헤더와 바디 셀을 렌더링한다', async () => {
             const wrapper = mountTable({
                 props: { columns: labeledColumns },
@@ -1124,6 +1137,96 @@ describe('VsTable', () => {
 
             const style = wrapper.find('.vs-table-table').attributes('style') ?? '';
             expect(style).toContain('minmax(max-content, 1fr) minmax(max-content, 1fr) auto');
+        });
+    });
+
+    describe('sticky header', () => {
+        // thead(.vs-table-thead)는 display:contents라 박스가 없어 직접 관측할 수 없다.
+        // 박스를 갖는 sentinel 마커를 관측 대상으로 삼는지 회귀로 고정한다.
+        it('display:contents인 thead가 아니라 박스가 있는 sentinel(.vs-table-header-sentinel)을 관측한다', async () => {
+            const observed: Element[] = [];
+            const callbacks: IntersectionObserverCallback[] = [];
+            const original = globalThis.IntersectionObserver;
+            class MockIntersectionObserver {
+                constructor(callback: IntersectionObserverCallback) {
+                    callbacks.push(callback);
+                }
+                observe(el: Element) {
+                    observed.push(el);
+                }
+                unobserve() {}
+                disconnect() {}
+                takeRecords() {
+                    return [];
+                }
+            }
+            globalThis.IntersectionObserver = MockIntersectionObserver as unknown as typeof IntersectionObserver;
+
+            try {
+                const wrapper = mountTable({ props: { stickyHeader: true } });
+                await nextTick();
+                await nextTick();
+
+                const target = observed[observed.length - 1] as HTMLElement | undefined;
+                expect(target).toBeTruthy();
+                expect(target?.classList.contains('vs-table-header-sentinel')).toBe(true);
+                expect(target?.tagName).not.toBe('THEAD');
+
+                wrapper.unmount();
+            } finally {
+                globalThis.IntersectionObserver = original;
+            }
+        });
+
+        it('원본 헤더가 화면에 보이면 sticky 복제 헤더를 렌더링하지 않고, 벗어나면 렌더링한다', async () => {
+            const callbacks: IntersectionObserverCallback[] = [];
+            const original = globalThis.IntersectionObserver;
+            class MockIntersectionObserver {
+                constructor(callback: IntersectionObserverCallback) {
+                    callbacks.push(callback);
+                }
+                observe() {}
+                unobserve() {}
+                disconnect() {}
+                takeRecords() {
+                    return [];
+                }
+            }
+            globalThis.IntersectionObserver = MockIntersectionObserver as unknown as typeof IntersectionObserver;
+
+            try {
+                const wrapper = mountTable({ props: { stickyHeader: true } });
+                await nextTick();
+                await nextTick();
+
+                const fire = (isIntersecting: boolean) => {
+                    const callback = callbacks[callbacks.length - 1];
+                    const entries = [{ isIntersecting }] as unknown as IntersectionObserverEntry[];
+                    callback?.(entries, {} as IntersectionObserver);
+                };
+
+                fire(true);
+                await nextTick();
+                expect(wrapper.find('.vs-table-sticky-header').exists()).toBe(false);
+
+                fire(false);
+                await nextTick();
+                expect(wrapper.find('.vs-table-sticky-header').exists()).toBe(true);
+
+                wrapper.unmount();
+            } finally {
+                globalThis.IntersectionObserver = original;
+            }
+        });
+
+        it('styleSet의 $stickyHeaderTop을 sticky wrapper의 top 오프셋으로 적용한다', async () => {
+            const wrapper = mountTable({ props: { stickyHeader: true, styleSet: { $stickyHeaderTop: '60px' } } });
+            await nextTick();
+
+            // 마운트 직후 isHeaderOutOfView 기본값(true)으로 sticky wrapper가 렌더된다.
+            expect(wrapper.find('.vs-table-sticky-wrapper').attributes('style')).toContain('top: 60px');
+
+            wrapper.unmount();
         });
     });
 

--- a/packages/vlossom/src/components/vs-table/__tests__/vs-table.test.ts
+++ b/packages/vlossom/src/components/vs-table/__tests__/vs-table.test.ts
@@ -997,10 +997,10 @@ describe('VsTable', () => {
 
             await nextTick();
 
-            const headerRow = wrapper.find('thead tr');
-            const style = headerRow.attributes('style') ?? '';
+            const table = wrapper.find('.vs-table-table');
+            const style = table.attributes('style') ?? '';
             expect(style).toContain('200px');
-            expect(style).toContain('1fr');
+            expect(style).toContain('minmax(max-content, 1fr)');
         });
 
         it('minWidth만 정의된 컬럼은 minmax(min, 1fr)로 반영된다', async () => {
@@ -1015,8 +1015,8 @@ describe('VsTable', () => {
 
             await nextTick();
 
-            const headerRow = wrapper.find('thead tr');
-            const style = headerRow.attributes('style') ?? '';
+            const table = wrapper.find('.vs-table-table');
+            const style = table.attributes('style') ?? '';
             expect(style).toContain('minmax(150px, 1fr)');
         });
 
@@ -1032,8 +1032,8 @@ describe('VsTable', () => {
 
             await nextTick();
 
-            const headerRow = wrapper.find('thead tr');
-            const style = headerRow.attributes('style') ?? '';
+            const table = wrapper.find('.vs-table-table');
+            const style = table.attributes('style') ?? '';
             expect(style).toContain('minmax(auto, 300px)');
         });
 
@@ -1049,8 +1049,8 @@ describe('VsTable', () => {
 
             await nextTick();
 
-            const headerRow = wrapper.find('thead tr');
-            const style = headerRow.attributes('style') ?? '';
+            const table = wrapper.find('.vs-table-table');
+            const style = table.attributes('style') ?? '';
             expect(style).toContain('minmax(100px, 400px)');
         });
 
@@ -1066,12 +1066,12 @@ describe('VsTable', () => {
 
             await nextTick();
 
-            const headerRow = wrapper.find('thead tr');
-            const style = headerRow.attributes('style') ?? '';
+            const table = wrapper.find('.vs-table-table');
+            const style = table.attributes('style') ?? '';
             expect(style).toContain('250px');
         });
 
-        it('width/minWidth/maxWidth가 없는 컬럼은 기본값 1fr로 반영된다', async () => {
+        it('width/minWidth/maxWidth가 없는 컬럼은 기본값 minmax(max-content, 1fr)로 반영된다', async () => {
             const wrapper = mountTable({
                 props: {
                     columns: [
@@ -1083,9 +1083,47 @@ describe('VsTable', () => {
 
             await nextTick();
 
-            const headerRow = wrapper.find('thead tr');
-            const style = headerRow.attributes('style') ?? '';
-            expect(style).toContain('grid-template-columns: 1fr 1fr');
+            const table = wrapper.find('.vs-table-table');
+            const style = table.attributes('style') ?? '';
+            expect(style).toContain('grid-template-columns: minmax(max-content, 1fr) minmax(max-content, 1fr)');
+        });
+    });
+
+    describe('expand 슬롯에 따른 grid 트랙', () => {
+        it('expand 슬롯이 없으면 expand 트랙(auto)이 추가되지 않는다', async () => {
+            const wrapper = mountTable({
+                props: {
+                    columns: [
+                        { key: 'name', label: 'Name' },
+                        { key: 'age', label: 'Age' },
+                    ],
+                },
+            });
+
+            await nextTick();
+
+            const style = wrapper.find('.vs-table-table').attributes('style') ?? '';
+            expect(style).toContain('grid-template-columns: minmax(max-content, 1fr) minmax(max-content, 1fr)');
+            expect(style).not.toContain('auto');
+        });
+
+        it('expand 슬롯이 있으면 끝에 expand 트랙(auto)이 추가된다', async () => {
+            const wrapper = mountTable({
+                props: {
+                    columns: [
+                        { key: 'name', label: 'Name' },
+                        { key: 'age', label: 'Age' },
+                    ],
+                },
+                slots: {
+                    expand: '<div>detail</div>',
+                },
+            });
+
+            await nextTick();
+
+            const style = wrapper.find('.vs-table-table').attributes('style') ?? '';
+            expect(style).toContain('minmax(max-content, 1fr) minmax(max-content, 1fr) auto');
         });
     });
 

--- a/packages/vlossom/src/components/vs-table/composables/table-composable.ts
+++ b/packages/vlossom/src/components/vs-table/composables/table-composable.ts
@@ -8,7 +8,7 @@ import {
     type TemplateRef,
     type WritableComputedRef,
 } from 'vue';
-import { functionUtil, objectUtil } from '@/utils';
+import { functionUtil, objectUtil, stringUtil } from '@/utils';
 import { type UIState, type VsComponent, type PropsOf, type SearchProps, type Size } from '@/declaration';
 import type { VsSearchInputRef } from '@/components';
 
@@ -40,7 +40,7 @@ export const TABLE_COMPOSABLE_TOKEN = Symbol('TABLE_COMPOSABLE_TOKEN');
 export function useTable(
     tableId: string,
     props: PropsOf<VsComponent.VsTable>,
-    refs: { searchInputRef: TemplateRef<VsSearchInputRef> },
+    refs: { searchInputRef: TemplateRef<VsSearchInputRef>; hasExpandSlot: ComputedRef<boolean> },
     cb?: {
         updateSelectedItems: (items: VsTableItem[]) => void;
         updatePage: (page: number) => void;
@@ -174,6 +174,43 @@ export function useTable(
         toggleSelectAll,
     } = useTableSelect(selectable, items, selectedItems);
 
+    function getGridColumnWidth(column: VsTableColumnDef): string {
+        const { width, minWidth, maxWidth } = column;
+        if (width) {
+            return stringUtil.toStringSize(width);
+        }
+        const min = minWidth ? stringUtil.toStringSize(minWidth) : null;
+        const max = maxWidth ? stringUtil.toStringSize(maxWidth) : null;
+        if (min && max) {
+            return `minmax(${min}, ${max})`;
+        }
+        if (min) {
+            return `minmax(${min}, 1fr)`;
+        }
+        if (max) {
+            return `minmax(auto, ${max})`;
+        }
+        return 'minmax(max-content, 1fr)';
+    }
+
+    const gridTemplateColumns = computed<string>(() => {
+        const cols: string[] = [];
+        if (draggable?.value) {
+            cols.push('auto');
+        }
+        if (anySelectable.value) {
+            cols.push('auto');
+        }
+        columns.value.forEach((column) => {
+            cols.push(getGridColumnWidth(column));
+        });
+        // expand 셀은 anyExpandable && expand 슬롯이 있을 때만 렌더되므로(showExpand) 트랙도 같은 조건으로 추가한다.
+        if (anyExpandable.value && refs.hasExpandSlot.value) {
+            cols.push('auto');
+        }
+        return cols.join(' ');
+    });
+
     const builtCellMatrix = computed<VsTableCell[][]>(() => {
         return tableCellBuilder.updateColumnDefs(columns.value).updateItems(items.value).build();
     });
@@ -254,6 +291,7 @@ export function useTable(
         headerCells,
         bodyCells,
         loading,
+        gridTemplateColumns,
         anyExpandable,
         isExpanded,
         toggleExpand,
@@ -285,6 +323,7 @@ export type TableComposable = {
     items: Ref<VsTableItem[]>;
     headerCells: Ref<VsTableHeaderCell[]>;
     bodyCells: ComputedRef<VsTableBodyCell[][]>;
+    gridTemplateColumns: ComputedRef<string>;
     anyExpandable: ComputedRef<boolean>;
     anySelectable: ComputedRef<boolean>;
     selectedItems: Ref<VsTableItem[]>;

--- a/packages/vlossom/src/components/vs-table/types.ts
+++ b/packages/vlossom/src/components/vs-table/types.ts
@@ -23,7 +23,9 @@ export const TABLE_SIZE_TOKEN = Symbol('TABLE_SIZE_TOKEN');
 export interface VsTableStyleSet extends CSSProperties {
     $toolbar?: CSSProperties;
     $search?: VsSearchInputStyleSet;
+    $caption?: CSSProperties;
     $header?: CSSProperties;
+    $stickyHeaderTop?: string;
     $row?: CSSProperties & {
         $selected?: CSSProperties;
     };

--- a/packages/vlossom/src/components/vs-visible-render/VsVisibleRender.css
+++ b/packages/vlossom/src/components/vs-visible-render/VsVisibleRender.css
@@ -2,8 +2,11 @@
     @apply relative w-full;
 }
 
-/* Hide children that are outside the viewport */
-.vs-visible-render > *[data-io-visible='false'] {
+/* 뷰포트 밖 자식은 paint만 생략하고 레이아웃 박스는 유지한다.
+   언마운트/display:none으로 제거하면 스크롤 높이를 보존하려고 자식마다 높이를 알아야 해서 높이가 제각각인 콘텐츠에 대응하기 어렵기 때문이다.
+   selector로 직계가 아닌 자식을 관측할 수 있어 후손 결합자로 매칭한다.
+   data-io-visible는 이 컴포넌트가 관측 대상에만 부여하므로 다른 요소를 건드리지 않는다. */
+.vs-visible-render [data-io-visible='false'] {
     visibility: hidden !important;
     pointer-events: none;
 }


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
vs-table의 스타일 이슈와 visible-render 제대로 적용하는 작업입니다

## Description
- vs-table column line 틀어지는 이슈 (#556 )
  - table이 같은 grid 안에서 동작하도록 subgrid를 row에 적용
  - sticky header가 table과 별도로 한 벌 더 존재하기 때문에 column grid style 연동함
- vs-table sticky-header 개선
  - 위 작업을 하면서 table에 `display: contents` 적용했기 때문에 InersectionObserver가 구독할 대상이 모호해짐
  - header의 sentinel DOM을 추가해서 대신하게 함
  - style-set에 $stickyHeaderTop 변수 추가해서 stickyHeader 사용성 높임
- vs-table caption 영역 style-set 추가
- vs-visible-render가 잘못 설정되어 있던 이슈 (#557 )
  - vs-visible-render가 table 전체에 적용되어 있어서 row 단위에 적용하도록 selector prop 지정

<img width="1894" height="520" alt="image" src="https://github.com/user-attachments/assets/bddb7874-6d26-483c-8700-a7926ffbb205" />