### PR TITLE
feat(input): add focus-placeholder prop to input components

### DIFF
--- a/packages/vlossom/playground/views/Inputs.vue
+++ b/packages/vlossom/playground/views/Inputs.vue
@@ -36,7 +36,8 @@
             <vs-file-drop
                 v-model="files"
                 label="Upload Files"
-                placeholder="Drop files here"
+                placeholder="Drag files here or Click to select"
+                focus-placeholder="DROP THEM HERE !"
                 multiple
                 :grid="{ xs: 12, md: 6, lg: 3 }"
             />
@@ -48,7 +49,13 @@
 
         <h3 class="mb-4 font-semibold">VsInput</h3>
         <vs-form :grid-size="12" column-gap="1.5rem" row-gap="3rem">
-            <vs-input v-model="inputText" label="Text" placeholder="Enter text..." :grid="{ xs: 12, md: 6, lg: 3 }" />
+            <vs-input
+                v-model="inputText"
+                label="Text"
+                placeholder="Enter a fruit..."
+                focus-placeholder="e.g. apple, banana, cherry..."
+                :grid="{ xs: 12, md: 6, lg: 3 }"
+            />
             <vs-input placeholder="No label" :grid="{ xs: 12, md: 6, lg: 3 }" />
             <vs-input
                 v-model="inputNumber"
@@ -73,7 +80,11 @@
         <h3 class="mb-4 font-semibold">VsDatePicker</h3>
         <vs-form :grid-size="12" column-gap="1.5rem" row-gap="3rem">
             <vs-date-picker v-model="dpDate" type="date" label="Date" :grid="{ xs: 12, md: 6, lg: 3 }" />
-            <vs-date-picker placeholder="No label" :grid="{ xs: 12, md: 6, lg: 3 }" />
+            <vs-date-picker
+                placeholder="select Your birth date "
+                focus-placeholder="it will be presented as 'YYYY-MM-DD'"
+                :grid="{ xs: 12, md: 6, lg: 3 }"
+            />
             <vs-date-picker
                 v-model="dpDatetime"
                 type="datetime-local"
@@ -106,6 +117,7 @@
                 v-model="selectValue"
                 label="Basic"
                 placeholder="Select a fruit..."
+                focus-placeholder="Try click a fruit below options..."
                 :options="selectOptions"
                 :grid="{ xs: 12, md: 6, lg: 3 }"
             />
@@ -260,6 +272,7 @@
                 v-model="textareaValue"
                 label="Description"
                 placeholder="Enter description..."
+                :focus-placeholder="'e.g. ' + LOREM_IPSUM"
                 :grid="{ xs: 12, md: 6, lg: 3 }"
             />
             <vs-textarea placeholder="No label" :grid="{ xs: 12, md: 6, lg: 3 }" />
@@ -272,6 +285,17 @@
 <script lang="ts">
 import { defineComponent, ref, useTemplateRef, type Ref, type TemplateRef } from 'vue';
 import type { VsSearchInputRef } from '@/components/vs-search-input/types';
+
+const LOREM_IPSUM = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor 
+incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris 
+nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+velit esse nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia 
+deserunt mollit anim id est laborum. Fusce ac turpis quis ligula lacinia aliquet. Mauris ipsum. 
+Nulla metus metus, ullamcorper vel, tincidunt sed, euismod in, nibh. Quisque volutpat condimentum velit.
+Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Nam nec ante. 
+Vestibulum sapien. Proin quam. Etiam ultrices. Suspendisse in justo eu magna luctus suscipit. 
+Sed lectus. Integer euismod lacus luctus magna.  Integer id quam. Morbi mi. Quisque nisl felis,
+venenatis tristique, dignissim in, ultrices sit amet, augue. Proin sodales libero eget ante.`;
 
 export default defineComponent({
     name: 'Inputs',
@@ -353,6 +377,7 @@ export default defineComponent({
         const dpReadonlyValue: Ref<string> = ref('2026-05-18');
 
         return {
+            LOREM_IPSUM,
             inputText,
             inputNumber,
             inputPassword,

--- a/packages/vlossom/src/components/vs-date-picker/README.ko.md
+++ b/packages/vlossom/src/components/vs-date-picker/README.ko.md
@@ -96,7 +96,7 @@ value = '2026-05';
 
 값을 선택하거나 필드가 포커스를 잃으면 picker가 닫힙니다. `disabled`/`readonly` 상태에서는 모두 무시됩니다.
 
-> **placeholder 참고**: 네이티브 `date`/`time` input은 `placeholder` 속성을 무시합니다. 값이 비어 있고 picker가 닫혀 있는 동안에는 `text` input으로 렌더링해 `placeholder`가 보이게 하고, picker가 열리면 네이티브 picker 타입으로 전환합니다. 이 때문에 (picker가 열려 있을 때 노출되는) `focusPlaceholder`는 `date`/`time` 타입에서는 시각적 효과가 없습니다 — 네이티브 picker UI가 대신 표시됩니다.
+> **placeholder 참고**: 네이티브 `date`/`time` input은 `placeholder` 속성을 무시합니다. 값이 비어 있고 picker가 닫혀 있는 동안에는 `text` input으로 렌더링해 `placeholder`가 보이게 하고, picker가 열리면 네이티브 picker 타입으로 전환합니다.
 
 ## 커스텀 룰
 
@@ -127,7 +127,6 @@ value = '2026-05';
 | `size`           | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'`            | `'md'`      | -        | 입력 영역 높이 · 패딩 · 폰트 · 아이콘 크기 제어.                                       |
 | `label`          | `string`                                          | `''`        | -        | 라벨 텍스트.                                                                           |
 | `placeholder`    | `string`                                          | `''`        | -        | 플레이스홀더.                                                                          |
-| `focusPlaceholder` | `string`                                        | `''`        | -        | picker가 열려 있는 동안 표시되는 플레이스홀더. 그 외에는 `placeholder`로 대체. 위 참고. |
 | `disabled`       | `boolean`                                         | `false`     | -        | 컴포넌트 비활성화.                                                                     |
 | `readonly`       | `boolean`                                         | `false`     | -        | 읽기 전용.                                                                             |
 | `required`       | `boolean`                                         | `false`     | -        | `required` 룰 추가.                                                                    |

--- a/packages/vlossom/src/components/vs-date-picker/README.ko.md
+++ b/packages/vlossom/src/components/vs-date-picker/README.ko.md
@@ -11,7 +11,7 @@
 - 네이티브 `<input type>` 기반 4종 타입 지원: `date`, `datetime-local`, `time`, `month`.
 - `modelValue`는 항상 format-validated 문자열입니다. format은 `type` 으로부터 결정됩니다.
 - `required`, `min`/`max` (string), format 불일치 감지를 포함한 폼 유효성 검사.
-- 기본 지우기 버튼 + 캘린더 아이콘 버튼 제공. `open()`은 `showPicker()` feature detect 후 fallback.
+- 기본 지우기 버튼 + 캘린더/시계 아이콘 제공. 네이티브 picker는 클릭, Enter/Space, 또는 `open()` 메서드(`showPicker()`)로 열립니다.
 
 ## Basic Usage
 
@@ -83,20 +83,20 @@ value = '2026-05';
 ## 제한 사항
 
 - **`format` prop은 지원하지 않습니다.** 네이티브 picker는 브라우저/OS 로케일을 따르며 라이브러리가 이를 덮어쓸 수 없습니다. 특정 시각 포맷이 필요하면 별도 렌더링 레이어를 사용하세요.
-- **`open()` (showPicker)** 는 일부 브라우저에서 사용자 제스처를 요구합니다. 이벤트 핸들러 바깥에서 프로그래밍적으로 호출하면 조용히 `focus()`로 fallback될 수 있습니다.
+- **`open()` (`showPicker()`)** 는 대부분의 브라우저에서 사용자 제스처를 요구합니다. 사용자 제스처 핸들러 바깥에서 호출하면 브라우저가 무시할 수 있습니다.
 - **제약은 rule 기반으로만 적용됩니다.** `min`, `max`는 선택 값을 검증하지만 네이티브 picker UI로 forward되지는 않습니다.
 
 ### Picker 열기 동작
 
 네이티브 캘린더는 다음 중 하나로 열립니다:
 
-- input 영역(또는 캘린더 아이콘)을 클릭 — 열린 상태에서 다시 클릭하면 닫힙니다.
-- 필드가 포커스된 상태(클릭이든 Tab 이동이든)에서 **Enter** 키를 누르면 picker가 열리고, 다시 누르면 닫힙니다(토글).
+- input 영역(캘린더 아이콘 포함)을 클릭하거나,
+- 필드가 포커스된 상태(클릭이든 Tab 이동이든)에서 **Enter** 또는 **Space** 키를 누르거나,
 - 사용자 제스처 안에서 `dpRef.value.open()`을 호출.
 
-`disabled`/`readonly` 상태에서는 모두 무시됩니다.
+값을 선택하거나 필드가 포커스를 잃으면 picker가 닫힙니다. `disabled`/`readonly` 상태에서는 모두 무시됩니다.
 
-> **placeholder 참고**: 네이티브 `date`/`time` input은 `placeholder` 속성을 무시합니다. 값이 비어 있고 포커스되지 않은 동안에는 `text` input으로 렌더링해 `placeholder`가 보이게 하고, 상호작용 시 네이티브 picker 타입으로 전환합니다.
+> **placeholder 참고**: 네이티브 `date`/`time` input은 `placeholder` 속성을 무시합니다. 값이 비어 있고 picker가 닫혀 있는 동안에는 `text` input으로 렌더링해 `placeholder`가 보이게 하고, picker가 열리면 네이티브 picker 타입으로 전환합니다. 이 때문에 (picker가 열려 있을 때 노출되는) `focusPlaceholder`는 `date`/`time` 타입에서는 시각적 효과가 없습니다 — 네이티브 picker UI가 대신 표시됩니다.
 
 ## 커스텀 룰
 
@@ -127,6 +127,7 @@ value = '2026-05';
 | `size`           | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'`            | `'md'`      | -        | 입력 영역 높이 · 패딩 · 폰트 · 아이콘 크기 제어.                                       |
 | `label`          | `string`                                          | `''`        | -        | 라벨 텍스트.                                                                           |
 | `placeholder`    | `string`                                          | `''`        | -        | 플레이스홀더.                                                                          |
+| `focusPlaceholder` | `string`                                        | `''`        | -        | picker가 열려 있는 동안 표시되는 플레이스홀더. 그 외에는 `placeholder`로 대체. 위 참고. |
 | `disabled`       | `boolean`                                         | `false`     | -        | 컴포넌트 비활성화.                                                                     |
 | `readonly`       | `boolean`                                         | `false`     | -        | 읽기 전용.                                                                             |
 | `required`       | `boolean`                                         | `false`     | -        | `required` 룰 추가.                                                                    |
@@ -194,4 +195,4 @@ interface VsDatePickerStyleSet extends CSSProperties {
 | `validate` | -          | 유효성 검사를 트리거하고 결과를 반환합니다.                               |
 | `clear`    | -          | 값을 비웁니다 (modelValue → `''`).                                        |
 | `reset`    | -          | 값을 초기값으로 되돌립니다.                                               |
-| `open`     | -          | `showPicker()`로 네이티브 picker를 엽니다 (실패 시 `focus()`로 fallback). |
+| `open`     | -          | `showPicker()`로 네이티브 picker를 엽니다. 사용자 제스처 핸들러 안에서 호출하세요. |

--- a/packages/vlossom/src/components/vs-date-picker/README.md
+++ b/packages/vlossom/src/components/vs-date-picker/README.md
@@ -11,7 +11,7 @@ A native-first date picker component with form validation and format-validated s
 - Four input types: `date`, `datetime-local`, `time`, `month` — backed by native `<input type>`.
 - `modelValue` is always a format-validated string. The format is derived from `type`.
 - Form validation with `required`, `min`/`max` (string), and format-mismatch detection.
-- Built-in clear button and calendar icon button; `showPicker()` feature detection on `open()`.
+- Built-in clear button and a calendar/clock icon; the native picker opens on click, Enter/Space, or the `open()` method (`showPicker()`).
 
 ## Basic Usage
 
@@ -83,20 +83,20 @@ value = '2026-05';
 ## Limitations
 
 - **`format` prop is not supported.** Native pickers respect the browser/OS locale; the library cannot override this. Use a custom rendering layer if you need a specific visual format.
-- **`open()` (showPicker)** requires a user gesture in some browsers. Calling it programmatically (outside an event handler) may silently fall back to `focus()`.
+- **`open()` (`showPicker()`)** requires a user gesture in most browsers. Calling it outside a user-gesture handler may be ignored by the browser.
 - **Validation constraints are rule-based.** `min` and `max` validate the selected value but are not forwarded to the native picker UI.
 
 ### Picker Trigger
 
 The native calendar opens when:
 
-- the input area (or the calendar icon) is clicked — clicking again while it is open closes it, or
-- the **Enter** key is pressed while the field is focused (whether reached by click or by Tab) — Enter toggles the picker open and closed, or
+- the input area (including the calendar icon) is clicked, or
+- the **Enter** or **Space** key is pressed while the field is focused (whether reached by click or by Tab), or
 - `dpRef.value.open()` is invoked inside a user-gesture handler.
 
-When `disabled` or `readonly` is set, all triggers are no-ops.
+The picker closes when a value is selected or the field loses focus. When `disabled` or `readonly` is set, all triggers are no-ops.
 
-> **Placeholder note**: native `date`/`time` inputs ignore the `placeholder` attribute. While the field is empty and unfocused it is rendered as a `text` input so the `placeholder` is visible, then switched to the native picker type on interaction.
+> **Placeholder note**: native `date`/`time` inputs ignore the `placeholder` attribute. While the field is empty and the picker is closed it is rendered as a `text` input so the `placeholder` is visible, then switched to the native picker type when the picker opens. Because of this, `focusPlaceholder` (shown while the picker is open) has no visible effect on `date`/`time` types — the native picker UI is shown instead.
 
 ## Custom Rules
 
@@ -127,6 +127,7 @@ Default rules can be turned off via `noDefaultRules`.
 | `size`           | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'`            | `'md'`      | -        | Input height, padding, font, and icon size.                                                                         |
 | `label`          | `string`                                          | `''`        | -        | Label text.                                                                                                         |
 | `placeholder`    | `string`                                          | `''`        | -        | Placeholder.                                                                                                        |
+| `focusPlaceholder` | `string`                                        | `''`        | -        | Placeholder shown while the picker is open; falls back to `placeholder` otherwise. See the Placeholder note above.  |
 | `disabled`       | `boolean`                                         | `false`     | -        | Disables the component.                                                                                             |
 | `readonly`       | `boolean`                                         | `false`     | -        | Makes the component read-only.                                                                                      |
 | `required`       | `boolean`                                         | `false`     | -        | Adds `required` rule.                                                                                               |
@@ -194,4 +195,4 @@ interface VsDatePickerStyleSet extends CSSProperties {
 | `validate` | -          | Triggers validation and returns the result.                           |
 | `clear`    | -          | Clears the value (modelValue → `''`).                                 |
 | `reset`    | -          | Resets the value to its initial value.                                |
-| `open`     | -          | Opens the native picker via `showPicker()` (falls back to `focus()`). |
+| `open`     | -          | Opens the native picker via `showPicker()`. Call from within a user-gesture handler. |

--- a/packages/vlossom/src/components/vs-date-picker/README.md
+++ b/packages/vlossom/src/components/vs-date-picker/README.md
@@ -96,7 +96,7 @@ The native calendar opens when:
 
 The picker closes when a value is selected or the field loses focus. When `disabled` or `readonly` is set, all triggers are no-ops.
 
-> **Placeholder note**: native `date`/`time` inputs ignore the `placeholder` attribute. While the field is empty and the picker is closed it is rendered as a `text` input so the `placeholder` is visible, then switched to the native picker type when the picker opens. Because of this, `focusPlaceholder` (shown while the picker is open) has no visible effect on `date`/`time` types — the native picker UI is shown instead.
+> **Placeholder note**: native `date`/`time` inputs ignore the `placeholder` attribute. While the field is empty and the picker is closed it is rendered as a `text` input so the `placeholder` is visible, then switched to the native picker type when the picker opens.
 
 ## Custom Rules
 
@@ -127,7 +127,6 @@ Default rules can be turned off via `noDefaultRules`.
 | `size`           | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'`            | `'md'`      | -        | Input height, padding, font, and icon size.                                                                         |
 | `label`          | `string`                                          | `''`        | -        | Label text.                                                                                                         |
 | `placeholder`    | `string`                                          | `''`        | -        | Placeholder.                                                                                                        |
-| `focusPlaceholder` | `string`                                        | `''`        | -        | Placeholder shown while the picker is open; falls back to `placeholder` otherwise. See the Placeholder note above.  |
 | `disabled`       | `boolean`                                         | `false`     | -        | Disables the component.                                                                                             |
 | `readonly`       | `boolean`                                         | `false`     | -        | Makes the component read-only.                                                                                      |
 | `required`       | `boolean`                                         | `false`     | -        | Adds `required` rule.                                                                                               |

--- a/packages/vlossom/src/components/vs-date-picker/VsDatePicker.vue
+++ b/packages/vlossom/src/components/vs-date-picker/VsDatePicker.vue
@@ -175,7 +175,6 @@ export default defineComponent({
             readonly,
             messages,
             placeholder,
-            focusPlaceholder,
             rules,
             noDefaultRules,
             state,
@@ -222,9 +221,6 @@ export default defineComponent({
         );
 
         const computedPlaceholder = computed<string>(() => {
-            if (pickerOpen.value && focusPlaceholder.value) {
-                return focusPlaceholder.value;
-            }
             return placeholder.value || TYPE_TO_FORMAT[type.value];
         });
 

--- a/packages/vlossom/src/components/vs-date-picker/VsDatePicker.vue
+++ b/packages/vlossom/src/components/vs-date-picker/VsDatePicker.vue
@@ -287,6 +287,10 @@ export default defineComponent({
         }
 
         async function onClick(): Promise<void> {
+            if (pickerOpen.value) {
+                pickerOpen.value = false;
+                return;
+            }
             await openPicker();
         }
 
@@ -298,6 +302,11 @@ export default defineComponent({
             pickerOpen.value = true;
 
             await nextTick();
+
+            if (typeof dateInputRef.value?.inputRef?.showPicker !== 'function') {
+                pickerOpen.value = false;
+                return;
+            }
             dateInputRef.value?.inputRef?.showPicker();
         }
 

--- a/packages/vlossom/src/components/vs-date-picker/VsDatePicker.vue
+++ b/packages/vlossom/src/components/vs-date-picker/VsDatePicker.vue
@@ -183,7 +183,7 @@ export default defineComponent({
         const dateInputRef: TemplateRef<VsInputRef> = useTemplateRef('dateInputRef');
 
         const inputValue: Ref<VsDatePickerValueType> = ref(modelValue.value);
-        const pickerOpen: Ref<boolean> = ref(false); // 네이티브 picker는 열기/닫기 API가 없어 상태를 직접 추적
+        const pickerOpen = ref(false); // 네이티브 picker는 열기/닫기 API가 없어 상태를 직접 추적
 
         const { componentStyleSet } = useStyleSet<VsDatePickerStyleSet>(componentName, styleSet);
 

--- a/packages/vlossom/src/components/vs-date-picker/VsDatePicker.vue
+++ b/packages/vlossom/src/components/vs-date-picker/VsDatePicker.vue
@@ -39,9 +39,9 @@
             @update:model-value="onDateInput"
             @focus="onFocus"
             @blur="onBlur"
-            @pointerdown="onPointerDown"
-            @click="onClick"
-            @keydown.enter.stop="onKeydownEnter"
+            @click.prevent.stop="onClick"
+            @keydown.enter.stop="open"
+            @keydown.space.prevent.stop="open"
         >
             <template #prepend>
                 <slot v-if="$slots['prepend']" name="prepend" />
@@ -62,6 +62,7 @@
 import {
     computed,
     defineComponent,
+    nextTick,
     ref,
     toRefs,
     useTemplateRef,
@@ -74,6 +75,7 @@ import {
 import { VsComponent, type Size } from '@/declaration';
 import { logUtil } from '@/utils';
 import { useStyleSet, useInput } from '@/composables';
+import type { VsInputRef, VsInputType } from '@/components';
 import { getInputProps, getResponsiveProps, getColorSchemeProps, getStyleSetProps } from '@/props';
 
 import { FORMAT_PATTERNS, TYPE_TO_FORMAT } from './constants';
@@ -81,7 +83,6 @@ import { type VsDatePickerStyleSet, type VsDatePickerType, type VsDatePickerValu
 import { useVsDatePickerRules } from './vs-date-picker-rules';
 
 import { CalendarIcon, ClockIcon } from '@lucide/vue';
-import type { VsInputRef, VsInputType } from '@/components/vs-input/types';
 import VsInput from '@/components/vs-input/VsInput.vue';
 import VsInputWrapper from '@/components/vs-input-wrapper/VsInputWrapper.vue';
 
@@ -174,6 +175,7 @@ export default defineComponent({
             readonly,
             messages,
             placeholder,
+            focusPlaceholder,
             rules,
             noDefaultRules,
             state,
@@ -182,11 +184,7 @@ export default defineComponent({
         const dateInputRef: TemplateRef<VsInputRef> = useTemplateRef('dateInputRef');
 
         const inputValue: Ref<VsDatePickerValueType> = ref(modelValue.value);
-        const isFocused = ref(false);
-        const pointerInitiated = ref(false);
-        // 네이티브 picker는 열기/닫기 API가 없어 상태를 직접 추적
-        const pickerOpen = ref(false);
-        const suppressFocusEvents = ref(false);
+        const pickerOpen: Ref<boolean> = ref(false); // 네이티브 picker는 열기/닫기 API가 없어 상태를 직접 추적
 
         const { componentStyleSet } = useStyleSet<VsDatePickerStyleSet>(componentName, styleSet);
 
@@ -224,10 +222,10 @@ export default defineComponent({
         );
 
         const computedPlaceholder = computed<string>(() => {
-            if (!placeholder.value) {
-                return TYPE_TO_FORMAT[type.value];
+            if (pickerOpen.value && focusPlaceholder.value) {
+                return focusPlaceholder.value;
             }
-            return placeholder.value;
+            return placeholder.value || TYPE_TO_FORMAT[type.value];
         });
 
         const displayValue = computed<string>(() => {
@@ -244,9 +242,12 @@ export default defineComponent({
             return CalendarIcon;
         });
 
-        // date/time input은 placeholder를 무시 → 비어있고 비포커스면 text로 노출 후 네이티브 타입으로 캐스팅
+        /**
+         * input type 'date/time'는 custom placeholder 설정 값을 무시하고 native placeholder를 노출한다.
+         * input type 'text'로 우회하여 custom placeholder가 노출되도록 강제한다.
+         */
         const deceiveType = computed<VsInputType>(() => {
-            if (!isFocused.value && !displayValue.value) {
+            if (!pickerOpen.value && !displayValue.value) {
                 return 'text';
             }
             return type.value as unknown as VsInputType;
@@ -273,106 +274,35 @@ export default defineComponent({
         }
 
         function focus(): void {
-            dateInputRef.value?.focus();
+            dateInputRef.value?.inputRef?.focus();
         }
 
         function blur(): void {
-            dateInputRef.value?.blur();
-        }
-
-        function onPointerDown(): void {
-            pointerInitiated.value = true;
+            dateInputRef.value?.inputRef?.blur();
         }
 
         function onFocus(e: FocusEvent): void {
-            // 포인터 focus는 click까지 text 유지(타입 변경 시 click 무시), 키보드 focus는 즉시 전환
-            if (!pointerInitiated.value) {
-                isFocused.value = true;
-            }
-            if (suppressFocusEvents.value) {
-                return;
-            }
             emit('focus', e);
         }
 
         function onBlur(e: FocusEvent): void {
-            isFocused.value = false;
-            pointerInitiated.value = false;
             pickerOpen.value = false;
-            if (suppressFocusEvents.value) {
-                return;
-            }
             emit('blur', e);
         }
 
-        // text→네이티브 타입 전환 후 picker 열기. click 핸들러 안에서 해야 제스처가 유지돼 첫 click에 열림
-        function openPicker(): void {
+        async function onClick(): Promise<void> {
+            await openPicker();
+        }
+
+        async function openPicker(): Promise<void> {
             if (computedDisabled.value || computedReadonly.value) {
                 return;
             }
 
-            const input = dateInputRef.value?.inputRef;
-            if (!input) {
-                return;
-            }
-
-            isFocused.value = true;
-            if (input.type !== type.value) {
-                input.type = type.value;
-            }
-
-            input.focus();
-
-            const showPicker = input.showPicker;
-            if (typeof showPicker === 'function') {
-                showPicker.call(input);
-            }
             pickerOpen.value = true;
-        }
 
-        // 포커스 유지하며 닫는 API가 없어 blur로 닫고 재포커스
-        function closePicker(input: HTMLInputElement): void {
-            pickerOpen.value = false;
-            suppressFocusEvents.value = true;
-            input.blur();
-            input.focus();
-            suppressFocusEvents.value = false;
-        }
-
-        // 토글: 열린 picker는 mousedown에서 브라우저가 닫으므로 재오픈만 안 하면 됨
-        function onClick(): void {
-            pointerInitiated.value = false;
-
-            if (computedDisabled.value || computedReadonly.value) {
-                return;
-            }
-
-            if (pickerOpen.value) {
-                pickerOpen.value = false;
-                return;
-            }
-
-            openPicker();
-        }
-
-        function onKeydownEnter(e: KeyboardEvent): void {
-            if (computedDisabled.value || computedReadonly.value) {
-                return;
-            }
-
-            const input = dateInputRef.value?.inputRef;
-            if (!input) {
-                return;
-            }
-
-            e.preventDefault();
-
-            if (pickerOpen.value) {
-                closePicker(input);
-                return;
-            }
-
-            openPicker();
+            await nextTick();
+            dateInputRef.value?.inputRef?.showPicker();
         }
 
         watch(
@@ -404,9 +334,7 @@ export default defineComponent({
 
             // Methods
             onDateInput,
-            onPointerDown,
             onClick,
-            onKeydownEnter,
             onFocus,
             onBlur,
             focus,

--- a/packages/vlossom/src/components/vs-date-picker/__stories__/vs-date-picker.stories.ts
+++ b/packages/vlossom/src/components/vs-date-picker/__stories__/vs-date-picker.stories.ts
@@ -43,6 +43,12 @@ const meta: Meta<typeof VsDatePicker> = {
             description: '플레이스홀더 텍스트',
             table: { category: 'Input Props' },
         },
+        focusPlaceholder: {
+            control: 'text',
+            description:
+                'picker가 열려 있는 동안 표시되는 플레이스홀더. date/time 타입은 열리면 네이티브 picker가 표시되어 시각적 효과는 없습니다.',
+            table: { category: 'Input Props' },
+        },
         noClear: {
             control: 'boolean',
             description: 'clear 버튼 숨김',
@@ -165,6 +171,23 @@ export const WithLabel: Story = {
     args: {
         label: '시작일',
         placeholder: '날짜를 선택하세요',
+    },
+};
+
+export const FocusPlaceholder: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    'focusPlaceholder는 picker가 열려 있는 동안 노출되는 플레이스홀더입니다. ' +
+                    '단, date/time 타입은 picker가 열리면 네이티브 picker UI가 표시되므로 시각적 효과는 없습니다.',
+            },
+        },
+    },
+    args: {
+        label: '날짜',
+        placeholder: '날짜를 선택하세요',
+        focusPlaceholder: 'YYYY-MM-DD',
     },
 };
 

--- a/packages/vlossom/src/components/vs-date-picker/__stories__/vs-date-picker.stories.ts
+++ b/packages/vlossom/src/components/vs-date-picker/__stories__/vs-date-picker.stories.ts
@@ -43,12 +43,6 @@ const meta: Meta<typeof VsDatePicker> = {
             description: '플레이스홀더 텍스트',
             table: { category: 'Input Props' },
         },
-        focusPlaceholder: {
-            control: 'text',
-            description:
-                'picker가 열려 있는 동안 표시되는 플레이스홀더. date/time 타입은 열리면 네이티브 picker가 표시되어 시각적 효과는 없습니다.',
-            table: { category: 'Input Props' },
-        },
         noClear: {
             control: 'boolean',
             description: 'clear 버튼 숨김',
@@ -171,23 +165,6 @@ export const WithLabel: Story = {
     args: {
         label: '시작일',
         placeholder: '날짜를 선택하세요',
-    },
-};
-
-export const FocusPlaceholder: Story = {
-    parameters: {
-        docs: {
-            description: {
-                story:
-                    'focusPlaceholder는 picker가 열려 있는 동안 노출되는 플레이스홀더입니다. ' +
-                    '단, date/time 타입은 picker가 열리면 네이티브 picker UI가 표시되므로 시각적 효과는 없습니다.',
-            },
-        },
-    },
-    args: {
-        label: '날짜',
-        placeholder: '날짜를 선택하세요',
-        focusPlaceholder: 'YYYY-MM-DD',
     },
 };
 

--- a/packages/vlossom/src/components/vs-date-picker/__tests__/vs-date-picker.test.ts
+++ b/packages/vlossom/src/components/vs-date-picker/__tests__/vs-date-picker.test.ts
@@ -379,46 +379,4 @@ describe('VsDatePicker', () => {
         });
     });
 
-    describe('focusPlaceholder', () => {
-        it('picker가 열리면 focusPlaceholder를, 닫히면 placeholder를 노출한다', async () => {
-            const wrapper = mount(VsDatePicker, {
-                props: {
-                    modelValue: '',
-                    type: 'date',
-                    placeholder: 'Select date',
-                    focusPlaceholder: 'YYYY-MM-DD',
-                },
-            });
-            const inputEl = findDateInput(wrapper).element as HTMLInputElement & { showPicker?: () => void };
-            inputEl.showPicker = vi.fn();
-
-            // given: picker가 닫혀 있으면 placeholder를 노출한다.
-            expect(findDateInput(wrapper).attributes('placeholder')).toBe('Select date');
-
-            // when: 클릭으로 picker를 연다.
-            await findDateInput(wrapper).trigger('click');
-            await flushPromises();
-
-            // then: focusPlaceholder를 노출한다.
-            expect(findDateInput(wrapper).attributes('placeholder')).toBe('YYYY-MM-DD');
-
-            // when: blur로 picker가 닫힌다.
-            await findDateInput(wrapper).trigger('blur');
-
-            // then: 다시 placeholder를 노출한다.
-            expect(findDateInput(wrapper).attributes('placeholder')).toBe('Select date');
-        });
-
-        it('focusPlaceholder가 없으면 picker가 열려도 placeholder를 유지한다', async () => {
-            const wrapper = mount(VsDatePicker, {
-                props: { modelValue: '', type: 'date', placeholder: 'Select date' },
-            });
-            const inputEl = findDateInput(wrapper).element as HTMLInputElement & { showPicker?: () => void };
-            inputEl.showPicker = vi.fn();
-
-            await findDateInput(wrapper).trigger('click');
-            await flushPromises();
-            expect(findDateInput(wrapper).attributes('placeholder')).toBe('Select date');
-        });
-    });
 });

--- a/packages/vlossom/src/components/vs-date-picker/__tests__/vs-date-picker.test.ts
+++ b/packages/vlossom/src/components/vs-date-picker/__tests__/vs-date-picker.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { mount } from '@vue/test-utils';
+import { mount, flushPromises } from '@vue/test-utils';
 import { nextTick, defineComponent } from 'vue';
 import VsDatePicker from '../VsDatePicker.vue';
 import VsForm from '@/components/vs-form/VsForm.vue';
@@ -10,18 +10,22 @@ function findDateInput(wrapper: ReturnType<typeof mount>) {
 
 describe('VsDatePicker', () => {
     describe('datetime 기본 동작', () => {
-        it('type=date에서 포커스되면 VsInput 내부 input의 type 속성이 date여야 한다', async () => {
+        it('type=date에서 클릭으로 picker를 열면 VsInput 내부 input의 type 속성이 date가 된다', async () => {
             const wrapper = mount(VsDatePicker, {
                 props: { modelValue: '', type: 'date' },
             });
-            // 빈 값 + 비포커스 상태에서는 placeholder 노출을 위해 text 타입으로 렌더링된다.
+            const inputEl = findDateInput(wrapper).element as HTMLInputElement & { showPicker?: () => void };
+            inputEl.showPicker = vi.fn();
+            // 빈 값 + picker 닫힘 상태에서는 placeholder 노출을 위해 text 타입으로 렌더링된다.
             expect(findDateInput(wrapper).attributes('type')).toBe('text');
 
-            await findDateInput(wrapper).trigger('focus');
+            // picker가 열리면 native picker 타입으로 전환된다.
+            await findDateInput(wrapper).trigger('click');
+            await flushPromises();
             expect(findDateInput(wrapper).attributes('type')).toBe('date');
         });
 
-        it('type 4종 (date/datetime-local/time/month) 전환', async () => {
+        it('type 4종 (date/datetime-local/time/month) — 클릭으로 열면 native picker type으로 전환된다', async () => {
             const types: Array<'date' | 'datetime-local' | 'time' | 'month'> = [
                 'date',
                 'datetime-local',
@@ -32,8 +36,11 @@ describe('VsDatePicker', () => {
                 const wrapper = mount(VsDatePicker, {
                     props: { modelValue: '', type: t },
                 });
-                // 포커스되면 native picker type으로 전환된다.
-                await findDateInput(wrapper).trigger('focus');
+                const inputEl = findDateInput(wrapper).element as HTMLInputElement & { showPicker?: () => void };
+                inputEl.showPicker = vi.fn();
+                // picker가 열리면 native picker type으로 전환된다.
+                await findDateInput(wrapper).trigger('click');
+                await flushPromises();
                 expect(findDateInput(wrapper).attributes('type')).toBe(t);
             }
         });
@@ -103,7 +110,7 @@ describe('VsDatePicker', () => {
             expect(w2.find('.vs-clear-button').exists()).toBe(false);
         });
 
-        it('open() 메서드는 showPicker가 있으면 호출하고 없으면 focus한다', () => {
+        it('open() 메서드는 native picker의 showPicker를 호출한다', async () => {
             const wrapper = mount(VsDatePicker, {
                 props: { modelValue: '', type: 'date' },
             });
@@ -112,7 +119,7 @@ describe('VsDatePicker', () => {
             };
             const showPicker = vi.fn();
             input.showPicker = showPicker;
-            (wrapper.vm as unknown as { open: () => void }).open();
+            await (wrapper.vm as unknown as { open: () => Promise<void> }).open();
             expect(showPicker).toHaveBeenCalled();
         });
 
@@ -193,11 +200,15 @@ describe('VsDatePicker', () => {
             expect(input.attributes('placeholder')).toBe('Select date');
         });
 
-        it('포커스 시 native picker type으로 전환되고 blur 후 빈 값이면 다시 text로 돌아간다', async () => {
+        it('클릭으로 picker를 열면 native picker type으로 전환되고 blur 후 빈 값이면 다시 text로 돌아간다', async () => {
             const wrapper = mount(VsDatePicker, {
                 props: { modelValue: '', type: 'date', placeholder: 'Select date' },
             });
-            await findDateInput(wrapper).trigger('focus');
+            const inputEl = findDateInput(wrapper).element as HTMLInputElement & { showPicker?: () => void };
+            inputEl.showPicker = vi.fn();
+
+            await findDateInput(wrapper).trigger('click');
+            await flushPromises();
             expect(findDateInput(wrapper).attributes('type')).toBe('date');
 
             await findDateInput(wrapper).trigger('blur');
@@ -210,31 +221,9 @@ describe('VsDatePicker', () => {
             });
             expect(findDateInput(wrapper).attributes('type')).toBe('date');
         });
-
-        it('pointer로 인한 focus 시에는 click 전까지 text 타입을 유지하고, click 시 native picker로 전환하며 picker를 연다', async () => {
-            // pointerdown -> focus 사이에 type을 바꾸면 브라우저가 click 이벤트를 삼켜
-            // 클릭-투-오픈이 깨진다. 따라서 pointer focus 동안에는 text를 유지해야 한다.
-            const wrapper = mount(VsDatePicker, {
-                props: { modelValue: '', type: 'date', placeholder: 'Select date' },
-            });
-            const inputEl = findDateInput(wrapper).element as HTMLInputElement & {
-                showPicker?: () => void;
-            };
-            const showPicker = vi.fn();
-            inputEl.showPicker = showPicker;
-
-            await findDateInput(wrapper).trigger('pointerdown');
-            await findDateInput(wrapper).trigger('focus');
-            // pointer로 인한 focus 동안에는 click을 삼키지 않도록 text 타입을 유지한다.
-            expect(findDateInput(wrapper).attributes('type')).toBe('text');
-
-            await findDateInput(wrapper).trigger('click');
-            expect(findDateInput(wrapper).attributes('type')).toBe('date');
-            expect(showPicker).toHaveBeenCalledTimes(1);
-        });
     });
 
-    describe('picker toggle', () => {
+    describe('picker open', () => {
         function withShowPicker(wrapper: ReturnType<typeof mount>) {
             const inputEl = findDateInput(wrapper).element as HTMLInputElement & {
                 showPicker?: () => void;
@@ -244,22 +233,44 @@ describe('VsDatePicker', () => {
             return showPicker;
         }
 
-        it('첫 클릭은 picker를 열고, 다시 클릭하면 다시 열지 않는다 (토글로 닫힘)', async () => {
+        it('클릭할 때마다 showPicker를 호출해 picker를 연다 (토글로 닫는 동작 없음)', async () => {
             const wrapper = mount(VsDatePicker, {
                 props: { modelValue: '', type: 'date' },
             });
             const showPicker = withShowPicker(wrapper);
 
             await findDateInput(wrapper).trigger('click');
+            await flushPromises();
             expect(showPicker).toHaveBeenCalledTimes(1);
 
-            // 열린 상태에서 다시 클릭하면 재오픈하지 않는다 (브라우저가 mousedown에서 닫음).
+            // 토글로 닫는 동작이 없으므로 다시 클릭하면 또 연다.
             await findDateInput(wrapper).trigger('click');
-            expect(showPicker).toHaveBeenCalledTimes(1);
-
-            // 닫힌 뒤 다시 클릭하면 다시 열린다.
-            await findDateInput(wrapper).trigger('click');
+            await flushPromises();
             expect(showPicker).toHaveBeenCalledTimes(2);
+        });
+
+        it('Enter 키로 picker를 연다', async () => {
+            const wrapper = mount(VsDatePicker, {
+                props: { modelValue: '', type: 'date' },
+            });
+            const showPicker = withShowPicker(wrapper);
+
+            await findDateInput(wrapper).trigger('focus');
+            await findDateInput(wrapper).trigger('keydown', { key: 'Enter' });
+            await flushPromises();
+            expect(showPicker).toHaveBeenCalledTimes(1);
+        });
+
+        it('Space 키로 picker를 연다', async () => {
+            const wrapper = mount(VsDatePicker, {
+                props: { modelValue: '', type: 'date' },
+            });
+            const showPicker = withShowPicker(wrapper);
+
+            await findDateInput(wrapper).trigger('focus');
+            await findDateInput(wrapper).trigger('keydown', { key: ' ' });
+            await flushPromises();
+            expect(showPicker).toHaveBeenCalledTimes(1);
         });
 
         it('blur 후 다시 클릭하면 picker가 다시 열린다', async () => {
@@ -269,48 +280,28 @@ describe('VsDatePicker', () => {
             const showPicker = withShowPicker(wrapper);
 
             await findDateInput(wrapper).trigger('click');
+            await flushPromises();
             expect(showPicker).toHaveBeenCalledTimes(1);
 
             await findDateInput(wrapper).trigger('blur');
             await findDateInput(wrapper).trigger('click');
+            await flushPromises();
             expect(showPicker).toHaveBeenCalledTimes(2);
         });
 
-        it('Enter 키로 picker를 열고 닫을 수 있다 (포커스 유지)', async () => {
-            const wrapper = mount(VsDatePicker, {
-                props: { modelValue: '', type: 'date' },
-            });
-            const showPicker = withShowPicker(wrapper);
-
-            await findDateInput(wrapper).trigger('focus');
-
-            // Enter로 열기
-            await findDateInput(wrapper).trigger('keydown', { key: 'Enter' });
-            expect(showPicker).toHaveBeenCalledTimes(1);
-
-            // Enter로 닫기 (재오픈 없음)
-            await findDateInput(wrapper).trigger('keydown', { key: 'Enter' });
-            expect(showPicker).toHaveBeenCalledTimes(1);
-
-            // Enter로 다시 열기
-            await findDateInput(wrapper).trigger('keydown', { key: 'Enter' });
-            expect(showPicker).toHaveBeenCalledTimes(2);
-        });
-
-        it('값을 선택하면 picker 상태가 닫힘으로 리셋되어 다음 클릭에 다시 열린다', async () => {
+        it('값을 선택하면 picker 상태가 닫힘으로 리셋된다', async () => {
             const wrapper = mount(VsDatePicker, {
                 props: { modelValue: '', type: 'date' },
             });
             const showPicker = withShowPicker(wrapper);
 
             await findDateInput(wrapper).trigger('click');
+            await flushPromises();
             expect(showPicker).toHaveBeenCalledTimes(1);
 
-            // 값 선택 = picker 닫힘
+            // 값 선택 = picker 닫힘 (pickerOpen=false), 값이 있으므로 native type은 유지된다.
             await findDateInput(wrapper).setValue('2026-05-18');
-
-            await findDateInput(wrapper).trigger('click');
-            expect(showPicker).toHaveBeenCalledTimes(2);
+            expect(findDateInput(wrapper).attributes('type')).toBe('date');
         });
 
         it('disabled/readonly 상태에서는 클릭/Enter로 picker가 열리지 않는다', async () => {
@@ -322,6 +313,7 @@ describe('VsDatePicker', () => {
 
                 await findDateInput(wrapper).trigger('click');
                 await findDateInput(wrapper).trigger('keydown', { key: 'Enter' });
+                await flushPromises();
                 expect(showPicker).not.toHaveBeenCalled();
             }
         });
@@ -384,6 +376,49 @@ describe('VsDatePicker', () => {
             });
             await wrapper.setProps({ type: 'datetime-local' });
             expect(wrapper.emitted('update:modelValue')).toBeFalsy();
+        });
+    });
+
+    describe('focusPlaceholder', () => {
+        it('picker가 열리면 focusPlaceholder를, 닫히면 placeholder를 노출한다', async () => {
+            const wrapper = mount(VsDatePicker, {
+                props: {
+                    modelValue: '',
+                    type: 'date',
+                    placeholder: 'Select date',
+                    focusPlaceholder: 'YYYY-MM-DD',
+                },
+            });
+            const inputEl = findDateInput(wrapper).element as HTMLInputElement & { showPicker?: () => void };
+            inputEl.showPicker = vi.fn();
+
+            // given: picker가 닫혀 있으면 placeholder를 노출한다.
+            expect(findDateInput(wrapper).attributes('placeholder')).toBe('Select date');
+
+            // when: 클릭으로 picker를 연다.
+            await findDateInput(wrapper).trigger('click');
+            await flushPromises();
+
+            // then: focusPlaceholder를 노출한다.
+            expect(findDateInput(wrapper).attributes('placeholder')).toBe('YYYY-MM-DD');
+
+            // when: blur로 picker가 닫힌다.
+            await findDateInput(wrapper).trigger('blur');
+
+            // then: 다시 placeholder를 노출한다.
+            expect(findDateInput(wrapper).attributes('placeholder')).toBe('Select date');
+        });
+
+        it('focusPlaceholder가 없으면 picker가 열려도 placeholder를 유지한다', async () => {
+            const wrapper = mount(VsDatePicker, {
+                props: { modelValue: '', type: 'date', placeholder: 'Select date' },
+            });
+            const inputEl = findDateInput(wrapper).element as HTMLInputElement & { showPicker?: () => void };
+            inputEl.showPicker = vi.fn();
+
+            await findDateInput(wrapper).trigger('click');
+            await flushPromises();
+            expect(findDateInput(wrapper).attributes('placeholder')).toBe('Select date');
         });
     });
 });

--- a/packages/vlossom/src/components/vs-date-picker/__tests__/vs-date-picker.test.ts
+++ b/packages/vlossom/src/components/vs-date-picker/__tests__/vs-date-picker.test.ts
@@ -233,7 +233,7 @@ describe('VsDatePicker', () => {
             return showPicker;
         }
 
-        it('클릭할 때마다 showPicker를 호출해 picker를 연다 (토글로 닫는 동작 없음)', async () => {
+        it('클릭할 때마다 showPicker를 호출해 picker를 연다', async () => {
             const wrapper = mount(VsDatePicker, {
                 props: { modelValue: '', type: 'date' },
             });
@@ -242,11 +242,6 @@ describe('VsDatePicker', () => {
             await findDateInput(wrapper).trigger('click');
             await flushPromises();
             expect(showPicker).toHaveBeenCalledTimes(1);
-
-            // 토글로 닫는 동작이 없으므로 다시 클릭하면 또 연다.
-            await findDateInput(wrapper).trigger('click');
-            await flushPromises();
-            expect(showPicker).toHaveBeenCalledTimes(2);
         });
 
         it('Enter 키로 picker를 연다', async () => {
@@ -378,5 +373,4 @@ describe('VsDatePicker', () => {
             expect(wrapper.emitted('update:modelValue')).toBeFalsy();
         });
     });
-
 });

--- a/packages/vlossom/src/components/vs-file-drop/README.ko.md
+++ b/packages/vlossom/src/components/vs-file-drop/README.ko.md
@@ -62,6 +62,21 @@ const files = ref([]);
 </template>
 ```
 
+### 포커스 플레이스홀더
+
+파일을 영역 위로 드래그하거나 파일 다이얼로그가 열려 있는 동안 다른 안내 문구를 표시합니다:
+
+```html
+<template>
+    <vs-file-drop
+        v-model="files"
+        label="업로드"
+        placeholder="파일을 여기에 드롭하거나 클릭해서 선택하세요"
+        focus-placeholder="여기에 놓으세요"
+    />
+</template>
+```
+
 ## Props
 
 | Prop | 타입 | 기본값 | 필수 | 설명 |
@@ -79,6 +94,7 @@ const files = ref([]);
 | `name` | `string` | `''` | | 입력의 HTML name 속성 |
 | `noDefaultRules` | `boolean` | `false` | | 기본 유효성 검사 규칙 비활성화 |
 | `placeholder` | `string` | `''` | | 드롭 영역에 표시되는 플레이스홀더 텍스트 |
+| `focusPlaceholder` | `string` | `''` | | 파일을 영역 위로 드래그하거나 파일 다이얼로그가 열려 있는 동안 표시되는 플레이스홀더. 그 외에는 `placeholder`로 대체 |
 | `readonly` | `boolean` | `false` | | 컴포넌트를 읽기 전용으로 만들기 |
 | `rules` | `Rule[]` | `[]` | | 사용자 정의 유효성 검사 규칙 |
 | `state` | `'idle' \| 'info' \| 'success' \| 'warning' \| 'error'` | `'idle'` | | 현재 유효성 검사 상태 |

--- a/packages/vlossom/src/components/vs-file-drop/README.md
+++ b/packages/vlossom/src/components/vs-file-drop/README.md
@@ -62,6 +62,21 @@ const files = ref([]);
 </template>
 ```
 
+### Focus Placeholder
+
+Show a different hint while a file is being dragged over the area or the file dialog is open:
+
+```html
+<template>
+    <vs-file-drop
+        v-model="files"
+        label="Upload"
+        placeholder="Drop files here or click to select"
+        focus-placeholder="Release to drop"
+    />
+</template>
+```
+
 ## Props
 
 | Prop | Type | Default | Required | Description |
@@ -79,6 +94,7 @@ const files = ref([]);
 | `name` | `string` | `''` | | HTML name attribute for the input |
 | `noDefaultRules` | `boolean` | `false` | | Disable default validation rules |
 | `placeholder` | `string` | `''` | | Placeholder text shown in the drop area |
+| `focusPlaceholder` | `string` | `''` | | Placeholder shown while a file is dragged over the area or the file dialog is open; falls back to `placeholder` otherwise |
 | `readonly` | `boolean` | `false` | | Make the component read-only |
 | `rules` | `Rule[]` | `[]` | | Custom validation rules |
 | `state` | `'idle' \| 'info' \| 'success' \| 'warning' \| 'error'` | `'idle'` | | Current validation state |

--- a/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
+++ b/packages/vlossom/src/components/vs-file-drop/VsFileDrop.vue
@@ -38,6 +38,7 @@
                 :accept
                 :multiple
                 @change.stop="handleFileDialog"
+                @click.stop="onClick"
                 @focus.stop="onFocus"
                 @blur.stop="onBlur"
                 @keydown.enter.stop="openFileDialog"
@@ -48,7 +49,7 @@
                 <slot :dragging="dragging">
                     <div class="vs-file-drop-placeholder" :style="componentStyleSet.$placeholder">
                         <PaperclipIcon class="placeholder-icon" :stroke-width="2.5" />
-                        <span class="placeholder-text">{{ placeholder }}</span>
+                        <span class="placeholder-text">{{ computedPlaceholder }}</span>
                     </div>
 
                     <div v-if="hasValue" class="vs-file-drop-files" :style="componentStyleSet.$files">
@@ -95,7 +96,17 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, ref, toRefs, useTemplateRef, type PropType, type Ref, type TemplateRef } from 'vue';
+import {
+    computed,
+    defineComponent,
+    ref,
+    toRefs,
+    useTemplateRef,
+    type ComputedRef,
+    type PropType,
+    type Ref,
+    type TemplateRef,
+} from 'vue';
 import { VsComponent, type Breakpoints, type StateMessage } from '@/declaration';
 import { useColorScheme, useStyleSet, useInput, useStateClass } from '@/composables';
 import { getInputProps, getResponsiveProps, getColorSchemeProps, getStyleSetProps, getMinMaxProps } from '@/props';
@@ -149,11 +160,14 @@ export default defineComponent({
             min,
             width,
             height,
+            placeholder,
+            focusPlaceholder,
         } = toRefs(props);
 
         const inputValue: Ref<FileDropValueType> = ref([]);
         const fileDropRef: TemplateRef<HTMLInputElement> = useTemplateRef('fileDropRef');
-        const dragging = ref(false);
+        const dragging: Ref<boolean> = ref(false);
+        const isDialogOpen: Ref<boolean> = ref(false);
         const componentMessages: Ref<StateMessage[]> = ref([]);
 
         const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
@@ -234,6 +248,18 @@ export default defineComponent({
 
         const { stateBoxClasses } = useStateClass(computedState);
         const hasValue = computed(() => inputValue.value.length > 0);
+        const computedPlaceholder: ComputedRef<string> = computed(() => {
+            if (!focusPlaceholder.value) {
+                return placeholder.value || '';
+            }
+            if (isDialogOpen.value) {
+                return focusPlaceholder.value;
+            }
+            if (dragging.value) {
+                return focusPlaceholder.value;
+            }
+            return placeholder.value || '';
+        });
 
         function setDragging(value: boolean) {
             if (computedDisabled.value || computedReadonly.value) {
@@ -337,11 +363,29 @@ export default defineComponent({
             inputValue.value = filteredFiles;
         }
 
-        function onFocus(e: FocusEvent) {
+        function onClick(): void {
+            isDialogOpen.value = true;
+        }
+
+        function onFocus(e: FocusEvent): void {
+            /**
+             * OS 파일 선택 다이얼로그가 닫히는 시점을 focus 이벤트로 감지한다.
+             *
+             * 'file' 타입 <input/> 은 포커스 동작이 독특하다.
+             * 1. 다이얼로그를 열려고 <input/> 을 클릭(터치)하면,
+             *    브라우저는 <input/> 을 focus 했다가 곧바로 blur 한다 (즉, 다이얼로그가 떠 있는 동안 <input/> 은 blur 상태다.)
+             * 2. 다이얼로그를 닫으면, 브라우저는 blur 돼 있던 <input/> 을 다시 focus 한다.
+             *
+             * 따라서 isDialogOpen 이 true 인데 focus 가 들어왔다면,
+             * 다이얼로그가 방금 닫혔다는 뜻이므로 상태를 false 로 되돌린다.
+             */
+            if (isDialogOpen.value) {
+                isDialogOpen.value = false;
+            }
             emit('focus', e);
         }
 
-        function onBlur(e: FocusEvent) {
+        function onBlur(e: FocusEvent): void {
             emit('blur', e);
         }
 
@@ -362,6 +406,7 @@ export default defineComponent({
             computedMessages,
             computedDisabled,
             computedReadonly,
+            computedPlaceholder,
             shake,
             colorSchemeClass,
             componentStyleSet,
@@ -380,6 +425,7 @@ export default defineComponent({
             handleFileDialog,
             handleFileDrop,
             handleFileRemove,
+            onClick,
             onFocus,
             onBlur,
             focus,

--- a/packages/vlossom/src/components/vs-file-drop/__stories__/vs-file-drop.stories.ts
+++ b/packages/vlossom/src/components/vs-file-drop/__stories__/vs-file-drop.stories.ts
@@ -91,6 +91,23 @@ export const WithLabel: Story = {
     },
 };
 
+export const FocusPlaceholder: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    'focusPlaceholder는 파일을 영역 위로 드래그하거나 파일 다이얼로그가 열려 있는 동안 노출되는 플레이스홀더입니다. ' +
+                    '그 외에는 placeholder로 되돌아갑니다.',
+            },
+        },
+    },
+    args: {
+        label: '첨부 파일',
+        placeholder: '파일을 드래그하거나 클릭하여 업로드하세요',
+        focusPlaceholder: '여기에 파일을 놓으세요',
+    },
+};
+
 export const AcceptFileTypes: Story = {
     parameters: {
         docs: {

--- a/packages/vlossom/src/components/vs-file-drop/__tests__/vs-file-drop.test.ts
+++ b/packages/vlossom/src/components/vs-file-drop/__tests__/vs-file-drop.test.ts
@@ -545,6 +545,58 @@ describe('vs-file-drop', () => {
         });
     });
 
+    describe('focusPlaceholder', () => {
+        it('파일을 드래그하는 동안 focusPlaceholder를, 그 외에는 placeholder를 노출한다', async () => {
+            // given
+            const placeholder = 'Drop files here';
+            const focusPlaceholder = 'Release to drop';
+            const wrapper = mount(VsFileDrop, { props: { modelValue: [], placeholder, focusPlaceholder } });
+            const input = wrapper.find('input[type="file"]');
+
+            // then: 드래그 전에는 placeholder를 노출한다.
+            expect(wrapper.find('.placeholder-text').text()).toBe(placeholder);
+
+            // when: 파일을 영역 위로 드래그한다.
+            await input.trigger('dragenter');
+
+            // then: focusPlaceholder를 노출한다.
+            expect(wrapper.find('.placeholder-text').text()).toBe(focusPlaceholder);
+
+            // when: 드래그가 영역을 벗어난다.
+            await wrapper.find('.vs-file-drop').trigger('dragleave');
+
+            // then: 다시 placeholder를 노출한다.
+            expect(wrapper.find('.placeholder-text').text()).toBe(placeholder);
+        });
+
+        it('파일 다이얼로그가 열리면(click) focusPlaceholder를 노출한다', async () => {
+            // given
+            const placeholder = 'Drop files here';
+            const focusPlaceholder = 'Choosing a file...';
+            const wrapper = mount(VsFileDrop, { props: { modelValue: [], placeholder, focusPlaceholder } });
+            const input = wrapper.find('input[type="file"]');
+
+            // when: input 클릭으로 파일 다이얼로그를 연다.
+            await input.trigger('click');
+
+            // then: focusPlaceholder를 노출한다.
+            expect(wrapper.find('.placeholder-text').text()).toBe(focusPlaceholder);
+        });
+
+        it('focusPlaceholder가 없으면 드래그 중에도 placeholder를 유지한다', async () => {
+            // given
+            const placeholder = 'Drop files here';
+            const wrapper = mount(VsFileDrop, { props: { modelValue: [], placeholder } });
+            const input = wrapper.find('input[type="file"]');
+
+            // when
+            await input.trigger('dragenter');
+
+            // then
+            expect(wrapper.find('.placeholder-text').text()).toBe(placeholder);
+        });
+    });
+
     describe('파일 입력 (dialog)', () => {
         it('accept를 설정하면 원하는 타입의 파일만 dialog에서 확인할 수 있다', () => {
             // given

--- a/packages/vlossom/src/components/vs-input/README.ko.md
+++ b/packages/vlossom/src/components/vs-input/README.ko.md
@@ -74,6 +74,14 @@ const text = ref('');
 </template>
 ```
 
+### 포커스 플레이스홀더
+
+```html
+<template>
+    <vs-input v-model="value" placeholder="검색" focus-placeholder="키워드를 입력하세요..." />
+</template>
+```
+
 ## Props
 
 | Prop              | Type                                              | Default  | Required | Description                                                          |
@@ -84,6 +92,7 @@ const text = ref('');
 | `type`            | `'email' \| 'number' \| 'password' \| 'search' \| 'tel' \| 'text' \| 'url'` | `'text'` | - | HTML 입력 타입.              |
 | `label`           | `string`                                          | `''`     | -        | 입력 위에 표시되는 라벨 텍스트.                                      |
 | `placeholder`     | `string`                                          | `''`     | -        | 입력의 플레이스홀더 텍스트.                                          |
+| `focusPlaceholder` | `string`                                          | `''`     | -        | 입력에 포커스된 동안 표시되는 플레이스홀더. 포커스가 아닐 때는 `placeholder`로 대체됩니다. |
 | `disabled`        | `boolean`                                         | `false`  | -        | 입력을 비활성화합니다.                                               |
 | `readonly`        | `boolean`                                         | `false`  | -        | 입력을 읽기 전용으로 설정합니다.                                     |
 | `required`        | `boolean`                                         | `false`  | -        | 필드를 필수로 표시합니다 (유효성 검사 추가).                         |

--- a/packages/vlossom/src/components/vs-input/README.md
+++ b/packages/vlossom/src/components/vs-input/README.md
@@ -74,6 +74,14 @@ const text = ref('');
 </template>
 ```
 
+### Focus Placeholder
+
+```html
+<template>
+    <vs-input v-model="value" placeholder="Search" focus-placeholder="Type a keyword..." />
+</template>
+```
+
 ## Props
 
 | Prop              | Type                                              | Default  | Required | Description                                                      |
@@ -84,6 +92,7 @@ const text = ref('');
 | `type`            | `'email' \| 'number' \| 'password' \| 'search' \| 'tel' \| 'text' \| 'url'` | `'text'` | - | HTML input type.                     |
 | `label`           | `string`                                          | `''`     | -        | Label text displayed above the input.                            |
 | `placeholder`     | `string`                                          | `''`     | -        | Placeholder text for the input.                                  |
+| `focusPlaceholder` | `string`                                          | `''`     | -        | Placeholder shown while the input is focused. Falls back to `placeholder` when not focused. |
 | `disabled`        | `boolean`                                         | `false`  | -        | Disables the input.                                              |
 | `readonly`        | `boolean`                                         | `false`  | -        | Makes the input read-only.                                       |
 | `required`        | `boolean`                                         | `false`  | -        | Marks the field as required (adds validation).                   |

--- a/packages/vlossom/src/components/vs-input/VsInput.vue
+++ b/packages/vlossom/src/components/vs-input/VsInput.vue
@@ -34,7 +34,7 @@
                 :disabled="computedDisabled"
                 :readonly="computedReadonly"
                 :aria-required="required"
-                :placeholder
+                :placeholder="computedPlaceholder"
                 @input.stop="onInput"
                 @focus.stop="onFocus"
                 @blur.stop="onBlur"
@@ -66,7 +66,17 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, toRefs, useTemplateRef, type PropType, type Ref, type TemplateRef, ref } from 'vue';
+import {
+    computed,
+    defineComponent,
+    toRefs,
+    useTemplateRef,
+    ref,
+    type PropType,
+    type Ref,
+    type TemplateRef,
+    type ComputedRef,
+} from 'vue';
 import { VsComponent, type Size, type StringModifiers } from '@/declaration';
 import { useColorScheme, useStyleSet, useInput, useStringModifier, useStateClass, useSizeClass } from '@/composables';
 import { getInputProps, getResponsiveProps, getColorSchemeProps, getStyleSetProps, getMinMaxProps } from '@/props';
@@ -123,9 +133,13 @@ export default defineComponent({
             noDefaultRules,
             size,
             state,
+            placeholder,
+            focusPlaceholder,
         } = toRefs(props);
 
         const inputValue: Ref<VsInputValueType> = ref(modelValue.value);
+        const focused: Ref<boolean> = ref(false);
+
         const inputRef: TemplateRef<HTMLInputElement> = useTemplateRef('inputRef');
         const isNumberInput = computed(() => type.value === 'number');
 
@@ -204,6 +218,13 @@ export default defineComponent({
             () => !!inputValue.value && !noClear.value && !computedReadonly.value && !computedDisabled.value,
         );
 
+        const computedPlaceholder: ComputedRef<string> = computed(() => {
+            if (focused.value && focusPlaceholder.value) {
+                return focusPlaceholder.value;
+            }
+            return placeholder.value || '';
+        });
+
         function onInput(event: Event) {
             const target = event.target as HTMLInputElement;
             const value = target.value || '';
@@ -220,10 +241,12 @@ export default defineComponent({
 
         function onFocus(e: FocusEvent) {
             emit('focus', e);
+            focused.value = true;
         }
 
         function onBlur(e: FocusEvent) {
             emit('blur', e);
+            focused.value = false;
         }
 
         function select() {
@@ -249,6 +272,7 @@ export default defineComponent({
             computedMessages,
             computedDisabled,
             computedReadonly,
+            computedPlaceholder,
             renderClearButton,
             shake,
             stateBoxClasses,

--- a/packages/vlossom/src/components/vs-input/__stories__/vs-input.stories.ts
+++ b/packages/vlossom/src/components/vs-input/__stories__/vs-input.stories.ts
@@ -60,6 +60,11 @@ const meta: Meta<typeof VsInput> = {
             description: '플레이스홀더 텍스트',
             table: { category: 'Input Props' },
         },
+        focusPlaceholder: {
+            control: 'text',
+            description: '포커스 상태일 때 표시되는 플레이스홀더 (미포커스 시 placeholder로 대체)',
+            table: { category: 'Input Props' },
+        },
         autocomplete: {
             control: 'boolean',
             description: '자동완성 활성화',
@@ -210,6 +215,21 @@ export const WithLabel: Story = {
     args: {
         label: '이름',
         placeholder: '이름을 입력하세요',
+    },
+};
+
+export const FocusPlaceholder: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'focusPlaceholder prop을 사용하면 입력에 포커스된 동안 다른 플레이스홀더를 표시할 수 있습니다. 포커스가 해제되면 placeholder로 되돌아갑니다.',
+            },
+        },
+    },
+    args: {
+        label: '검색',
+        placeholder: '검색',
+        focusPlaceholder: '키워드를 입력하세요...',
     },
 };
 

--- a/packages/vlossom/src/components/vs-input/__tests__/vs-input.test.ts
+++ b/packages/vlossom/src/components/vs-input/__tests__/vs-input.test.ts
@@ -147,6 +147,38 @@ describe('VsInput', () => {
         });
     });
 
+    describe('focusPlaceholder', () => {
+        it('focus 시에는 focusPlaceholder를, blur 시에는 placeholder를 보여줘야 한다', async () => {
+            // given
+            const wrapper = mount(VsInput, {
+                props: {
+                    placeholder: 'Enter text',
+                    focusPlaceholder: 'Type a keyword...',
+                },
+                attachTo: document.body,
+            });
+            const input = wrapper.find('input');
+
+            // then (포커스 전에는 placeholder를 보여준다)
+            expect(input.attributes('placeholder')).toBe('Enter text');
+
+            // when (focus)
+            await input.trigger('focus');
+
+            // then (포커스 중에는 focusPlaceholder를 보여준다)
+            expect(input.attributes('placeholder')).toBe('Type a keyword...');
+
+            // when (blur)
+            await input.trigger('blur');
+
+            // then (포커스가 해제되면 다시 placeholder로 되돌아간다)
+            expect(input.attributes('placeholder')).toBe('Enter text');
+
+            // cleanup
+            wrapper.unmount();
+        });
+    });
+
     describe('state', () => {
         it('state를 error로 설정하면 vs-state-error 클래스가 추가되어야 한다', () => {
             // given

--- a/packages/vlossom/src/components/vs-select/README.ko.md
+++ b/packages/vlossom/src/components/vs-select/README.ko.md
@@ -47,6 +47,22 @@ const options = ['사과', '바나나', '체리'];
 </template>
 ```
 
+### Focus Placeholder
+
+셀렉트가 포커스되거나 열려 있을 때 다른 placeholder를 표시합니다. 그 외에는 `placeholder`로 폴백합니다.
+
+```html
+<template>
+    <vs-select
+        v-model="selected"
+        :options="options"
+        placeholder="과일 선택"
+        focus-placeholder="아래 목록에서 선택하세요"
+        label="과일 선택"
+    />
+</template>
+```
+
 ### 커스텀 레이블이 있는 객체 옵션
 
 ```html
@@ -86,6 +102,8 @@ const options = [
 | `messages`        | `Message[]`                                                      | `[]`                  | -        | 유효성 검사 메시지                                      |
 | `name`            | `string`                                                         | `''`                  | -        | HTML name 속성                                          |
 | `noDefaultRules`  | `boolean`                                                        | `false`               | -        | 내장 유효성 검사 규칙 비활성화                          |
+| `placeholder`     | `string`                                                         | `''`                  | -        | 선택된 옵션이 없을 때 표시되는 placeholder              |
+| `focusPlaceholder`| `string`                                                         | `''`                  | -        | 셀렉트가 포커스되거나 열려 있을 때 표시되는 placeholder. 그 외에는 `placeholder`로 폴백합니다. |
 | `readonly`        | `boolean`                                                        | `false`               | -        | 셀렉트를 읽기 전용으로 설정                             |
 | `rules`           | `Rule[]`                                                         | `[]`                  | -        | 커스텀 유효성 검사 규칙                                 |
 | `state`           | `'idle' \| 'info' \| 'success' \| 'warning' \| 'error'`        | `'idle'`              | -        | 유효성 검사 상태                                        |

--- a/packages/vlossom/src/components/vs-select/README.md
+++ b/packages/vlossom/src/components/vs-select/README.md
@@ -47,6 +47,22 @@ const options = ['Apple', 'Banana', 'Cherry'];
 </template>
 ```
 
+### Focus Placeholder
+
+Show a different placeholder while the select is focused or open. It falls back to `placeholder` otherwise.
+
+```html
+<template>
+    <vs-select
+        v-model="selected"
+        :options="options"
+        placeholder="Select a fruit"
+        focus-placeholder="Pick from the list below"
+        label="Choose a fruit"
+    />
+</template>
+```
+
 ### Object Options with Custom Labels
 
 ```html
@@ -86,6 +102,8 @@ const options = [
 | `messages`        | `Message[]`                                                      | `[]`                  | -        | Validation messages                                     |
 | `name`            | `string`                                                         | `''`                  | -        | HTML name attribute                                     |
 | `noDefaultRules`  | `boolean`                                                        | `false`               | -        | Disables built-in validation rules                      |
+| `placeholder`     | `string`                                                         | `''`                  | -        | Placeholder shown when no option is selected            |
+| `focusPlaceholder`| `string`                                                         | `''`                  | -        | Placeholder shown while the select is focused/open. Falls back to `placeholder` otherwise. |
 | `readonly`        | `boolean`                                                        | `false`               | -        | Makes the select read-only                              |
 | `rules`           | `Rule[]`                                                         | `[]`                  | -        | Custom validation rules                                 |
 | `state`           | `'idle' \| 'info' \| 'success' \| 'warning' \| 'error'`        | `'idle'`              | -        | Validation state                                        |

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -26,7 +26,7 @@
                 :color-scheme="computedColorScheme"
                 :is-empty
                 :is-open
-                :placeholder
+                :placeholder="computedPlaceholder"
                 :multiple
                 :collapse-chips
                 :closable-chips
@@ -226,6 +226,8 @@ export default defineComponent({
             min,
             max,
             size,
+            placeholder,
+            focusPlaceholder,
         } = toRefs(props);
 
         const isOpen = ref(false);
@@ -379,6 +381,13 @@ export default defineComponent({
             'vs-readonly': computedReadonly.value,
             [sizeClass.value]: !!sizeClass.value,
         }));
+
+        const computedPlaceholder = computed(() => {
+            if (isUsingSelect.value && focusPlaceholder.value) {
+                return focusPlaceholder.value;
+            }
+            return placeholder.value ?? '';
+        });
 
         function toggleOpen() {
             if (isSelectUnavailable.value) {
@@ -567,6 +576,7 @@ export default defineComponent({
             computedState,
             computedDisabled,
             computedReadonly,
+            computedPlaceholder,
             filteredOptions,
             shake,
             openOptions,

--- a/packages/vlossom/src/components/vs-select/__stories__/vs-select.stories.ts
+++ b/packages/vlossom/src/components/vs-select/__stories__/vs-select.stories.ts
@@ -51,6 +51,23 @@ export const Default: Story = {
     },
 };
 
+export const FocusPlaceholder: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'select가 포커스되거나 열려 있을 때는 focusPlaceholder를, 그 외에는 placeholder를 보여줍니다.',
+            },
+        },
+    },
+    args: {
+        label: 'Select',
+        options: basicOptions,
+        placeholder: 'Select a fruit',
+        focusPlaceholder: 'Pick from the list below',
+        modelValue: null,
+    },
+};
+
 export const Sizes: Story = {
     parameters: {
         docs: {

--- a/packages/vlossom/src/components/vs-select/__tests__/vs-select.test.ts
+++ b/packages/vlossom/src/components/vs-select/__tests__/vs-select.test.ts
@@ -787,4 +787,83 @@ describe('VsSelect', () => {
             expect(wrapper.props('modelValue')).toEqual(['Banana']);
         });
     });
+
+    describe('focusPlaceholder', () => {
+        it('옵션 목록이 열리면 focusPlaceholder를 보여주고 닫히면 placeholder로 되돌아간다', async () => {
+            // given: placeholder와 focusPlaceholder가 모두 설정된 select (선택값 없음)
+            const wrapper = mount(VsSelect, {
+                props: {
+                    options: basicOptions,
+                    modelValue: null,
+                    placeholder: 'Select a fruit',
+                    focusPlaceholder: 'Pick from the list below',
+                },
+            });
+            const placeholderText = () => wrapper.find('.vs-select-placeholder').text();
+
+            // then: 닫힌 상태에서는 placeholder가 보인다
+            expect(placeholderText()).toBe('Select a fruit');
+
+            // when: 옵션 목록을 연다
+            wrapper.vm.openOptions();
+            await nextTick();
+
+            // then: focusPlaceholder가 보인다
+            expect(placeholderText()).toBe('Pick from the list below');
+
+            // when: 옵션 목록을 닫는다
+            wrapper.vm.closeOptions();
+            await nextTick();
+
+            // then: 다시 placeholder로 되돌아간다
+            expect(placeholderText()).toBe('Select a fruit');
+        });
+
+        it('트리거가 포커스되면 focusPlaceholder를 보여주고 blur되면 placeholder로 되돌아간다', async () => {
+            // given: placeholder와 focusPlaceholder가 모두 설정된 select (선택값 없음)
+            const wrapper = mount(VsSelect, {
+                props: {
+                    options: basicOptions,
+                    modelValue: null,
+                    placeholder: 'Select a fruit',
+                    focusPlaceholder: 'Pick from the list below',
+                },
+            });
+            const trigger = wrapper.find('.vs-select-trigger');
+            const placeholderText = () => wrapper.find('.vs-select-placeholder').text();
+
+            // then: 포커스 전에는 placeholder가 보인다
+            expect(placeholderText()).toBe('Select a fruit');
+
+            // when: 트리거에 포커스를 준다
+            await trigger.trigger('focus');
+
+            // then: focusPlaceholder가 보인다
+            expect(placeholderText()).toBe('Pick from the list below');
+
+            // when: 트리거에서 포커스가 해제된다
+            await trigger.trigger('blur');
+
+            // then: 다시 placeholder로 되돌아간다
+            expect(placeholderText()).toBe('Select a fruit');
+        });
+
+        it('focusPlaceholder가 비어 있으면 열려 있어도 placeholder를 유지한다', async () => {
+            // given: focusPlaceholder가 설정되지 않은 select (선택값 없음)
+            const wrapper = mount(VsSelect, {
+                props: {
+                    options: basicOptions,
+                    modelValue: null,
+                    placeholder: 'Select a fruit',
+                },
+            });
+
+            // when: 옵션 목록을 연다
+            wrapper.vm.openOptions();
+            await nextTick();
+
+            // then: focusPlaceholder가 없으므로 placeholder를 그대로 보여준다
+            expect(wrapper.find('.vs-select-placeholder').text()).toBe('Select a fruit');
+        });
+    });
 });

--- a/packages/vlossom/src/components/vs-textarea/README.ko.md
+++ b/packages/vlossom/src/components/vs-textarea/README.ko.md
@@ -50,6 +50,19 @@ const text = ref('');
 </template>
 ```
 
+### 포커스 플레이스홀더
+
+```html
+<template>
+    <vs-textarea
+        v-model="text"
+        label="설명"
+        placeholder="설명을 입력하세요..."
+        focus-placeholder="여기에 내용을 입력하세요"
+    />
+</template>
+```
+
 ## Props
 
 | Prop | 타입 | 기본값 | 필수 | 설명 |
@@ -73,6 +86,7 @@ const text = ref('');
 | `noLabel` | `boolean` | `false` | | 레이블 영역 숨김 |
 | `noMessages` | `boolean` | `false` | | 메시지 영역 숨김 |
 | `placeholder` | `string` | `''` | | 플레이스홀더 텍스트 |
+| `focusPlaceholder` | `string` | `''` | | textarea가 포커스된 동안 표시되는 플레이스홀더입니다. 포커스가 해제되면 `placeholder`로 대체됩니다. |
 | `readonly` | `boolean` | `false` | | 읽기 전용 모드 |
 | `required` | `boolean` | `false` | | 필수 입력 필드로 표시 |
 | `rules` | `Rule[]` | `[]` | | 커스텀 유효성 검사 규칙 |

--- a/packages/vlossom/src/components/vs-textarea/README.md
+++ b/packages/vlossom/src/components/vs-textarea/README.md
@@ -50,6 +50,19 @@ const text = ref('');
 </template>
 ```
 
+### Focus Placeholder
+
+```html
+<template>
+    <vs-textarea
+        v-model="text"
+        label="Description"
+        placeholder="Enter description..."
+        focus-placeholder="Type your text here"
+    />
+</template>
+```
+
 ## Props
 
 | Prop | Type | Default | Required | Description |
@@ -73,6 +86,7 @@ const text = ref('');
 | `noLabel` | `boolean` | `false` | | Hides the label area |
 | `noMessages` | `boolean` | `false` | | Hides the message area |
 | `placeholder` | `string` | `''` | | Placeholder text |
+| `focusPlaceholder` | `string` | `''` | | Placeholder shown while the textarea is focused. Falls back to `placeholder` when not focused. |
 | `readonly` | `boolean` | `false` | | Makes the textarea read-only |
 | `required` | `boolean` | `false` | | Marks the field as required |
 | `rules` | `Rule[]` | `[]` | | Custom validation rules |

--- a/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
+++ b/packages/vlossom/src/components/vs-textarea/VsTextarea.vue
@@ -26,7 +26,7 @@
             :disabled="computedDisabled"
             :readonly="computedReadonly"
             :name
-            :placeholder="placeholder"
+            :placeholder="computedPlaceholder"
             :value="inputValue"
             :aria-required="required"
             :autocomplete="autocomplete ? 'on' : 'off'"
@@ -96,6 +96,7 @@ export default defineComponent({
 
         const textareaRef: TemplateRef<HTMLTextAreaElement> = useTemplateRef('textareaRef');
         const inputValue: Ref<VsTextareaValueType> = ref(modelValue.value);
+        const isFocused: Ref<boolean> = ref(false);
 
         const { colorSchemeClass } = useColorScheme(componentName, colorScheme);
 
@@ -155,6 +156,13 @@ export default defineComponent({
             'vs-focus-visible': !computedDisabled.value && !computedReadonly.value,
         }));
 
+        const computedPlaceholder = computed(() => {
+            if (isFocused.value && props.focusPlaceholder) {
+                return props.focusPlaceholder;
+            }
+            return props.placeholder ?? '';
+        });
+
         const { stateBoxClasses } = useStateClass(computedState);
 
         const { sizeClass } = useSizeClass(size);
@@ -166,10 +174,12 @@ export default defineComponent({
         }
 
         function onFocus(e: FocusEvent) {
+            isFocused.value = true;
             emit('focus', e);
         }
 
         function onBlur(e: FocusEvent) {
+            isFocused.value = false;
             emit('blur', e);
         }
 
@@ -200,6 +210,7 @@ export default defineComponent({
             computedReadonly,
             computedMessages,
             computedState,
+            computedPlaceholder,
             inputValue,
             shake,
 

--- a/packages/vlossom/src/components/vs-textarea/__stories__/vs-textarea.stories.ts
+++ b/packages/vlossom/src/components/vs-textarea/__stories__/vs-textarea.stories.ts
@@ -54,6 +54,11 @@ const meta: Meta<typeof VsTextarea> = {
             description: '플레이스홀더 텍스트',
             table: { category: 'Textarea Props' },
         },
+        focusPlaceholder: {
+            control: 'text',
+            description: '포커스 상태일 때 표시되는 플레이스홀더 텍스트 (미설정 시 placeholder로 대체)',
+            table: { category: 'Textarea Props' },
+        },
         autocomplete: {
             control: 'boolean',
             description: '자동완성 활성화',
@@ -224,6 +229,23 @@ export const WithLabel: Story = {
     args: {
         label: '설명',
         placeholder: '설명을 입력하세요',
+    },
+};
+
+export const FocusPlaceholder: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    'focusPlaceholder prop을 사용하면 포커스 상태일 때 다른 플레이스홀더를 표시할 수 있습니다. ' +
+                    '포커스가 해제되면 placeholder로 돌아갑니다.',
+            },
+        },
+    },
+    args: {
+        label: '설명',
+        placeholder: '클릭하여 입력을 시작하세요',
+        focusPlaceholder: '설명을 자세히 입력해 주세요...',
     },
 };
 

--- a/packages/vlossom/src/components/vs-textarea/__tests__/vs-textarea.test.ts
+++ b/packages/vlossom/src/components/vs-textarea/__tests__/vs-textarea.test.ts
@@ -190,6 +190,38 @@ describe('VsTextarea', () => {
         });
     });
 
+    describe('focusPlaceholder', () => {
+        it('포커스 상태에 따라 placeholder가 focusPlaceholder로 전환되어야 한다', async () => {
+            // given
+            const wrapper = mount(VsTextarea, {
+                props: {
+                    placeholder: 'blur placeholder',
+                    focusPlaceholder: 'focus placeholder',
+                },
+                attachTo: document.body,
+            });
+            const textarea = wrapper.find('textarea');
+
+            // then: 포커스 전에는 placeholder가 노출된다
+            expect(textarea.attributes('placeholder')).toBe('blur placeholder');
+
+            // when: 포커스되면 focusPlaceholder로 전환된다
+            await textarea.trigger('focus');
+
+            // then
+            expect(textarea.attributes('placeholder')).toBe('focus placeholder');
+
+            // when: 포커스가 해제되면 다시 placeholder로 돌아온다
+            await textarea.trigger('blur');
+
+            // then
+            expect(textarea.attributes('placeholder')).toBe('blur placeholder');
+
+            // cleanup
+            wrapper.unmount();
+        });
+    });
+
     describe('state', () => {
         it('state를 error로 설정하면 vs-state-error 클래스가 추가되어야 한다', () => {
             // given

--- a/packages/vlossom/src/props/input-props.ts
+++ b/packages/vlossom/src/props/input-props.ts
@@ -29,6 +29,7 @@ interface InputPropsDefinition<T = unknown> extends InputWrapperPropsDefinition 
     name: { type: typeof String; default: string };
     noDefaultRules: { type: typeof Boolean; default: boolean };
     placeholder: { type: typeof String; default: string };
+    focusPlaceholder: { type: typeof String; default: string };
     readonly: { type: typeof Boolean; default: boolean };
     rules: { type: PropType<Rule<T>[]>; default: () => Rule<T>[] };
     state: { type: PropType<UIState>; default: UIState };
@@ -45,6 +46,7 @@ export function getInputProps<T = unknown, K extends keyof InputPropsDefinition<
             name: { type: String, default: '' },
             noDefaultRules: { type: Boolean, default: false },
             placeholder: { type: String, default: '' },
+            focusPlaceholder: { type: String, default: '' },
             readonly: { type: Boolean, default: false },
             rules: { type: Array as PropType<Rule<T>[]>, default: () => [] },
             state: { type: String as PropType<UIState>, default: 'idle' },

--- a/packages/vlossom/src/storybook/args.ts
+++ b/packages/vlossom/src/storybook/args.ts
@@ -17,6 +17,7 @@ export const inputPropsArgTypes = {
     name: { control: 'text' as any, table: { category: 'Input Props' } },
     noDefaultRules: { control: 'boolean' as any, table: { category: 'Input Props' } },
     placeholder: { control: 'text' as any, table: { category: 'Input Props' } },
+    focusPlaceholder: { control: 'text' as any, table: { category: 'Input Props' } },
     readonly: { control: 'boolean' as any, table: { category: 'Input Props' } },
     rules: { control: 'object' as any, table: { category: 'Input Props' } },
     state: {


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Feature (feat)
-   [ ] Fix Bug (fix)
-   [ ] Refactor (refactor)
-   [ ] Style (style)
-   [ ] Test (test)
-   [ ] CI (ci)
-   [ ] Build (build)
-   [ ] Update Docs (docs)
-   [ ] Chore (chore)

## Summary

Input compoments에 포커스 상태에서 별도 노출되는 `focusPlaceholder` prop을 추가합니다.

## Description

- 전체 input components를 확인하고 적용 가능한 모든 컴퍼넌트에 적용했습니다
   - VsFileDrop
   - VsInput
   - VsSelect
   - VsTextarea
- `VsDatePicker` 로직을 개선했습니다
- Sandbox/Inputs.vue 에 일부 케이스에 적용하였습니다
- test, stories, readme 문서를 갱신했습니다

## Screenshots or Recordings

<img width="523" height="1050" alt="focusPlaceholder" src="https://github.com/user-attachments/assets/11f49e66-5978-4164-817c-4d1675c19409" />

## Related Tickets & Documents

- Closes #584 

