### PR TITLE
fix(VsSelect): fill missing interfaces (open, close options)

### DIFF
--- a/packages/vlossom/src/components/vs-form/types.ts
+++ b/packages/vlossom/src/components/vs-form/types.ts
@@ -13,5 +13,6 @@ export interface VsFormRef extends ComponentPublicInstance<typeof VsForm> {
     valid: ComputedRef<boolean>;
     changed: ComputedRef<boolean>;
     clear: () => void;
+    reset: () => void;
     validate: () => Promise<boolean>;
 }

--- a/packages/vlossom/src/components/vs-select/README.ko.md
+++ b/packages/vlossom/src/components/vs-select/README.ko.md
@@ -172,10 +172,12 @@ interface VsSelectStyleSet extends CSSProperties {
 
 ## Methods
 
-| Method     | Parameters | 설명                        |
-| ---------- | ---------- | --------------------------- |
-| `focus`    | -          | 셀렉트 트리거에 포커스      |
-| `blur`     | -          | 셀렉트 트리거 포커스 해제   |
-| `validate` | -          | 유효성 검사 실행            |
-| `clear`    | -          | 선택 값 비우기             |
-| `reset`    | -          | 선택 값을 초기값으로 되돌리기 |
+| Method         | Parameters | 설명                          |
+| -------------- | ---------- | ----------------------------- |
+| `focus`        | -          | 셀렉트 트리거에 포커스        |
+| `blur`         | -          | 셀렉트 트리거 포커스 해제     |
+| `openOptions`  | -          | 옵션 드롭다운 열기            |
+| `closeOptions` | -          | 옵션 드롭다운 닫기            |
+| `validate`     | -          | 유효성 검사 실행              |
+| `clear`        | -          | 선택 값 비우기               |
+| `reset`        | -          | 선택 값을 초기값으로 되돌리기 |

--- a/packages/vlossom/src/components/vs-select/README.md
+++ b/packages/vlossom/src/components/vs-select/README.md
@@ -172,10 +172,12 @@ interface VsSelectStyleSet extends CSSProperties {
 
 ## Methods
 
-| Method     | Parameters | Description                   |
-| ---------- | ---------- | ----------------------------- |
-| `focus`    | -          | Focuses the select trigger    |
-| `blur`     | -          | Blurs the select trigger      |
-| `validate` | -          | Triggers validation           |
-| `clear`    | -          | Clears the selected value     |
-| `reset`    | -          | Resets the selected value to its initial value |
+| Method         | Parameters | Description                                     |
+| -------------- | ---------- | ----------------------------------------------- |
+| `focus`        | -          | Focuses the select trigger                      |
+| `blur`         | -          | Blurs the select trigger                        |
+| `openOptions`  | -          | Opens the options dropdown                       |
+| `closeOptions` | -          | Closes the options dropdown                      |
+| `validate`     | -          | Triggers validation                             |
+| `clear`        | -          | Clears the selected value                        |
+| `reset`        | -          | Resets the selected value to its initial value  |

--- a/packages/vlossom/src/components/vs-select/types.ts
+++ b/packages/vlossom/src/components/vs-select/types.ts
@@ -1,5 +1,5 @@
 import type { ComponentPublicInstance, CSSProperties } from 'vue';
-import type { FocusableRef } from '@/declaration';
+import type { FocusableRef, FormChildRef } from '@/declaration';
 import type VsSelect from './VsSelect.vue';
 import type VsSelectTrigger from './VsSelectTrigger.vue';
 
@@ -15,7 +15,10 @@ declare module 'vue' {
 
 export type { VsSelect, VsSelectTrigger };
 
-export interface VsSelectRef extends ComponentPublicInstance<typeof VsSelect> {}
+export interface VsSelectRef extends ComponentPublicInstance<typeof VsSelect>, FocusableRef, FormChildRef {
+    openOptions: () => void;
+    closeOptions: () => void;
+}
 
 export interface VsSelectTriggerRef extends ComponentPublicInstance<typeof VsSelectTrigger>, FocusableRef {}
 

--- a/packages/vlossom/src/declaration/types.ts
+++ b/packages/vlossom/src/declaration/types.ts
@@ -111,6 +111,7 @@ export interface InputComponentParams<T = unknown> {
 export interface FormChildRef {
     validate: () => boolean;
     clear: () => void;
+    reset: () => void;
 }
 
 export interface FocusableRef {


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
vs-select type에서 누락된 interface들을 채움

## Description
- vs-select에 누락된 FocusableRef, FormChildRef, openOptions, closeOptions 채우기
- vs-form과 FormChildRef 타입에 누락됐던 reset interface type도 채움