### PR TITLE
fix(VsCheckbox): match the checkbox interface and implementation

### DIFF
--- a/packages/vlossom/src/components/vs-checkbox/README.ko.md
+++ b/packages/vlossom/src/components/vs-checkbox/README.ko.md
@@ -210,4 +210,4 @@ interface VsCheckboxSetStyleSet extends CSSProperties {
 | `validate` | — | 유효성 검사를 실행하고 결과를 반환합니다 |
 | `focus` | — | 체크박스 입력 요소에 포커스를 줍니다 |
 | `blur` | — | 체크박스 입력 요소의 포커스를 제거합니다 |
-| `toggle` | — | 체크 상태를 전환합니다 |
+| `toggle` | — | 체크 상태를 전환하고 값이 변경됐는지 반환합니다 |

--- a/packages/vlossom/src/components/vs-checkbox/README.md
+++ b/packages/vlossom/src/components/vs-checkbox/README.md
@@ -210,4 +210,4 @@ interface VsCheckboxSetStyleSet extends CSSProperties {
 | `validate` | — | Triggers validation and returns the result |
 | `focus` | — | Focuses the checkbox input element |
 | `blur` | — | Blurs the checkbox input element |
-| `toggle` | — | Toggles the checked state |
+| `toggle` | — | Toggles the checked state and returns whether the value changed |

--- a/packages/vlossom/src/components/vs-checkbox/VsCheckbox.vue
+++ b/packages/vlossom/src/components/vs-checkbox/VsCheckbox.vue
@@ -33,7 +33,7 @@
                     :checked="isChecked"
                     :aria-required="required"
                     :name
-                    @click.prevent.stop="toggle"
+                    @click.prevent.stop="onToggle"
                     @focus.stop="onFocus"
                     @blur.stop="onBlur"
                 />
@@ -204,9 +204,9 @@ export default defineComponent({
             'vs-readonly': computedReadonly.value,
         }));
 
-        async function toggle(e: MouseEvent) {
+        async function toggle(): Promise<boolean> {
             if (computedDisabled.value || computedReadonly.value) {
-                return;
+                return false;
             }
 
             const toValue = getUpdatedValue(!isChecked.value);
@@ -215,12 +215,19 @@ export default defineComponent({
             if (beforeChangeFn) {
                 const result = await beforeChangeFn(inputValue.value, toValue, trueValue.value);
                 if (!result) {
-                    return;
+                    return false;
                 }
             }
 
             inputValue.value = toValue;
-            emit('toggle', isChecked.value, e);
+            return true;
+        }
+
+        async function onToggle(e: MouseEvent) {
+            const toggled = await toggle();
+            if (toggled) {
+                emit('toggle', isChecked.value, e);
+            }
         }
 
         function onFocus(e: FocusEvent) {
@@ -270,6 +277,7 @@ export default defineComponent({
             isChecked,
             shake,
             toggle,
+            onToggle,
             onFocus,
             onBlur,
             validate,

--- a/packages/vlossom/src/components/vs-checkbox/__tests__/vs-checkbox.test.ts
+++ b/packages/vlossom/src/components/vs-checkbox/__tests__/vs-checkbox.test.ts
@@ -355,6 +355,141 @@ describe('vs-checkbox', () => {
         });
     });
 
+    describe('toggle', () => {
+        afterEach(() => {
+            vi.restoreAllMocks();
+        });
+
+        it('toggle 함수를 호출하면 체크 상태가 전환되고 true를 반환한다', async () => {
+            // given
+            const wrapper = mount(VsCheckbox, {
+                props: {
+                    modelValue: false,
+                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+                },
+            });
+
+            // when
+            const result = await wrapper.vm.toggle();
+            await nextTick();
+
+            // then
+            expect(result).toBe(true);
+            expect(wrapper.vm.isChecked).toBe(true);
+            expect(wrapper.props('modelValue')).toBe(true);
+        });
+
+        it('disabled이면 toggle 함수가 상태를 바꾸지 않고 false를 반환한다', async () => {
+            // given
+            const wrapper = mount(VsCheckbox, {
+                props: {
+                    modelValue: false,
+                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+                    disabled: true,
+                },
+            });
+
+            // when
+            const result = await wrapper.vm.toggle();
+            await nextTick();
+
+            // then
+            expect(result).toBe(false);
+            expect(wrapper.vm.isChecked).toBe(false);
+        });
+
+        it('readonly이면 toggle 함수가 상태를 바꾸지 않고 false를 반환한다', async () => {
+            // given
+            const wrapper = mount(VsCheckbox, {
+                props: {
+                    modelValue: false,
+                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+                    readonly: true,
+                },
+            });
+
+            // when
+            const result = await wrapper.vm.toggle();
+            await nextTick();
+
+            // then
+            expect(result).toBe(false);
+            expect(wrapper.vm.isChecked).toBe(false);
+        });
+
+        it('beforeChange가 false를 반환하면 toggle 함수가 상태를 바꾸지 않고 false를 반환한다', async () => {
+            // given
+            const wrapper = mount(VsCheckbox, {
+                props: {
+                    modelValue: false,
+                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+                    beforeChange: () => Promise.resolve(false),
+                },
+            });
+
+            // when
+            const result = await wrapper.vm.toggle();
+            await nextTick();
+
+            // then
+            expect(result).toBe(false);
+            expect(wrapper.vm.isChecked).toBe(false);
+        });
+
+        it('toggle 함수 호출은 toggle 이벤트를 발생시키지 않는다', async () => {
+            // given
+            const wrapper = mount(VsCheckbox, {
+                props: {
+                    modelValue: false,
+                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+                },
+            });
+
+            // when
+            await wrapper.vm.toggle();
+            await nextTick();
+
+            // then
+            expect(wrapper.emitted('toggle')).toBeUndefined();
+        });
+
+        it('input click 시 toggle 이벤트가 새 체크 상태, 마우스 이벤트와 함께 발생한다', async () => {
+            // given
+            const wrapper = mount(VsCheckbox, {
+                props: {
+                    modelValue: false,
+                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+                },
+            });
+
+            // when
+            await wrapper.find('input').trigger('click');
+
+            // then
+            const toggleEvent = wrapper.emitted('toggle');
+            expect(toggleEvent).toHaveLength(1);
+            expect(toggleEvent?.[0][0]).toBe(true);
+            expect(toggleEvent?.[0][1]).toBeInstanceOf(Event);
+        });
+
+        it('beforeChange가 false를 반환하면 input click 시 toggle 이벤트가 발생하지 않는다', async () => {
+            // given
+            const wrapper = mount(VsCheckbox, {
+                props: {
+                    modelValue: false,
+                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+                    beforeChange: () => Promise.resolve(false),
+                },
+            });
+
+            // when
+            await wrapper.find('input').trigger('click');
+
+            // then
+            expect(wrapper.emitted('toggle')).toBeUndefined();
+        });
+    });
+
     describe('clear', () => {
         describe('multiple 이 true인 경우', () => {
             it('clear 함수를 호출하면 빈 배열로 업데이트된다', async () => {

--- a/packages/vlossom/src/components/vs-checkbox/types.ts
+++ b/packages/vlossom/src/components/vs-checkbox/types.ts
@@ -14,7 +14,7 @@ declare module 'vue' {
 export type { VsCheckbox, VsCheckboxSet };
 
 export interface VsCheckboxRef extends ComponentPublicInstance<typeof VsCheckbox>, FocusableRef, FormChildRef {
-    toggle: () => void;
+    toggle: () => Promise<boolean>;
 }
 
 export interface VsCheckboxSetRef extends ComponentPublicInstance<typeof VsCheckboxSet>, FocusableRef, FormChildRef {}


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
vs-checkbox toggle interface가 실제 구현과 차이가 있었음 (#572 )

## Description
- vs-checkbox의 기존 toggle 함수를 onToggle로 바꾸고, interface로 노출할 toggle을 구현함
- toggle 함수의 시그니쳐는 `() => Promise<boolean>`으로 정리함
<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
