### PR TITLE
fix(VsTable): fix table hover border inset

### DIFF
--- a/packages/vlossom/src/components/vs-table/VsTable.css
+++ b/packages/vlossom/src/components/vs-table/VsTable.css
@@ -84,6 +84,7 @@
         min-width: 0;
         color: var(--vs-cs-font-colored);
         font-weight: var(--vs-font-weight);
+        font-weight: 500;
         font-size: var(--vs-size-font, var(--vs-font-size-md));
         text-align: left;
 

--- a/packages/vlossom/src/components/vs-table/VsTable.css
+++ b/packages/vlossom/src/components/vs-table/VsTable.css
@@ -149,7 +149,7 @@
             &:after {
                 content: '';
                 @apply pointer-events-none absolute;
-                inset: -1px;
+                inset: 0;
                 border: 1px solid var(--vs-cs-bg-primary);
             }
         }

--- a/packages/vlossom/src/components/vs-table/VsTable.css
+++ b/packages/vlossom/src/components/vs-table/VsTable.css
@@ -83,7 +83,6 @@
         /* min-width: auto 무력화 */
         min-width: 0;
         color: var(--vs-cs-font-colored);
-        font-weight: var(--vs-font-weight);
         font-weight: 500;
         font-size: var(--vs-size-font, var(--vs-font-size-md));
         text-align: left;


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
vs-table hover 때 border 넘침 이슈 수정

## Description
- inset: 0으로 해결
- header font-weight 500 누락된 것 추가
<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
