### PR TITLE
fix(VsImage): fix image IntersectionObserver entries check

### DIFF
--- a/packages/vlossom/src/components/vs-image/VsImage.vue
+++ b/packages/vlossom/src/components/vs-image/VsImage.vue
@@ -112,8 +112,8 @@ export default defineComponent({
 
         if (hasIntersectionObserver && lazy.value) {
             // Use Intersection Observer for Lazy Load
-            const { pause } = useIntersectionObserver(vsImageRef, ([{ isIntersecting }]) => {
-                if (isIntersecting) {
+            const { pause } = useIntersectionObserver(vsImageRef, (entries) => {
+                if (entries.some((entry) => entry.isIntersecting)) {
                     isLoaded.value = true;
                     pause();
                 }

--- a/packages/vlossom/src/components/vs-image/__tests__/vs-image.test.ts
+++ b/packages/vlossom/src/components/vs-image/__tests__/vs-image.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import VsImage from './../VsImage.vue';
 
@@ -181,9 +182,14 @@ describe('vs-image', () => {
     });
 
     describe('lazy', () => {
+        let observerCallback: IntersectionObserverCallback | null = null;
         const mockIntersectionObserver = class IntersectionObserver {
-            constructor() {}
+            constructor(callback: IntersectionObserverCallback) {
+                observerCallback = callback;
+            }
             observe = () => null;
+            disconnect = () => null;
+            unobserve = () => null;
         };
         const originalIntersectionObserver = window.IntersectionObserver;
 
@@ -219,8 +225,35 @@ describe('vs-image', () => {
             expect(wrapper.html()).toContain(imagePath);
         });
 
+        it('교차 변화가 batch로 묶여 전달되어도, intersecting entry가 있으면 lazy 이미지를 로드해야 한다', async () => {
+            // given
+            window.IntersectionObserver = mockIntersectionObserver as any;
+
+            const imagePath = '/images/test.png';
+            const wrapper = mount(VsImage, {
+                props: {
+                    src: imagePath,
+                    lazy: true,
+                },
+            });
+            await nextTick();
+
+            expect(wrapper.html()).not.toContain(imagePath);
+
+            // when: 첫 entry가 stale(false)이고 최신 entry가 true인 batch 전달
+            observerCallback?.(
+                [{ isIntersecting: false }, { isIntersecting: true }] as IntersectionObserverEntry[],
+                {} as IntersectionObserver,
+            );
+            await nextTick();
+
+            // then
+            expect(wrapper.vm.computedSrc).toBe(imagePath);
+        });
+
         afterEach(() => {
             window.IntersectionObserver = originalIntersectionObserver;
+            observerCallback = null;
         });
     });
 });


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
vs-image IntersectionObserver entry check 때문에 skeleton 상태 되는 이슈(#570 )를 수정

## Description

### 원인

VsImage.vue의 IntersectionObserver 콜백이 ([{ isIntersecting }]) => …로 entries[0](가장 오래된 entry)만 읽고 있었습니다.

IntersectionObserver는 메인 스레드 부하가 높을 때 짧은 시간 내 교차 변화들을 한 콜백에 batch로 전달합니다. expandable이 height: 0 → auto로 애니메이션하는 동안 이미지가 클립 영역을 빠르게 드나들며 [{isIntersecting:false}, {isIntersecting:true}] 형태로 묶여 전달됩니다(4사이클에 56회 관측). 콜백은 첫 entry(false)만 보고 현재 상태(true)를 버려서 isLoaded가 끝내 false → computedSrc='' → skeleton 고정.

→ "이미지가 많을수록 / 개발자 도구 켰을 때 심함"이 정확히 설명됩니다(부하 ↑ → batch 다중 entry ↑).

### 해결방법
단방향 로드 래치이므로 batch 내 교차 항목이 하나라도 있으면 로드하도록 변경