### PR TITLE
fix(VsTable): bind row key to item identity instead of row index

### DIFF
--- a/packages/vlossom/src/components/vs-grouped-list/VsGroupedList.vue
+++ b/packages/vlossom/src/components/vs-grouped-list/VsGroupedList.vue
@@ -14,7 +14,7 @@
         </template>
 
         <vs-visible-render class="vs-grouped-list-list" ref="visibleRenderRef" root-margin="10px" tabindex="-1">
-            <template v-for="(group, groupIndex) in groupedItems" :key="`group-${groupIndex}`">
+            <template v-for="(group, groupIndex) in groupedItems" :key="group.name">
                 <div v-if="!!groupBy" class="vs-grouped-list-group" :style="componentStyleSet.$group">
                     <slot name="group" :group="group.name" :groupIndex :items="group.items">
                         <div class="vs-grouped-list-group-content">
@@ -24,7 +24,7 @@
                 </div>
                 <div
                     v-for="(item, groupedIndex) in group.items"
-                    :key="`${item.id}-${groupedIndex}`"
+                    :key="item.id"
                     :id="item.id"
                     :class="['vs-grouped-list-item', { 'vs-disabled': item.disabled }]"
                     :style="componentStyleSet.$item"
@@ -130,7 +130,7 @@ export default defineComponent({
                 // groupOrder가 있으면 그 순서대로, 나머지는 순서대로
                 const orderedSet = new Set<string>();
                 for (const groupName of groupOrder.value) {
-                    if (allGroups.includes(groupName)) {
+                    if (!orderedSet.has(groupName) && allGroups.includes(groupName)) {
                         orderedSet.add(groupName);
                         orderedGroups.push(groupName);
                     }

--- a/packages/vlossom/src/components/vs-grouped-list/__tests__/vs-grouped-list.test.ts
+++ b/packages/vlossom/src/components/vs-grouped-list/__tests__/vs-grouped-list.test.ts
@@ -133,6 +133,29 @@ describe('vs-grouped-list', () => {
             expect(groupedItems[3].name).toBe('D'); // 등장 순서대로
         });
 
+        it('groupOrder에 중복된 그룹이 있어도 그룹은 한 번만 나와야 한다', () => {
+            // given
+            const rawItems = [
+                { id: 1, name: '아이템 1', category: 'A' },
+                { id: 2, name: '아이템 2', category: 'B' },
+            ];
+            const items = createOptionItems(rawItems);
+
+            // when
+            const wrapper = mount(VsGroupedList, {
+                props: {
+                    items,
+                    groupBy: (item: any) => item.category,
+                    groupOrder: ['A', 'A', 'B'],
+                },
+            });
+
+            // then
+            const groupedItems: VsGroupedListGroup[] = wrapper.vm.groupedItems;
+            expect(groupedItems).toHaveLength(2);
+            expect(groupedItems.map((group) => group.name)).toEqual(['A', 'B']);
+        });
+
         it('ungrouped 아이템은 항상 제일 밑에 위치해야 한다', () => {
             // given
             const rawItems = [

--- a/packages/vlossom/src/components/vs-table/VsTable.vue
+++ b/packages/vlossom/src/components/vs-table/VsTable.vue
@@ -110,7 +110,6 @@ import {
     VS_TABLE_BODY_SLOT_PREFIXES,
     VS_TABLE_HEADER_SLOT_PREFIXES,
 } from './constants';
-import { getRowItem } from './models/table-model';
 
 import type { VsSearchInputRef } from './../vs-search-input/types';
 
@@ -368,7 +367,7 @@ export default defineComponent({
             emit('drag', event);
         }
         function searchRows(searchText: string): void {
-            const items = table.bodyCells.value.map((row) => getRowItem(row));
+            const items = table.bodyRows.value.map((row) => row.item);
             emit('search', items, searchText);
         }
         function paginate(page: number, pageSize: number): void {
@@ -391,18 +390,18 @@ export default defineComponent({
         }
 
         function expand(index: number): void {
-            const row = table.bodyCells.value[index];
+            const row = table.bodyRows.value[index];
             if (!row) {
                 return;
             }
-            table.setExpand(row, true);
+            table.setExpand(row.cells, true);
         }
         function collapse(index: number): void {
-            const row = table.bodyCells.value[index];
+            const row = table.bodyRows.value[index];
             if (!row) {
                 return;
             }
-            table.setExpand(row, false);
+            table.setExpand(row.cells, false);
         }
 
         watch(useStickyHeader, (visible) => {

--- a/packages/vlossom/src/components/vs-table/VsTableBody.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableBody.vue
@@ -1,17 +1,17 @@
 <template>
     <draggable
         tag="tbody"
-        v-model="displayedBodyCells"
+        v-model="displayedRows"
         v-bind="DEFAULT_SORTABLE_OPTIONS"
         :id
         :class="[TABLE_DRAG_WRAPPER_CLASS, 'vs-table-body']"
-        :item-key="getRowId"
+        :item-key="getRowKey"
         :disabled="loading"
         @update="handleDragUpdate"
     >
         <template #item="{ element, index }">
             <vs-table-body-row
-                :cells="element"
+                :row="element"
                 :rowIdx="index"
                 @click-cell="clickCell"
                 @click-row="clickRow"
@@ -25,7 +25,7 @@
         </template>
     </draggable>
 
-    <tbody class="vs-table-tbody" v-if="displayedBodyCells.length === 0">
+    <tbody class="vs-table-tbody" v-if="displayedRows.length === 0">
         <tr class="vs-table-body-row">
             <td class="vs-table-td vs-table-no-data-cell" colspan="100%">
                 <div class="vs-table-no-data">
@@ -48,12 +48,11 @@
 <script lang="ts">
 import { computed, defineComponent, inject, ref, watch, type ComputedRef } from 'vue';
 import type { ColorScheme } from '@/declaration';
-import { TABLE_COLOR_SCHEME_TOKEN, type VsTableBodyCell } from './types';
+import { TABLE_COLOR_SCHEME_TOKEN, type VsTableBodyCell, type VsTableRow } from './types';
 import { DEFAULT_SORTABLE_OPTIONS, TABLE_DRAG_WRAPPER_CLASS, VS_TABLE_BODY_SLOT_PREFIXES } from './constants';
 import { TABLE_COMPOSABLE_TOKEN, type TableComposable } from './composables/table-composable';
 import draggable from 'vuedraggable/src/vuedraggable';
 import type { SortableEvent } from 'sortablejs';
-import { getRowId, getRowItem } from './models/table-model';
 
 import { BanIcon } from '@lucide/vue';
 import VsLoading from '@/components/vs-loading/VsLoading.vue';
@@ -71,7 +70,7 @@ export default defineComponent({
     },
     emits: ['click-cell', 'click-row', 'select-row', 'expand-row', 'drag'],
     setup(props, { slots, emit }) {
-        const { bodyCells, loading } = inject<TableComposable>(TABLE_COMPOSABLE_TOKEN)!;
+        const { bodyRows, loading } = inject<TableComposable>(TABLE_COMPOSABLE_TOKEN)!;
         const colorScheme = inject<ComputedRef<ColorScheme | undefined>>(TABLE_COLOR_SCHEME_TOKEN);
 
         const bodySlots = computed(() =>
@@ -82,21 +81,24 @@ export default defineComponent({
 
         // NOTE: These values are arrays used to represent the **draggable** view.
         const displayOrder = ref<number[]>([]);
-        const displayedBodyCells = computed<VsTableBodyCell[][]>({
-            get(): VsTableBodyCell[][] {
-                const baseCells = bodyCells.value;
+        const displayedRows = computed<VsTableRow[]>({
+            get(): VsTableRow[] {
+                const base = bodyRows.value;
                 if (displayOrder.value.length === 0) {
-                    return baseCells;
+                    return base;
                 }
-                return displayOrder.value.map((idx) => baseCells[idx]);
+                return displayOrder.value.map((idx) => base[idx]);
             },
-            set(newCells: VsTableBodyCell[][]): void {
-                const baseCells = bodyCells.value;
-                const baseIds = baseCells.map(getRowId);
+            set(newRows: VsTableRow[]): void {
+                const baseKeys = bodyRows.value.map((row) => row.key);
 
-                displayOrder.value = newCells.map((row) => baseIds.indexOf(getRowId(row))).filter((idx) => idx !== -1);
+                displayOrder.value = newRows.map((row) => baseKeys.indexOf(row.key)).filter((idx) => idx !== -1);
             },
         });
+
+        function getRowKey(row: VsTableRow): string {
+            return row.key;
+        }
 
         function clickCell(cell: VsTableBodyCell, event: MouseEvent): void {
             emit('click-cell', { ...cell }, event);
@@ -120,9 +122,9 @@ export default defineComponent({
         }
 
         watch(
-            bodyCells,
-            (newCells) => {
-                displayOrder.value = newCells.map((_, idx) => idx);
+            bodyRows,
+            (rows) => {
+                displayOrder.value = rows.map((_, idx) => idx);
             },
             { immediate: true },
         );
@@ -132,12 +134,11 @@ export default defineComponent({
             TABLE_DRAG_WRAPPER_CLASS,
             bodySlots,
             colorScheme,
-            displayedBodyCells,
+            displayedRows,
+            getRowKey,
             loading,
             clickCell,
             clickRow,
-            getRowItem: getRowItem,
-            getRowId,
             selectRow,
             expandRow,
             handleDragUpdate,

--- a/packages/vlossom/src/components/vs-table/VsTableBodyRow.vue
+++ b/packages/vlossom/src/components/vs-table/VsTableBodyRow.vue
@@ -1,12 +1,12 @@
 <template>
     <tr :class="['vs-table-body-row', classObj, stateClasses]" :style="rowStyle">
-        <vs-table-drag-cell :cells :rowIdx />
-        <vs-table-checkbox-cell :cells :rowIdx @select-row="selectRow">
+        <vs-table-drag-cell :cells="row.cells" :rowIdx />
+        <vs-table-checkbox-cell :cells="row.cells" :rowIdx @select-row="selectRow">
             <template #select="slotData">
                 <slot name="select" v-bind="slotData" />
             </template>
         </vs-table-checkbox-cell>
-        <template v-for="(cell, index) in cells" :key="cell.id">
+        <template v-for="(cell, index) in row.cells" :key="cell.id">
             <td
                 class="vs-table-td"
                 :id="cell.id"
@@ -30,9 +30,9 @@
                 </template>
             </td>
         </template>
-        <vs-table-expand-cell v-if="showExpand" :cells :rowIdx @expand-row="expandRow" />
+        <vs-table-expand-cell v-if="showExpand" :cells="row.cells" :rowIdx @expand-row="expandRow" />
         <td v-if="showExpand" class="vs-table-td vs-table-expanded-row">
-            <vs-table-expanded-panel :cells :rowIdx>
+            <vs-table-expanded-panel :cells="row.cells" :rowIdx>
                 <template #expand="slotData">
                     <slot name="expand" v-bind="slotData" />
                 </template>
@@ -50,10 +50,10 @@ import {
     TABLE_COLOR_SCHEME_TOKEN,
     TABLE_STYLE_SET_TOKEN,
     type VsTableBodyCell,
+    type VsTableRow,
     type VsTableStyleSet,
 } from './types';
 import { TABLE_COMPOSABLE_TOKEN, type TableComposable } from './composables/table-composable';
-import { getRowItem } from './models/table-model';
 
 import VsSkeleton from '@/components/vs-skeleton/VsSkeleton.vue';
 import VsTableDragCell from './VsTableDragCell.vue';
@@ -70,8 +70,8 @@ export default defineComponent({
         VsTableCheckboxCell,
     },
     props: {
-        cells: {
-            type: Array as PropType<VsTableBodyCell[]>,
+        row: {
+            type: Object as PropType<VsTableRow>,
             required: true,
         },
         rowIdx: {
@@ -81,7 +81,7 @@ export default defineComponent({
     },
     emits: ['click-cell', 'click-row', 'select-row', 'expand-row'],
     setup(props, { emit, slots }) {
-        const { cells, rowIdx: rowIndex } = toRefs(props);
+        const { row, rowIdx: rowIndex } = toRefs(props);
         const {
             anyExpandable,
             anySelectable,
@@ -96,7 +96,7 @@ export default defineComponent({
         const colorScheme = inject<ComputedRef<ColorScheme | undefined>>(TABLE_COLOR_SCHEME_TOKEN);
 
         const state = computed<UIState>(() => {
-            return stateFn.value(getRowItem(cells.value), rowIndex.value, items?.value);
+            return stateFn.value(row.value.item, rowIndex.value, items?.value);
         });
         const { stateClasses } = useStateClass(state);
 
@@ -104,7 +104,7 @@ export default defineComponent({
             if (!anySelectable.value) {
                 return false;
             }
-            return selectedItems.value.includes(getRowItem(props.cells));
+            return selectedItems.value.includes(row.value.item);
         });
 
         const showExpand = computed(() => anyExpandable.value && !!slots.expand);
@@ -171,12 +171,12 @@ export default defineComponent({
             return String(header.value ?? fallback);
         }
 
-        function selectRow(row: VsTableBodyCell[], event: MouseEvent): void {
-            emit('select-row', row, event);
+        function selectRow(cells: VsTableBodyCell[], event: MouseEvent): void {
+            emit('select-row', cells, event);
         }
 
-        function expandRow(row: VsTableBodyCell[], event: MouseEvent): void {
-            emit('expand-row', row, event);
+        function expandRow(cells: VsTableBodyCell[], event: MouseEvent): void {
+            emit('expand-row', cells, event);
         }
 
         return {

--- a/packages/vlossom/src/components/vs-table/__tests__/table-cell-builder.test.ts
+++ b/packages/vlossom/src/components/vs-table/__tests__/table-cell-builder.test.ts
@@ -7,7 +7,7 @@ describe('TableCellBuilder', () => {
         const items = [{ id: '1', name: 'Alice', age: 24 }];
         const builder = new TableCellBuilder('test-table-id', items, []);
 
-        const [header, ...body] = builder.build();
+        const { header, rows } = builder.build();
 
         expect(header).toHaveLength(3);
         expect(header[1]).toMatchObject({
@@ -17,7 +17,8 @@ describe('TableCellBuilder', () => {
             colIdx: 1,
             rowIdx: 0,
         });
-        expect(body[0][1]).toMatchObject({
+        expect(rows[0].item).toBe(items[0]);
+        expect(rows[0].cells[1]).toMatchObject({
             tag: 'td',
             value: 'Alice',
             item: items[0],
@@ -34,12 +35,12 @@ describe('TableCellBuilder', () => {
         ];
         const builder = new TableCellBuilder('test-table-id', items, ['name', 'meta.age']);
 
-        const [header, ...body] = builder.build();
+        const { header, rows } = builder.build();
 
         expect(header.map((h) => h.value)).toEqual(['name', 'meta.age']);
-        expect(body).toHaveLength(2);
-        expect(body[0].map((cell) => cell.value)).toEqual(['Alice', 27]);
-        expect(body[1].map((cell) => cell.value)).toEqual(['Bob', 31]);
+        expect(rows).toHaveLength(2);
+        expect(rows[0].cells.map((cell) => cell.value)).toEqual(['Alice', 27]);
+        expect(rows[1].cells.map((cell) => cell.value)).toEqual(['Bob', 31]);
     });
 
     it('객체 컬럼 정의를 사용하고, 업데이트 시 새로운 팩토리로 재생성한다', () => {
@@ -50,17 +51,38 @@ describe('TableCellBuilder', () => {
         const items = [{ id: '1', name: 'Alice', age: 24 }];
         const builder = new TableCellBuilder('test-table-id', items, columnDefs);
 
-        const [header] = builder.build();
+        const { header } = builder.build();
         expect(header.map((h) => h.value)).toEqual(['이름', '나이']);
 
         const nextColumnDefs: VsTableColumnDef[] = [{ key: 'title', label: '제목' }];
         const nextItems = [{ id: '99', title: 'Hello' }];
 
         builder.updateColumnDefs(nextColumnDefs).updateItems(nextItems);
-        const [nextHeader, ...nextBody] = builder.build();
+        const { header: nextHeader, rows: nextRows } = builder.build();
 
         expect(nextHeader.map((h) => h.colKey)).toEqual(['title']);
-        expect(nextBody[0][0]).toMatchObject({ value: 'Hello', colKey: 'title', rowIdx: 0, colIdx: 0 });
+        expect(nextRows[0].cells[0]).toMatchObject({ value: 'Hello', colKey: 'title', rowIdx: 0, colIdx: 0 });
+    });
+
+    it('아이템을 앞에 추가해 인덱스가 밀려도 기존 행의 key와 셀 id는 유지된다', () => {
+        const columnDefs: VsTableColumnDef[] = [{ key: 'name', label: '이름' }];
+        const alice = { id: '1', name: 'Alice' };
+        const bob = { id: '2', name: 'Bob' };
+        const builder = new TableCellBuilder('test-table-id', [alice, bob], columnDefs);
+
+        const { rows } = builder.build();
+        const aliceKey = rows[0].key;
+        const aliceCellId = rows[0].cells[0].id;
+        const bobKey = rows[1].key;
+
+        const carol = { id: '3', name: 'Carol' };
+        builder.updateItems([carol, alice, bob]);
+        const { rows: nextRows } = builder.build();
+
+        expect(nextRows[1].key).toBe(aliceKey);
+        expect(nextRows[1].cells[0]).toMatchObject({ id: aliceCellId, rowIdx: 1 });
+        expect(nextRows[2].key).toBe(bobKey);
+        expect(nextRows[0].key).not.toBe(aliceKey);
     });
 
     it('transform value 타입은 any이고 item 타입은 유지한다', () => {

--- a/packages/vlossom/src/components/vs-table/__tests__/table-composable.test.ts
+++ b/packages/vlossom/src/components/vs-table/__tests__/table-composable.test.ts
@@ -6,7 +6,6 @@ import type { VsSearchInputRef } from '@/components';
 import { useTable } from './../composables/table-composable';
 import {
     VsTableSortType,
-    type VsTableBodyCell,
     type VsTableColumnDef,
     type VsTableHeaderCell,
     type VsTableItem,
@@ -74,11 +73,11 @@ describe('useTable', () => {
         await nextTick();
 
         const headerCells = table.headerCells.value as VsTableHeaderCell[];
-        const bodyCells = table.bodyCells.value as VsTableBodyCell[][];
+        const bodyRows = table.bodyRows.value;
 
         expect(headerCells.map((h) => h.value)).toEqual(['이름', '나이']);
-        expect(bodyCells).toHaveLength(2);
-        expect(bodyCells[0].map((cell) => cell.value)).toEqual(['Alice', 24]);
+        expect(bodyRows).toHaveLength(2);
+        expect(bodyRows[0].cells.map((cell) => cell.value)).toEqual(['Alice', 24]);
     });
 
     it('컬럼과 아이템 변경을 감지해 셀을 재생성한다', async () => {
@@ -94,10 +93,29 @@ describe('useTable', () => {
         await nextTick();
 
         const columns = table.columns.value as VsTableColumnDef[] | null;
-        const bodyCells = table.bodyCells.value as VsTableBodyCell[][];
+        const bodyRows = table.bodyRows.value;
 
         expect(columns?.map((c) => c.key)).toEqual(['title']);
-        expect(bodyCells[0][0]).toMatchObject({ value: '새 항목', colKey: 'title' });
+        expect(bodyRows[0].cells[0]).toMatchObject({ value: '새 항목', colKey: 'title' });
+    });
+
+    it('아이템을 맨 앞에 추가해 인덱스가 밀려도 기존 행의 key가 유지된다', async () => {
+        const alice = { id: '1', name: 'Alice' };
+        const bob = { id: '2', name: 'Bob' };
+        const { table, reactiveProps } = setupUseTable({ columns: ['name'], items: [alice, bob] });
+
+        await nextTick();
+
+        const aliceKey = table.bodyRows.value[0].key;
+        const bobKey = table.bodyRows.value[1].key;
+
+        reactiveProps.items = [{ id: '3', name: 'Carol' }, alice, bob];
+        await nextTick();
+
+        expect(table.bodyRows.value.map((row) => row.item.name)).toEqual(['Carol', 'Alice', 'Bob']);
+        expect(table.bodyRows.value[1].key).toBe(aliceKey);
+        expect(table.bodyRows.value[2].key).toBe(bobKey);
+        expect(table.bodyRows.value[0].key).not.toBe(aliceKey);
     });
 
     it('선택 가능한 행이 있을 때 전체 선택/해제를 토글한다', async () => {
@@ -172,7 +190,7 @@ describe('useTable', () => {
         } as any;
         await nextTick();
 
-        const filteredNames = table.bodyCells.value.map((row) => row[1].value);
+        const filteredNames = table.bodyRows.value.map((row) => row.cells[1].value);
         expect(filteredNames).toEqual(['XYZ 사용자']);
     });
 
@@ -188,7 +206,7 @@ describe('useTable', () => {
             await nextTick();
 
             expect(table.pageSize.value).toBe(DEFAULT_PAGE_SIZE);
-            expect(table.bodyCells.value).toHaveLength(DEFAULT_PAGE_SIZE);
+            expect(table.bodyRows.value).toHaveLength(DEFAULT_PAGE_SIZE);
             expect(table.totalPages.value).toBe(3);
         });
 
@@ -214,7 +232,7 @@ describe('useTable', () => {
 
             expect(table.pageSize.value).toBe(20);
             expect(table.totalPages.value).toBe(3);
-            expect(table.bodyCells.value).toHaveLength(20);
+            expect(table.bodyRows.value).toHaveLength(20);
 
             reactiveProps.page = 2;
             reactiveProps.pageSize = 10;
@@ -223,7 +241,7 @@ describe('useTable', () => {
             expect(table.page.value).toBe(0);
             expect(table.pageSize.value).toBe(10);
             expect(table.totalPages.value).toBe(6);
-            expect(table.bodyCells.value).toHaveLength(10);
+            expect(table.bodyRows.value).toHaveLength(10);
         });
 
         describe('server mode', () => {
@@ -243,7 +261,7 @@ describe('useTable', () => {
                 await nextTick();
 
                 expect(table.totalPages.value).toBe(Math.ceil(500 / 10));
-                expect(table.bodyCells.value).toHaveLength(10);
+                expect(table.bodyRows.value).toHaveLength(10);
             });
 
             it('서버 모드에서는 client-side pagination을 수행하지 않는다', async () => {
@@ -265,9 +283,9 @@ describe('useTable', () => {
 
                 await nextTick();
 
-                expect(table.bodyCells.value).toHaveLength(10);
-                expect(table.bodyCells.value[0][0].value).toBe('User 20');
-                expect(table.bodyCells.value[9][0].value).toBe('User 29');
+                expect(table.bodyRows.value).toHaveLength(10);
+                expect(table.bodyRows.value[0].cells[0].value).toBe('User 20');
+                expect(table.bodyRows.value[9].cells[0].value).toBe('User 29');
             });
 
             it('서버 모드에서 totalItemCount가 없으면 총 페이지를 0으로 계산한다', async () => {
@@ -400,7 +418,7 @@ describe('useTable', () => {
                 expect(table.totalPages.value).toBe(1);
             });
 
-            it('pageSize가 Infinity일 때 bodyCells에 모든 아이템이 포함된다', async () => {
+            it('pageSize가 Infinity일 때 bodyRows에 모든 아이템이 포함된다', async () => {
                 const items = Array.from({ length: 50 }, (_, i) => ({ id: `${i}`, name: `User ${i}` }));
                 const { table } = setupUseTable({
                     columns: ['name'],
@@ -411,9 +429,9 @@ describe('useTable', () => {
                 });
 
                 await nextTick();
-                expect(table.bodyCells.value.length).toBe(50);
-                expect(table.bodyCells.value[0][0].value).toBe('User 0');
-                expect(table.bodyCells.value[49][0].value).toBe('User 49');
+                expect(table.bodyRows.value.length).toBe(50);
+                expect(table.bodyRows.value[0].cells[0].value).toBe('User 0');
+                expect(table.bodyRows.value[49].cells[0].value).toBe('User 49');
             });
 
             it('서버 모드에서 pageSize가 Infinity이면 totalItemCount 기반으로 전체 데이터를 표시한다', async () => {
@@ -457,7 +475,7 @@ describe('useTable', () => {
                 await nextTick();
 
                 expect(table.pageSize.value).toBe(5);
-                expect(table.bodyCells.value).toHaveLength(5);
+                expect(table.bodyRows.value).toHaveLength(5);
                 expect(table.totalPages.value).toBe(6);
             });
 
@@ -547,7 +565,7 @@ describe('useTable', () => {
             });
 
             await nextTick();
-            const row = table.bodyCells.value[0];
+            const row = table.bodyRows.value[0].cells;
 
             expect(table.anyExpandable.value).toBe(true);
             expect(table.isExpanded(row)).toBe(false);
@@ -567,7 +585,7 @@ describe('useTable', () => {
             });
 
             await nextTick();
-            const row = table.bodyCells.value[0];
+            const row = table.bodyRows.value[0].cells;
 
             expect(table.anyExpandable.value).toBe(false);
             expect(table.toggleExpand(row)).toBe(false);
@@ -580,7 +598,8 @@ describe('useTable', () => {
             { key: 'name', label: '이름', sortable: true },
         ];
 
-        const getNames = (table: ReturnType<typeof useTable>) => table.bodyCells.value.map((row) => row[1].value);
+        const getNames = (table: ReturnType<typeof useTable>) =>
+            table.bodyRows.value.map((row) => row.cells[1].value);
 
         it('초기 상태는 NONE이며 원본 순서를 유지한다', async () => {
             const { table } = setupUseTable({

--- a/packages/vlossom/src/components/vs-table/composables/table-composable.ts
+++ b/packages/vlossom/src/components/vs-table/composables/table-composable.ts
@@ -14,11 +14,11 @@ import type { VsSearchInputRef } from '@/components';
 
 import {
     type VsTableSortType,
-    type VsTableBodyCell,
     type VsTableColumnDef,
     type VsTableHeaderCell,
     type VsTableCell,
     type VsTableItem,
+    type VsTableRow,
     type VsTablePaginationOptions,
 } from './../types';
 import { TableCellBuilder } from './../models/table-cell-builder';
@@ -211,13 +211,13 @@ export function useTable(
         return cols.join(' ');
     });
 
-    const builtCellMatrix = computed<VsTableCell[][]>(() => {
+    const builtTable = computed<{ header: VsTableHeaderCell[]; rows: VsTableRow[] }>(() => {
         return tableCellBuilder.updateColumnDefs(columns.value).updateItems(items.value).build();
     });
     const headerCells = ref<VsTableHeaderCell[]>([]);
-    const rawBodyCells = ref<VsTableBodyCell[][]>([]);
+    const rawBodyRows = ref<VsTableRow[]>([]);
 
-    const totalItemsCount = computed(() => rawBodyCells.value.filter(matchBySearch).length);
+    const totalItemsCount = computed(() => rawBodyRows.value.filter(matchBySearch).length);
     const { totalPages, totalItems, pageStartIndex, pageEndIndex } = useTablePagination(
         pagination,
         page,
@@ -225,54 +225,42 @@ export function useTable(
         totalItemsCount,
         serverMode,
     );
-    const preprocessedBodyCells = computed<VsTableBodyCell[][]>(() => {
-        return rawBodyCells.value.filter(matchBySearch).sort(compareRows);
+    const preprocessedBodyRows = computed<VsTableRow[]>(() => {
+        return rawBodyRows.value.filter(matchBySearch).sort(compareRows);
     });
-    const bodyCells = computed<VsTableBodyCell[][]>(() => {
+    const bodyRows = computed<VsTableRow[]>(() => {
         if (objectUtil.isEmpty(pagination.value)) {
-            return preprocessedBodyCells.value;
+            return preprocessedBodyRows.value;
         }
         if (serverMode.value) {
-            return preprocessedBodyCells.value;
+            return preprocessedBodyRows.value;
         }
-        return preprocessedBodyCells.value.slice(pageStartIndex.value, pageEndIndex.value);
+        return preprocessedBodyRows.value.slice(pageStartIndex.value, pageEndIndex.value);
     });
 
-    function initCells(cellMatrix: VsTableCell[][]): void {
-        const [header, ...body] = cellMatrix;
-        const nextHeaderCells = [...header] as VsTableHeaderCell[];
-        const nextBodyCells = [...body] as VsTableBodyCell[][];
-
-        headerCells.value = nextHeaderCells;
-        rawBodyCells.value = nextBodyCells;
+    function initTable(built: { header: VsTableHeaderCell[]; rows: VsTableRow[] }): void {
+        headerCells.value = [...built.header];
+        rawBodyRows.value = [...built.rows];
     }
 
     function initialize(): void {
-        initCells(tableCellBuilder.build());
+        initTable(tableCellBuilder.build());
     }
 
-    watch(builtCellMatrix, (matrix) => {
-        initCells(matrix);
+    watch(builtTable, (next) => {
+        initTable(next);
     });
 
     watch(internalSelectedItems, (nextSelectedItems) => {
         cb?.updateSelectedItems(nextSelectedItems);
     });
 
-    watch(bodyCells, (nextBodyCells) => {
-        const pagedItems = nextBodyCells.map((row) => {
-            const firstCell = row[0];
-            return firstCell?.item || {};
-        });
-        cb?.updatePagedItems(pagedItems);
+    watch(bodyRows, (rows) => {
+        cb?.updatePagedItems(rows.map((row) => row.item));
     });
 
-    watch(preprocessedBodyCells, (nextBodyCells) => {
-        const nextTotalItems = nextBodyCells.map((row) => {
-            const firstCell = row[0];
-            return firstCell?.item || {};
-        });
-        cb?.updateTotalItems(nextTotalItems);
+    watch(preprocessedBodyRows, (rows) => {
+        cb?.updateTotalItems(rows.map((row) => row.item));
     });
 
     // pageSize 변경은 page를 0으로 리셋하지만 두 변경이 같은 tick에 일어나므로 콜백은 한 번만 실행된다.
@@ -289,7 +277,7 @@ export function useTable(
         state,
         draggable,
         headerCells,
-        bodyCells,
+        bodyRows,
         loading,
         gridTemplateColumns,
         anyExpandable,
@@ -322,7 +310,7 @@ export type TableComposable = {
     columns: ComputedRef<VsTableColumnDef[] | null>;
     items: Ref<VsTableItem[]>;
     headerCells: Ref<VsTableHeaderCell[]>;
-    bodyCells: ComputedRef<VsTableBodyCell[][]>;
+    bodyRows: ComputedRef<VsTableRow[]>;
     gridTemplateColumns: ComputedRef<string>;
     anyExpandable: ComputedRef<boolean>;
     anySelectable: ComputedRef<boolean>;

--- a/packages/vlossom/src/components/vs-table/composables/table-search-composable.ts
+++ b/packages/vlossom/src/components/vs-table/composables/table-search-composable.ts
@@ -1,8 +1,7 @@
 import { computed, type ComputedRef, type Ref } from 'vue';
 import type { VsSearchInputRef } from '@/components';
 import { objectUtil } from '@/utils';
-import { type VsTableBodyCell, type VsTableColumnDef } from './../types';
-import { getRowItem } from './../models/table-model';
+import { type VsTableColumnDef, type VsTableRow } from './../types';
 
 export function useTableSearch(ref: Ref<VsSearchInputRef | null>, columns: ComputedRef<VsTableColumnDef[] | null>) {
     const skipKeyList = computed<string[]>(() => {
@@ -12,11 +11,11 @@ export function useTableSearch(ref: Ref<VsSearchInputRef | null>, columns: Compu
         return columns.value.filter((col) => col.skipSearch).map((column) => column.key);
     });
 
-    function matchBySearch(row: VsTableBodyCell[]): boolean {
+    function matchBySearch(row: VsTableRow): boolean {
         if (!ref.value) {
             return true;
         }
-        const item = getRowItem(row);
+        const item = row.item;
         if (!item) {
             return false;
         }

--- a/packages/vlossom/src/components/vs-table/composables/table-sort-composable.ts
+++ b/packages/vlossom/src/components/vs-table/composables/table-sort-composable.ts
@@ -1,5 +1,5 @@
 import { ref, type Ref } from 'vue';
-import { VsTableSortType, type VsTableColumnDef, type VsTableBodyCell } from './../types';
+import { VsTableSortType, type VsTableColumnDef, type VsTableRow } from './../types';
 import { objectUtil, compareUtil } from '@/utils';
 
 const SORT_TYPE_COUNT = Object.keys(VsTableSortType).filter((value) => !isNaN(Number(value))).length;
@@ -8,15 +8,15 @@ export function useTableSort(columns: Ref<VsTableColumnDef[]>) {
     const sortType = ref<VsTableSortType>(VsTableSortType.NONE);
     const sortColumn = ref<VsTableColumnDef | null>(null);
 
-    function compareRows(aRow: VsTableBodyCell[], bRow: VsTableBodyCell[]): number {
+    function compareRows(aRow: VsTableRow, bRow: VsTableRow): number {
         if (sortType.value === VsTableSortType.NONE) {
             return 0;
         }
         if (!columns.value.length || !sortColumn.value) {
             return 0;
         }
-        const aItem = aRow[0]?.item;
-        const bItem = bRow[0]?.item;
+        const aItem = aRow.item;
+        const bItem = bRow.item;
         if (!aItem || !bItem) {
             return 0;
         }

--- a/packages/vlossom/src/components/vs-table/models/strategy/index.ts
+++ b/packages/vlossom/src/components/vs-table/models/strategy/index.ts
@@ -1,11 +1,11 @@
-import type { VsTableBodyCell, VsTableHeaderCell } from './../../types';
+import type { VsTableHeaderCell, VsTableRow } from './../../types';
 import NoColumnDefCellStrategy from './no-column-def-cell-strategy';
 import ObjectColumnDefCellStrategy from './object-column-def-cell-strategy';
 import StringKeyColumnDefCellStrategy from './string-column-def-cell-strategy';
 
 export interface TableCellStrategy {
     createHeaderCell(): VsTableHeaderCell[];
-    createBodyCell(): VsTableBodyCell[][];
+    createBodyRows(): VsTableRow[];
 }
 
 export const HEADER_ROW_INDEX = 0;

--- a/packages/vlossom/src/components/vs-table/models/strategy/no-column-def-cell-strategy.ts
+++ b/packages/vlossom/src/components/vs-table/models/strategy/no-column-def-cell-strategy.ts
@@ -1,11 +1,12 @@
 import { stringUtil } from '@/utils';
-import type { VsTableBodyCell, VsTableHeaderCell, VsTableItem } from './../../types';
+import type { VsTableBodyCell, VsTableHeaderCell, VsTableItem, VsTableRow } from './../../types';
 import { HEADER_ROW_INDEX, type TableCellStrategy } from './index';
 
 export default class NoColumnDefCellStrategy implements TableCellStrategy {
     public constructor(
         private tableId: string,
         private items: VsTableItem[],
+        private getRowKey: (item: VsTableItem) => string,
     ) {}
 
     public createHeaderCell(): VsTableHeaderCell[] {
@@ -22,18 +23,20 @@ export default class NoColumnDefCellStrategy implements TableCellStrategy {
         }));
     }
 
-    public createBodyCell(): VsTableBodyCell[][] {
+    public createBodyRows(): VsTableRow[] {
         const tag = 'td';
         return this.items.map((item: VsTableItem, rowIdx: number) => {
-            return Object.keys(item).map((key: string, colIdx: number) => ({
+            const rowKey = this.getRowKey(item);
+            const cells: VsTableBodyCell[] = Object.keys(item).map((key: string, colIdx: number) => ({
                 tag,
-                id: `${this.tableId}-${stringUtil.kebabCase(key)}-${rowIdx}`,
+                id: `${this.tableId}-${stringUtil.kebabCase(key)}-${rowKey}`,
                 value: item[key],
                 item,
                 colKey: key,
                 colIdx,
                 rowIdx,
             }));
+            return { key: rowKey, item, cells };
         });
     }
 }

--- a/packages/vlossom/src/components/vs-table/models/strategy/object-column-def-cell-strategy.ts
+++ b/packages/vlossom/src/components/vs-table/models/strategy/object-column-def-cell-strategy.ts
@@ -1,5 +1,5 @@
 import { objectUtil, stringUtil } from '@/utils';
-import type { VsTableBodyCell, VsTableColumnDef, VsTableHeaderCell, VsTableItem } from './../../types';
+import type { VsTableBodyCell, VsTableColumnDef, VsTableHeaderCell, VsTableItem, VsTableRow } from './../../types';
 import { HEADER_ROW_INDEX, type TableCellStrategy } from './index';
 
 export default class ObjectColumnDefCellStrategy implements TableCellStrategy {
@@ -7,6 +7,7 @@ export default class ObjectColumnDefCellStrategy implements TableCellStrategy {
         private tableId: string,
         private items: VsTableItem[],
         private columnDefs: VsTableColumnDef[],
+        private getRowKey: (item: VsTableItem) => string,
     ) {}
 
     public createHeaderCell(): VsTableHeaderCell[] {
@@ -23,12 +24,13 @@ export default class ObjectColumnDefCellStrategy implements TableCellStrategy {
         }));
     }
 
-    public createBodyCell(): VsTableBodyCell[][] {
+    public createBodyRows(): VsTableRow[] {
         const tag = 'td';
         return this.items.map((item: VsTableItem, rowIdx: number) => {
-            return this.columnDefs.map((header: VsTableColumnDef, colIdx: number) => ({
+            const key = this.getRowKey(item);
+            const cells: VsTableBodyCell[] = this.columnDefs.map((header: VsTableColumnDef, colIdx: number) => ({
                 tag,
-                id: `${this.tableId}-${stringUtil.kebabCase(header.key)}-${rowIdx}`,
+                id: `${this.tableId}-${stringUtil.kebabCase(header.key)}-${key}`,
                 value: header.transform
                     ? header.transform(objectUtil.get(item, header.key), item)
                     : objectUtil.get(item, header.key),
@@ -37,6 +39,7 @@ export default class ObjectColumnDefCellStrategy implements TableCellStrategy {
                 colIdx,
                 rowIdx,
             }));
+            return { key, item, cells };
         });
     }
 }

--- a/packages/vlossom/src/components/vs-table/models/strategy/string-column-def-cell-strategy.ts
+++ b/packages/vlossom/src/components/vs-table/models/strategy/string-column-def-cell-strategy.ts
@@ -1,5 +1,5 @@
 import { objectUtil, stringUtil } from '@/utils';
-import type { VsTableBodyCell, VsTableHeaderCell, VsTableItem } from './../../types';
+import type { VsTableBodyCell, VsTableHeaderCell, VsTableItem, VsTableRow } from './../../types';
 import { HEADER_ROW_INDEX, type TableCellStrategy } from './index';
 
 export default class StringKeyColumnDefCellStrategy implements TableCellStrategy {
@@ -7,6 +7,7 @@ export default class StringKeyColumnDefCellStrategy implements TableCellStrategy
         private tableId: string,
         private items: VsTableItem[],
         private columnDefs: string[],
+        private getRowKey: (item: VsTableItem) => string,
     ) {}
 
     public createHeaderCell(): VsTableHeaderCell[] {
@@ -22,18 +23,20 @@ export default class StringKeyColumnDefCellStrategy implements TableCellStrategy
         }));
     }
 
-    public createBodyCell(): VsTableBodyCell[][] {
+    public createBodyRows(): VsTableRow[] {
         const tag = 'td';
         return this.items.map((item: VsTableItem, rowIdx: number) => {
-            return this.columnDefs.map((headerKey: string, colIdx: number) => ({
+            const key = this.getRowKey(item);
+            const cells: VsTableBodyCell[] = this.columnDefs.map((headerKey: string, colIdx: number) => ({
                 tag,
-                id: `${this.tableId}-${stringUtil.kebabCase(headerKey)}-${rowIdx}`,
+                id: `${this.tableId}-${stringUtil.kebabCase(headerKey)}-${key}`,
                 value: objectUtil.get(item, headerKey),
                 item,
                 colKey: headerKey,
                 colIdx,
                 rowIdx,
             }));
+            return { key, item, cells };
         });
     }
 }

--- a/packages/vlossom/src/components/vs-table/models/table-cell-builder.ts
+++ b/packages/vlossom/src/components/vs-table/models/table-cell-builder.ts
@@ -1,5 +1,5 @@
-import { objectUtil } from '@/utils';
-import type { VsTableBodyCell, VsTableCell, VsTableColumnDef, VsTableHeaderCell, VsTableItem } from './../types';
+import { objectUtil, stringUtil } from '@/utils';
+import type { VsTableColumnDef, VsTableHeaderCell, VsTableItem, VsTableRow } from './../types';
 import { isVsTableColumnDefArray } from './table-model';
 import {
     NoColumnDefCellStrategy,
@@ -11,6 +11,9 @@ import {
 export class TableCellBuilder {
     private cellStrategy: TableCellStrategy;
 
+    // 행 key를 배열 인덱스가 아니라 아이템 객체의 동일성에 묶어, 아이템 추가/정렬 시에도 안정적으로 유지한다.
+    private readonly rowKeys = new WeakMap<object, string>();
+
     public constructor(
         private readonly tableId: string,
         private items: VsTableItem[],
@@ -19,14 +22,23 @@ export class TableCellBuilder {
         this.cellStrategy = this.getCellStrategy();
     }
 
+    private getRowKey = (item: VsTableItem): string => {
+        let key = this.rowKeys.get(item);
+        if (key === undefined) {
+            key = stringUtil.createID();
+            this.rowKeys.set(item, key);
+        }
+        return key;
+    };
+
     private getCellStrategy(): TableCellStrategy {
         if (!this.columnDefs?.length) {
-            return new NoColumnDefCellStrategy(this.tableId, this.items);
+            return new NoColumnDefCellStrategy(this.tableId, this.items, this.getRowKey);
         }
         if (isVsTableColumnDefArray(this.columnDefs)) {
-            return new ObjectColumnDefCellStrategy(this.tableId, this.items, this.columnDefs);
+            return new ObjectColumnDefCellStrategy(this.tableId, this.items, this.columnDefs, this.getRowKey);
         }
-        return new StringKeyColumnDefCellStrategy(this.tableId, this.items, this.columnDefs);
+        return new StringKeyColumnDefCellStrategy(this.tableId, this.items, this.columnDefs, this.getRowKey);
     }
 
     public updateItems(items: VsTableItem[]): TableCellBuilder {
@@ -47,9 +59,10 @@ export class TableCellBuilder {
         return this;
     }
 
-    public build(): VsTableCell[][] {
-        const headerCells: VsTableHeaderCell[] = this.cellStrategy.createHeaderCell();
-        const bodyCells: VsTableBodyCell[][] = this.cellStrategy.createBodyCell();
-        return [headerCells, ...bodyCells];
+    public build(): { header: VsTableHeaderCell[]; rows: VsTableRow[] } {
+        return {
+            header: this.cellStrategy.createHeaderCell(),
+            rows: this.cellStrategy.createBodyRows(),
+        };
     }
 }

--- a/packages/vlossom/src/components/vs-table/types.ts
+++ b/packages/vlossom/src/components/vs-table/types.ts
@@ -105,3 +105,9 @@ export interface VsTableBodyCell<I = VsTableItem> extends VsTableCell<I> {
     tag: 'td';
     item: I;
 }
+
+export interface VsTableRow<I = VsTableItem> {
+    key: string;
+    item: I;
+    cells: VsTableBodyCell<I>[];
+}

--- a/packages/vlossom/src/composables/option-list/__tests__/option-list-composable.test.ts
+++ b/packages/vlossom/src/composables/option-list/__tests__/option-list-composable.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { ref } from 'vue';
+import { useOptionList } from './../option-list-composable';
+
+describe('option-list-composable', () => {
+    describe('id', () => {
+        it('같은 객체 옵션은 순서가 바뀌어도 동일한 id를 유지한다', () => {
+            // given
+            const a = { name: 'A' };
+            const b = { name: 'B' };
+            const options = ref([a, b]);
+            const { computedOptions } = useOptionList(options, ref('name'), ref(''), ref(false));
+
+            const idA = computedOptions.value[0].id;
+            const idB = computedOptions.value[1].id;
+
+            // when
+            options.value = [b, a];
+
+            // then
+            expect(computedOptions.value[0].id).toBe(idB);
+            expect(computedOptions.value[1].id).toBe(idA);
+        });
+
+        it('label이 같아도 서로 다른 객체 옵션은 다른 id를 가진다', () => {
+            // given
+            const options = ref([{ name: 'same' }, { name: 'same' }]);
+
+            // when
+            const { computedOptions } = useOptionList(options, ref('name'), ref(''), ref(false));
+
+            // then
+            expect(computedOptions.value[0].id).not.toBe(computedOptions.value[1].id);
+        });
+
+        it('원시값 옵션의 id는 값 기반이라 순서가 바뀌어도 동일하다', () => {
+            // given
+            const options = ref(['apple', 'banana']);
+            const { computedOptions } = useOptionList(options, ref(''), ref(''), ref(false));
+
+            const idApple = computedOptions.value[0].id;
+            const idBanana = computedOptions.value[1].id;
+
+            // when
+            options.value = ['banana', 'apple'];
+
+            // then
+            expect(computedOptions.value[0].id).toBe(idBanana);
+            expect(computedOptions.value[1].id).toBe(idApple);
+        });
+
+        it('id는 CSS 선택자로 안전한 문자열이다(공백·앞자리 숫자 없음)', () => {
+            // given
+            const options = ref([42, 'a b', { name: 'obj' }]);
+
+            // when
+            const { computedOptions } = useOptionList(options, ref('name'), ref(''), ref(false));
+
+            // then
+            computedOptions.value.forEach(({ id }) => {
+                expect(id).toMatch(/^[A-Za-z]/);
+                expect(id).not.toContain(' ');
+            });
+        });
+    });
+});

--- a/packages/vlossom/src/composables/option-list/option-list-composable.ts
+++ b/packages/vlossom/src/composables/option-list/option-list-composable.ts
@@ -1,5 +1,5 @@
 import { computed, type Ref } from 'vue';
-import { stringUtil } from '@/utils';
+import { objectUtil, stringUtil } from '@/utils';
 import { useOptionLabelValue } from '@/composables/option-label-value/option-label-value-composable';
 
 export function useOptionList(
@@ -10,13 +10,28 @@ export function useOptionList(
 ) {
     const { getOptionLabel, getOptionValue } = useOptionLabelValue(optionLabel, optionValue);
 
+    const optionIdMap = new WeakMap<object, string>();
+
+    function getOptionId(option: any): string {
+        if (objectUtil.isObject(option)) {
+            let id = optionIdMap.get(option);
+            if (!id) {
+                id = stringUtil.createID();
+                optionIdMap.set(option, id);
+            }
+            return id;
+        }
+        // 원시값은 WeakMap에서 구분할 수 없기 때문에, hash로 정규화해 사용
+        return stringUtil.hash(String(option));
+    }
+
     const computedOptions = computed(() => {
         return options.value.map((option, index) => {
             const label = getOptionLabel(option);
             const value = getOptionValue(option);
 
             return {
-                id: stringUtil.hash(label + index), // unique id for each option
+                id: getOptionId(option),
                 item: option,
                 label,
                 value,


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
v-for key에 index가 바인딩 되면서 발생하는 remount 이슈 해결 (#577 )

## Description
- vs-table에 VsTableRow 타입을 추가해서 type이 key를 품고 있도록 정리 (model 추가 생성이 아님)
  - Cell[][] -> Row[]

### 기타
- option-list-composable도 index에 의존하는 부분이 있어서 제거
- vs-grouped-list도 option-list-composable에 영향 받는 부분이라 index binding 제거하는 방향으로 수정