### PR TITLE
fix(XIcon): adjust xIcon size by prop size

### DIFF
--- a/packages/vlossom/src/components/vs-chip/VsChip.css
+++ b/packages/vlossom/src/components/vs-chip/VsChip.css
@@ -26,6 +26,7 @@
 
         border: 1px solid var(--vs-cs-line);
         border-radius: 50%;
+        background-color: var(--vs-cs-bg-area-colored);
         min-width: var(--vs-chip-icon-size);
         max-width: var(--vs-chip-icon-size);
         min-height: var(--vs-chip-icon-size);
@@ -37,7 +38,8 @@
         @apply shrink-0 cursor-pointer;
 
         .vs-chip-close-icon {
-            @apply size-5;
+            width: calc(var(--vs-chip-computed-height) * 0.5);
+            height: calc(var(--vs-chip-computed-height) * 0.5);
         }
     }
 
@@ -73,8 +75,8 @@
         color: var(--vs-cs-font-primary);
 
         .vs-chip-icon {
-            border: 1px solid var(--vs-cs-font-primary);
-            color: var(--vs-cs-font-primary);
+            border: 1px solid var(--vs-cs-bg-primary);
+            color: var(--vs-cs-font);
         }
     }
 

--- a/packages/vlossom/src/components/vs-input/VsInput.css
+++ b/packages/vlossom/src/components/vs-input/VsInput.css
@@ -32,11 +32,18 @@
     }
 
     .vs-clear-button {
-        @apply mr-2.5 flex size-5 items-center justify-center rounded border-none opacity-0;
+        @apply mr-2.5 flex items-center justify-center rounded border-none opacity-0;
 
+        width: 1.25em;
+        height: 1.25em;
         transition: opacity 0.4s;
 
         background: none;
+
+        .vs-clear-icon {
+            width: 100%;
+            height: 100%;
+        }
 
         &:focus {
             @apply cursor-pointer opacity-100;

--- a/packages/vlossom/src/components/vs-select/VsSelect.css
+++ b/packages/vlossom/src/components/vs-select/VsSelect.css
@@ -26,14 +26,17 @@
         }
 
         .vs-select-clear-button {
-            @apply flex size-5 items-center justify-center rounded border-none opacity-0 focus-visible:outline-1;
+            @apply flex items-center justify-center rounded border-none opacity-0 focus-visible:outline-1;
 
+            width: 1.25em;
+            height: 1.25em;
             transition: opacity 0.4s;
             background: none;
             color: var(--vs-cs-font);
 
             .vs-select-clear-icon {
-                @apply size-5;
+                width: 100%;
+                height: 100%;
             }
 
             &:focus {

--- a/packages/vlossom/src/styles/color-scheme.scss
+++ b/packages/vlossom/src/styles/color-scheme.scss
@@ -67,7 +67,7 @@ $colors:
             --vs-cs-bg-area-colored: var(--vs-#{$color}-50);
             --vs-cs-bg: var(--vs-#{$color}-100);
             --vs-cs-bg-colored: var(--vs-#{$color}-100);
-            --vs-cs-bg-comp: var(--vs-#{$color}-P200);
+            --vs-cs-bg-comp: var(--vs-#{$color}-200);
             --vs-cs-bg-comp-colored: var(--vs-#{$color}-200);
             --vs-cs-bg-primary: var(--vs-#{$color}-600);
 


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
x 버튼이 component size에 반응하지 않는 스타일 이슈 해결

## Description
- x 버튼 font-size를 em으로 처리해서 font-size에 반응하도록 변경
- color-scheme에 있던 오타 버그 수정 (이거 안 써서 다행;;;)
- vs-chip closable 스타일 일부 수정
<!-- Uncomment below if necessary -->
## Screenshots

<img width="539" height="1011" alt="image" src="https://github.com/user-attachments/assets/305ee685-34f1-4588-ba3c-3a22e32a7b5d" />

<img width="515" height="1038" alt="image" src="https://github.com/user-attachments/assets/060c3d18-02d5-454e-8b4e-8adfa5b4f7de" />

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
