### PR TITLE
fix(VsSelect): add offset option at scrollToItem

### DIFF
--- a/packages/vlossom/src/components/vs-grouped-list/README.ko.md
+++ b/packages/vlossom/src/components/vs-grouped-list/README.ko.md
@@ -121,5 +121,5 @@ interface VsGroupedListStyleSet extends CSSProperties {
 
 | 메서드 | 파라미터 | 설명 |
 | ------ | -------- | ---- |
-| `scrollToItem` | `id: string` | 주어진 id를 가진 항목으로 목록 스크롤 |
+| `scrollToItem` | `id: string, offset?: number` | 주어진 id를 가진 항목으로 목록 스크롤. `offset`만큼 스크롤 위치를 위로 당겨 여백을 확보 (기본값: `0`) |
 | `hasScroll` | - | `boolean` 반환 — 목록에 스크롤바가 있으면 `true` |

--- a/packages/vlossom/src/components/vs-grouped-list/README.md
+++ b/packages/vlossom/src/components/vs-grouped-list/README.md
@@ -121,5 +121,5 @@ interface VsGroupedListStyleSet extends CSSProperties {
 
 | Method | Parameters | Description |
 | ------ | ---------- | ----------- |
-| `scrollToItem` | `id: string` | Scroll the list to the item with the given id |
+| `scrollToItem` | `id: string, offset?: number` | Scroll the list to the item with the given id. `offset` shifts the scroll position up by the given pixels (default: `0`) |
 | `hasScroll` | - | Returns `boolean` — `true` if the list has a scrollbar |

--- a/packages/vlossom/src/components/vs-grouped-list/VsGroupedList.vue
+++ b/packages/vlossom/src/components/vs-grouped-list/VsGroupedList.vue
@@ -164,7 +164,7 @@ export default defineComponent({
             emit('click-item', { ...item, groupedIndex, group, groupIndex });
         }
 
-        function scrollToItem(id: string) {
+        function scrollToItem(id: string, offset: number = 0) {
             if (!visibleRenderRef.value) {
                 return;
             }
@@ -180,7 +180,7 @@ export default defineComponent({
                 return;
             }
 
-            visibleRenderRef.value.scrollToElement(targetElement);
+            visibleRenderRef.value.scrollToElement(targetElement, offset);
         }
 
         function hasScroll() {

--- a/packages/vlossom/src/components/vs-grouped-list/__tests__/vs-grouped-list.test.ts
+++ b/packages/vlossom/src/components/vs-grouped-list/__tests__/vs-grouped-list.test.ts
@@ -340,4 +340,38 @@ describe('vs-grouped-list', () => {
             expect(groupedItems[0].items).toHaveLength(0);
         });
     });
+
+    describe('scrollToItem', () => {
+        it('존재하지 않는 id로 호출해도 오류가 발생하지 않아야 한다', () => {
+            // given
+            const wrapper = mount(VsGroupedList, {
+                props: { items: defaultItems },
+            });
+
+            // when, then
+            expect(() => wrapper.vm.scrollToItem('non-existent-id')).not.toThrow();
+        });
+
+        it('offset 없이 호출하면 오류가 발생하지 않아야 한다', () => {
+            // given
+            const wrapper = mount(VsGroupedList, {
+                props: { items: defaultItems },
+            });
+
+            // when, then
+            const targetId = defaultItems[0].id;
+            expect(() => wrapper.vm.scrollToItem(targetId)).not.toThrow();
+        });
+
+        it('offset을 전달하면 오류가 발생하지 않아야 한다', () => {
+            // given
+            const wrapper = mount(VsGroupedList, {
+                props: { items: defaultItems },
+            });
+
+            // when, then
+            const targetId = defaultItems[0].id;
+            expect(() => wrapper.vm.scrollToItem(targetId, 50)).not.toThrow();
+        });
+    });
 });

--- a/packages/vlossom/src/components/vs-grouped-list/types.ts
+++ b/packages/vlossom/src/components/vs-grouped-list/types.ts
@@ -11,7 +11,7 @@ declare module 'vue' {
 export type { VsGroupedList };
 
 export interface VsGroupedListRef extends ComponentPublicInstance<typeof VsGroupedList> {
-    scrollToItem: (id: string) => void;
+    scrollToItem: (id: string, offset?: number) => void;
     hasScroll: () => boolean;
 }
 

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -439,7 +439,7 @@ export default defineComponent({
 
                     const selectedId = selectedOptionIds.value[0];
                     if (selectedId && optionsListRef.value?.hasScroll()) {
-                        optionsListRef.value?.scrollToItem(selectedId);
+                        optionsListRef.value?.scrollToItem(selectedId, 50);
                     }
 
                     if (isUsingSearch.value) {

--- a/packages/vlossom/src/components/vs-select/__tests__/vs-select.test.ts
+++ b/packages/vlossom/src/components/vs-select/__tests__/vs-select.test.ts
@@ -651,6 +651,66 @@ describe('VsSelect', () => {
             // then
             expect(wrapper.vm.isOpen).toBe(false);
         });
+
+        it('선택된 옵션이 있고 스크롤이 있을 때 openOptions 호출 시 scrollToItem에 50px offset이 전달된다', async () => {
+            // given
+            // VsFloating을 스텁으로 대체해 Teleport/v-if 없이 슬롯을 바로 렌더링 → optionsListRef 즉시 접근 가능
+            vi.useFakeTimers();
+            const wrapper = mount(VsSelect, {
+                attachTo: document.body,
+                global: { stubs: { VsFloating: { template: '<div><slot /></div>' } } },
+                props: {
+                    options: basicOptions,
+                    modelValue: 'Apple',
+                },
+            });
+            await nextTick();
+
+            const optionsListRef = wrapper.vm.optionsListRef;
+            vi.spyOn(optionsListRef as any, 'hasScroll').mockReturnValue(true);
+            const scrollToItemSpy = vi.spyOn(optionsListRef as any, 'scrollToItem');
+
+            // when
+            wrapper.vm.openOptions();
+            vi.advanceTimersByTime(100);
+            await nextTick();
+
+            // then
+            const appleOption = wrapper.vm.filteredOptions.find((o: any) => o.value === 'Apple');
+            expect(scrollToItemSpy).toHaveBeenCalledWith(appleOption?.id, 50);
+
+            wrapper.unmount();
+            vi.useRealTimers();
+        });
+
+        it('선택된 옵션이 없을 때 openOptions 호출 시 scrollToItem이 호출되지 않는다', async () => {
+            // given
+            vi.useFakeTimers();
+            const wrapper = mount(VsSelect, {
+                attachTo: document.body,
+                global: { stubs: { VsFloating: { template: '<div><slot /></div>' } } },
+                props: {
+                    options: basicOptions,
+                    modelValue: null,
+                },
+            });
+            await nextTick();
+
+            const optionsListRef = wrapper.vm.optionsListRef;
+            vi.spyOn(optionsListRef as any, 'hasScroll').mockReturnValue(true);
+            const scrollToItemSpy = vi.spyOn(optionsListRef as any, 'scrollToItem');
+
+            // when
+            wrapper.vm.openOptions();
+            vi.advanceTimersByTime(100);
+            await nextTick();
+
+            // then
+            expect(scrollToItemSpy).not.toHaveBeenCalled();
+
+            wrapper.unmount();
+            vi.useRealTimers();
+        });
     });
 
     describe('emits', () => {

--- a/packages/vlossom/src/components/vs-visible-render/README.ko.md
+++ b/packages/vlossom/src/components/vs-visible-render/README.ko.md
@@ -94,7 +94,7 @@ IntersectionObserver를 사용하여 자식 요소의 가시성을 추적하고 
 
 | 메서드 | 매개변수 | 설명 |
 | ------ | -------- | ---- |
-| `scrollToElement` | `element: HTMLElement` | 주어진 요소가 보이도록 컨테이너를 스크롤 |
+| `scrollToElement` | `element: HTMLElement, offset?: number` | 주어진 요소가 보이도록 컨테이너를 스크롤. `offset`만큼 스크롤 위치를 위로 당겨 여백을 확보 (기본값: `0`) |
 
 ## 주의사항
 

--- a/packages/vlossom/src/components/vs-visible-render/README.md
+++ b/packages/vlossom/src/components/vs-visible-render/README.md
@@ -94,7 +94,7 @@ No StyleSet for this component.
 
 | Method | Parameters | Description |
 | ------ | ---------- | ----------- |
-| `scrollToElement` | `element: HTMLElement` | Scrolls the container so the given element is visible |
+| `scrollToElement` | `element: HTMLElement, offset?: number` | Scrolls the container so the given element is visible. `offset` shifts the scroll position up by the given pixels (default: `0`) |
 
 ## Caution
 

--- a/packages/vlossom/src/components/vs-visible-render/VsVisibleRender.vue
+++ b/packages/vlossom/src/components/vs-visible-render/VsVisibleRender.vue
@@ -215,7 +215,7 @@ export default defineComponent({
             });
         }
 
-        function scrollToElement(element: HTMLElement) {
+        function scrollToElement(element: HTMLElement, offset: number = 0) {
             if (!computedVisibleRenderRef.value || !element) {
                 return;
             }
@@ -233,7 +233,7 @@ export default defineComponent({
                     // viewport가 스크롤 컨테이너인 경우 window.scrollTo 사용
                     const rect = element.getBoundingClientRect();
                     const currentScrollY = window.scrollY || document.documentElement.scrollTop;
-                    const targetScrollY = currentScrollY + rect.top;
+                    const targetScrollY = currentScrollY + rect.top - offset;
 
                     window.scrollTo({
                         top: targetScrollY,
@@ -244,7 +244,7 @@ export default defineComponent({
                     const scrollContainer = scrollRoot as HTMLElement;
                     const containerRect = scrollContainer.getBoundingClientRect();
                     const targetRect = element.getBoundingClientRect();
-                    const targetScrollTop = scrollContainer.scrollTop + targetRect.top - containerRect.top;
+                    const targetScrollTop = scrollContainer.scrollTop + targetRect.top - containerRect.top - offset;
 
                     scrollContainer.scrollTo({
                         top: targetScrollTop,

--- a/packages/vlossom/src/components/vs-visible-render/types.ts
+++ b/packages/vlossom/src/components/vs-visible-render/types.ts
@@ -10,5 +10,5 @@ declare module 'vue' {
 export type { VsVisibleRender };
 
 export interface VsVisibleRenderRef extends ComponentPublicInstance<typeof VsVisibleRender> {
-    scrollToElement: (element: HTMLElement) => void;
+    scrollToElement: (element: HTMLElement, offset?: number) => void;
 }


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
vs-select 옵션이 선택된 상태일 때 options를 열었을 때 scroll에 offset을 추가하는 기능

## Description
- scrollToItem 함수에 offest 인자 옵셔널로 추가
- vs-select에서 50px 추가하도록 함
  - 50px은 옵션 두 개 보다는 작고 한 개보다는 큰 매직넘버
  - 옵션이 가운데로 오게 하는 건 공수가 많이 들고 오류 확률이 높아서 px로 마무리 함

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
