### PR TITLE
fix(VsSelect,VsRadioSet,VsCheckboxSet): warn and reset invalid modelValue

### DIFF
--- a/packages/vlossom/src/components/vs-checkbox/README.ko.md
+++ b/packages/vlossom/src/components/vs-checkbox/README.ko.md
@@ -211,3 +211,8 @@ interface VsCheckboxSetStyleSet extends CSSProperties {
 | `focus` | — | 체크박스 입력 요소에 포커스를 줍니다 |
 | `blur` | — | 체크박스 입력 요소의 포커스를 제거합니다 |
 | `toggle` | — | 체크 상태를 전환하고 값이 변경됐는지 반환합니다 |
+
+## Cautions
+
+- `VsCheckboxSet`의 `modelValue`에 `options`에 없는 값이 포함되면 (마운트 시 또는 프로그래매틱하게) 해당 값들은 제거되고 콘솔 경고가 출력됩니다.
+- `options`가 변경되어 현재 선택된 일부 값이 더 이상 존재하지 않으면 해당 항목이 제거되고 콘솔 경고가 출력됩니다.

--- a/packages/vlossom/src/components/vs-checkbox/README.md
+++ b/packages/vlossom/src/components/vs-checkbox/README.md
@@ -211,3 +211,8 @@ interface VsCheckboxSetStyleSet extends CSSProperties {
 | `focus` | — | Focuses the checkbox input element |
 | `blur` | — | Blurs the checkbox input element |
 | `toggle` | — | Toggles the checked state and returns whether the value changed |
+
+## Cautions
+
+- If `modelValue` of `VsCheckboxSet` is set to values not present in `options` — either on mount or programmatically — the invalid values are removed and a console warning is printed.
+- If `options` changes and some selected values are no longer present, the missing entries are removed and a console warning is printed.

--- a/packages/vlossom/src/components/vs-checkbox/VsCheckboxSet.vue
+++ b/packages/vlossom/src/components/vs-checkbox/VsCheckboxSet.vue
@@ -56,7 +56,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, ref, toRefs, watch, type PropType, type TemplateRef } from 'vue';
+import { computed, defineComponent, ref, toRefs, type PropType, type TemplateRef } from 'vue';
 import { VsComponent, type Size } from '@/declaration';
 import {
     getColorSchemeProps,
@@ -143,30 +143,28 @@ export default defineComponent({
             ref(true),
         );
 
-        function warnIfInvalid(value: any) {
-            if (!Array.isArray(value)) {
-                return;
-            }
-            const invalidValues = value.filter(
-                (v: any) => !options.value.some((o) => objectUtil.isEqual(getOptionValue(o), v)),
-            );
-            if (invalidValues.length > 0) {
-                logUtil.warning('VsCheckboxSet', `${JSON.stringify(invalidValues)} not in options, removed`);
-            }
-        }
-
-        function convertValue(value: any) {
+        function sanitizeValue(value: any) {
             if (!Array.isArray(value)) {
                 return [];
             }
-            return value.filter(
-                (v: any) => options.value.some((o) => objectUtil.isEqual(getOptionValue(o), v)),
-            );
+            const removed: any[] = [];
+            const kept = value.filter((v: any) => {
+                const found = options.value.some((o) => objectUtil.isEqual(getOptionValue(o), v));
+                if (!found) {
+                    removed.push(v);
+                }
+                return found;
+            });
+            if (removed.length > 0) {
+                const attempted = JSON.stringify(value);
+                const missing = JSON.stringify(removed);
+                logUtil.warning(
+                    'VsCheckboxSet',
+                    `Tried to set ${attempted}, but some values are not in options: ${missing}. Removed them.`,
+                );
+            }
+            return kept;
         }
-
-        watch(modelValue, (newValue) => {
-            warnIfInvalid(newValue);
-        });
 
         const {
             computedId,
@@ -193,11 +191,10 @@ export default defineComponent({
                 state,
                 callbacks: {
                     onMounted: () => {
-                        warnIfInvalid(modelValue.value);
-                        inputValue.value = convertValue(inputValue.value);
+                        inputValue.value = sanitizeValue(modelValue.value);
                     },
                     onChange: () => {
-                        inputValue.value = convertValue(inputValue.value);
+                        inputValue.value = sanitizeValue(inputValue.value);
                     },
                     onClear: () => {
                         inputValue.value = [];

--- a/packages/vlossom/src/components/vs-checkbox/VsCheckboxSet.vue
+++ b/packages/vlossom/src/components/vs-checkbox/VsCheckboxSet.vue
@@ -56,7 +56,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, ref, toRefs, type PropType, type TemplateRef } from 'vue';
+import { computed, defineComponent, ref, toRefs, watch, type PropType, type TemplateRef } from 'vue';
 import { VsComponent, type Size } from '@/declaration';
 import {
     getColorSchemeProps,
@@ -67,7 +67,7 @@ import {
     getMinMaxProps,
 } from '@/props';
 import { useColorScheme, useInput, useSizeClass, useStyleSet, useInputOption } from '@/composables';
-import { objectUtil } from '@/utils';
+import { logUtil, objectUtil } from '@/utils';
 
 import type { VsCheckboxSetStyleSet } from './types';
 import { useVsCheckboxSetRules } from './vs-checkbox-set-rules';
@@ -143,6 +143,31 @@ export default defineComponent({
             ref(true),
         );
 
+        function warnIfInvalid(value: any) {
+            if (!Array.isArray(value)) {
+                return;
+            }
+            const invalidValues = value.filter(
+                (v: any) => !options.value.some((o) => objectUtil.isEqual(getOptionValue(o), v)),
+            );
+            if (invalidValues.length > 0) {
+                logUtil.warning('VsCheckboxSet', `${JSON.stringify(invalidValues)} not in options, ignored`);
+            }
+        }
+
+        function convertValue(value: any) {
+            if (!Array.isArray(value)) {
+                return [];
+            }
+            return value.filter(
+                (v: any) => options.value.some((o) => objectUtil.isEqual(getOptionValue(o), v)),
+            );
+        }
+
+        watch(modelValue, (newValue) => {
+            warnIfInvalid(newValue);
+        });
+
         const {
             computedId,
             computedMessages,
@@ -168,14 +193,11 @@ export default defineComponent({
                 state,
                 callbacks: {
                     onMounted: () => {
-                        if (!Array.isArray(inputValue.value)) {
-                            inputValue.value = [];
-                        }
+                        warnIfInvalid(modelValue.value);
+                        inputValue.value = convertValue(inputValue.value);
                     },
                     onChange: () => {
-                        if (!Array.isArray(inputValue.value)) {
-                            inputValue.value = [];
-                        }
+                        inputValue.value = convertValue(inputValue.value);
                     },
                     onClear: () => {
                         inputValue.value = [];

--- a/packages/vlossom/src/components/vs-checkbox/VsCheckboxSet.vue
+++ b/packages/vlossom/src/components/vs-checkbox/VsCheckboxSet.vue
@@ -151,7 +151,7 @@ export default defineComponent({
                 (v: any) => !options.value.some((o) => objectUtil.isEqual(getOptionValue(o), v)),
             );
             if (invalidValues.length > 0) {
-                logUtil.warning('VsCheckboxSet', `${JSON.stringify(invalidValues)} not in options, ignored`);
+                logUtil.warning('VsCheckboxSet', `${JSON.stringify(invalidValues)} not in options, removed`);
             }
         }
 

--- a/packages/vlossom/src/components/vs-checkbox/__tests__/vs-checkbox-set.test.ts
+++ b/packages/vlossom/src/components/vs-checkbox/__tests__/vs-checkbox-set.test.ts
@@ -260,4 +260,96 @@ describe('VsCheckboxSet', () => {
             expect(updateModelValueEvent).toBeUndefined();
         });
     });
+
+    describe('invalid modelValue warning', () => {
+        it('options에 없는 초기 modelValue가 있으면 경고가 출력된다', async () => {
+            // given
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            // when
+            mount(VsCheckboxSet, {
+                props: {
+                    options: ['A', 'B', 'C'],
+                    modelValue: ['A', 'X', 'Y'],
+                },
+            });
+            await nextTick();
+
+            // then
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('not in options'));
+            warnSpy.mockRestore();
+        });
+
+        it('options에 있는 유효한 초기 modelValue를 설정하면 경고가 출력되지 않는다', async () => {
+            // given
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            // when
+            mount(VsCheckboxSet, {
+                props: {
+                    options: ['A', 'B', 'C'],
+                    modelValue: ['A', 'B'],
+                },
+            });
+            await nextTick();
+
+            // then
+            expect(warnSpy).not.toHaveBeenCalled();
+            warnSpy.mockRestore();
+        });
+
+        it('프로그래매틱하게 options에 없는 값이 포함된 배열로 변경하면 경고가 출력된다', async () => {
+            // given
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            const wrapper = mount(VsCheckboxSet, {
+                props: {
+                    options: ['A', 'B', 'C'],
+                    modelValue: ['A'],
+                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+                },
+            });
+
+            // when
+            await wrapper.setProps({ modelValue: ['A', 'X', 'Y'] });
+            await nextTick();
+
+            // then
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('not in options'));
+            warnSpy.mockRestore();
+        });
+
+        it('options에 없는 초기 modelValue가 포함되면 유효한 값만 남도록 리셋된다', async () => {
+            // given
+            const wrapper = mount(VsCheckboxSet, {
+                props: {
+                    options: ['A', 'B', 'C'],
+                    modelValue: ['A', 'X', 'Y'],
+                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+                },
+            });
+            await nextTick();
+
+            // then
+            expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([['A']]);
+        });
+
+        it('프로그래매틱하게 options에 없는 값이 포함된 배열로 변경하면 유효한 값만 남도록 리셋된다', async () => {
+            // given
+            const wrapper = mount(VsCheckboxSet, {
+                props: {
+                    options: ['A', 'B', 'C'],
+                    modelValue: ['A'],
+                    'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+                },
+            });
+
+            // when
+            await wrapper.setProps({ modelValue: ['A', 'X', 'Y'] });
+            await nextTick();
+
+            // then
+            const events = wrapper.emitted('update:modelValue');
+            expect(events?.[events.length - 1]).toEqual([['A']]);
+        });
+    });
 });

--- a/packages/vlossom/src/components/vs-radio/README.ko.md
+++ b/packages/vlossom/src/components/vs-radio/README.ko.md
@@ -237,3 +237,8 @@ interface VsRadioSetStyleSet extends CSSProperties {
 | `validate` | -          | 유효성 검사 실행               |
 | `clear`    | -          | 선택 값 비우기                |
 | `reset`    | -          | 선택 값을 초기값으로 되돌리기  |
+
+## Cautions
+
+- `VsRadioSet`의 `modelValue`에 `options`에 없는 값을 설정하면 (마운트 시 또는 프로그래매틱하게) 해당 값은 `null`로 초기화되고 콘솔 경고가 출력됩니다.
+- `options`가 변경되어 현재 `modelValue`가 더 이상 존재하지 않으면 값이 `null`로 초기화되고 콘솔 경고가 출력됩니다.

--- a/packages/vlossom/src/components/vs-radio/README.md
+++ b/packages/vlossom/src/components/vs-radio/README.md
@@ -237,3 +237,8 @@ interface VsRadioSetStyleSet extends CSSProperties {
 | `validate` | -          | Triggers validation              |
 | `clear`    | -          | Clears the selected value        |
 | `reset`    | -          | Resets the selected value to its initial value |
+
+## Cautions
+
+- If `modelValue` of `VsRadioSet` is set to a value not present in `options` — either on mount or programmatically — the value is reset to `null` and a console warning is printed.
+- If `options` changes and the current `modelValue` is no longer present, the value is reset to `null` and a console warning is printed.

--- a/packages/vlossom/src/components/vs-radio/VsRadioSet.vue
+++ b/packages/vlossom/src/components/vs-radio/VsRadioSet.vue
@@ -56,11 +56,11 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, ref, toRefs, type TemplateRef, useTemplateRef, type PropType } from 'vue';
+import { computed, defineComponent, ref, toRefs, watch, type TemplateRef, useTemplateRef, type PropType } from 'vue';
 import { useColorScheme, useInput, useInputOption, useSizeClass, useStyleSet } from '@/composables';
 import { getColorSchemeProps, getOptionsProps, getInputProps, getResponsiveProps, getStyleSetProps } from '@/props';
 import { VsComponent, type Size } from '@/declaration';
-import { objectUtil } from '@/utils';
+import { logUtil, objectUtil } from '@/utils';
 import type { VsRadioSetStyleSet } from './types';
 
 import VsInputWrapper from '@/components/vs-input-wrapper/VsInputWrapper.vue';
@@ -125,6 +125,28 @@ export default defineComponent({
 
         const { getOptionLabel, getOptionValue } = useInputOption(inputValue, options, optionLabel, optionValue);
 
+        function warnIfInvalid(value: any) {
+            if (value === null || value === undefined) {
+                return;
+            }
+            const found = options.value.some((o) => objectUtil.isEqual(getOptionValue(o), value));
+            if (!found) {
+                logUtil.warning('VsRadioSet', `"${value}" not in options, ignored`);
+            }
+        }
+
+        function convertValue(value: any) {
+            if (value === null || value === undefined) {
+                return value;
+            }
+            const found = options.value.some((o) => objectUtil.isEqual(getOptionValue(o), value));
+            return found ? value : null;
+        }
+
+        watch(modelValue, (newValue) => {
+            warnIfInvalid(newValue);
+        });
+
         function requiredCheck(value: any) {
             if (!required.value) {
                 return '';
@@ -157,6 +179,13 @@ export default defineComponent({
                 noDefaultRules,
                 state,
                 callbacks: {
+                    onMounted: () => {
+                        warnIfInvalid(modelValue.value);
+                        inputValue.value = convertValue(inputValue.value);
+                    },
+                    onChange: () => {
+                        inputValue.value = convertValue(inputValue.value);
+                    },
                     onClear: () => {
                         inputValue.value = null;
                     },

--- a/packages/vlossom/src/components/vs-radio/VsRadioSet.vue
+++ b/packages/vlossom/src/components/vs-radio/VsRadioSet.vue
@@ -56,7 +56,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, ref, toRefs, watch, type TemplateRef, useTemplateRef, type PropType } from 'vue';
+import { computed, defineComponent, ref, toRefs, type TemplateRef, useTemplateRef, type PropType } from 'vue';
 import { useColorScheme, useInput, useInputOption, useSizeClass, useStyleSet } from '@/composables';
 import { getColorSchemeProps, getOptionsProps, getInputProps, getResponsiveProps, getStyleSetProps } from '@/props';
 import { VsComponent, type Size } from '@/declaration';
@@ -125,27 +125,18 @@ export default defineComponent({
 
         const { getOptionLabel, getOptionValue } = useInputOption(inputValue, options, optionLabel, optionValue);
 
-        function warnIfInvalid(value: any) {
-            if (value === null || value === undefined) {
-                return;
-            }
-            const found = options.value.some((o) => objectUtil.isEqual(getOptionValue(o), value));
-            if (!found) {
-                logUtil.warning('VsRadioSet', `"${value}" not in options, reset to null`);
-            }
-        }
-
-        function convertValue(value: any) {
+        function sanitizeValue(value: any) {
             if (value === null || value === undefined) {
                 return value;
             }
             const found = options.value.some((o) => objectUtil.isEqual(getOptionValue(o), value));
-            return found ? value : null;
+            if (!found) {
+                const attempted = JSON.stringify(value);
+                logUtil.warning('VsRadioSet', `Tried to set ${attempted}, but it is not in options. Reset to null.`);
+                return null;
+            }
+            return value;
         }
-
-        watch(modelValue, (newValue) => {
-            warnIfInvalid(newValue);
-        });
 
         function requiredCheck(value: any) {
             if (!required.value) {
@@ -180,11 +171,10 @@ export default defineComponent({
                 state,
                 callbacks: {
                     onMounted: () => {
-                        warnIfInvalid(modelValue.value);
-                        inputValue.value = convertValue(inputValue.value);
+                        inputValue.value = sanitizeValue(modelValue.value);
                     },
                     onChange: () => {
-                        inputValue.value = convertValue(inputValue.value);
+                        inputValue.value = sanitizeValue(inputValue.value);
                     },
                     onClear: () => {
                         inputValue.value = null;

--- a/packages/vlossom/src/components/vs-radio/VsRadioSet.vue
+++ b/packages/vlossom/src/components/vs-radio/VsRadioSet.vue
@@ -131,7 +131,7 @@ export default defineComponent({
             }
             const found = options.value.some((o) => objectUtil.isEqual(getOptionValue(o), value));
             if (!found) {
-                logUtil.warning('VsRadioSet', `"${value}" not in options, ignored`);
+                logUtil.warning('VsRadioSet', `"${value}" not in options, reset to null`);
             }
         }
 

--- a/packages/vlossom/src/components/vs-radio/__tests__/vs-radio-set.test.ts
+++ b/packages/vlossom/src/components/vs-radio/__tests__/vs-radio-set.test.ts
@@ -246,7 +246,7 @@ describe('VsRadioSet', () => {
             await nextTick();
 
             // then
-            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"invalid" not in options'));
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Tried to set "invalid"'));
             warnSpy.mockRestore();
         });
 
@@ -284,7 +284,7 @@ describe('VsRadioSet', () => {
             await nextTick();
 
             // then
-            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"invalid" not in options'));
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Tried to set "invalid"'));
             warnSpy.mockRestore();
         });
 

--- a/packages/vlossom/src/components/vs-radio/__tests__/vs-radio-set.test.ts
+++ b/packages/vlossom/src/components/vs-radio/__tests__/vs-radio-set.test.ts
@@ -230,4 +230,96 @@ describe('VsRadioSet', () => {
             expect(wrapper.emitted('clear')?.[0]).toEqual(['A']);
         });
     });
+
+    describe('invalid modelValue warning', () => {
+        it('options에 없는 초기 modelValue를 설정하면 경고가 출력된다', async () => {
+            // given
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            // when
+            mount(VsRadioSet, {
+                props: {
+                    options: ['A', 'B', 'C'],
+                    modelValue: 'invalid',
+                },
+            });
+            await nextTick();
+
+            // then
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"invalid" not in options'));
+            warnSpy.mockRestore();
+        });
+
+        it('options에 있는 유효한 초기 modelValue를 설정하면 경고가 출력되지 않는다', async () => {
+            // given
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            // when
+            mount(VsRadioSet, {
+                props: {
+                    options: ['A', 'B', 'C'],
+                    modelValue: 'A',
+                },
+            });
+            await nextTick();
+
+            // then
+            expect(warnSpy).not.toHaveBeenCalled();
+            warnSpy.mockRestore();
+        });
+
+        it('프로그래매틱하게 options에 없는 값으로 변경하면 경고가 출력된다', async () => {
+            // given
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            const wrapper: VueWrapper<InstanceType<typeof VsRadioSet>> = mount(VsRadioSet, {
+                props: {
+                    options: ['A', 'B', 'C'],
+                    modelValue: 'A',
+                    'onUpdate:modelValue': (value) => wrapper.setProps({ modelValue: value }),
+                },
+            });
+
+            // when
+            await wrapper.setProps({ modelValue: 'invalid' });
+            await nextTick();
+
+            // then
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"invalid" not in options'));
+            warnSpy.mockRestore();
+        });
+
+        it('options에 없는 초기 modelValue를 설정하면 null로 리셋된다', async () => {
+            // given
+            const wrapper: VueWrapper<InstanceType<typeof VsRadioSet>> = mount(VsRadioSet, {
+                props: {
+                    options: ['A', 'B', 'C'],
+                    modelValue: 'invalid',
+                    'onUpdate:modelValue': (value) => wrapper.setProps({ modelValue: value }),
+                },
+            });
+            await nextTick();
+
+            // then
+            expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([null]);
+        });
+
+        it('프로그래매틱하게 options에 없는 값으로 변경하면 null로 리셋된다', async () => {
+            // given
+            const wrapper: VueWrapper<InstanceType<typeof VsRadioSet>> = mount(VsRadioSet, {
+                props: {
+                    options: ['A', 'B', 'C'],
+                    modelValue: 'A',
+                    'onUpdate:modelValue': (value) => wrapper.setProps({ modelValue: value }),
+                },
+            });
+
+            // when
+            await wrapper.setProps({ modelValue: 'invalid' });
+            await nextTick();
+
+            // then
+            const events = wrapper.emitted('update:modelValue');
+            expect(events?.[events.length - 1]).toEqual([null]);
+        });
+    });
 });

--- a/packages/vlossom/src/components/vs-select/README.ko.md
+++ b/packages/vlossom/src/components/vs-select/README.ko.md
@@ -181,3 +181,8 @@ interface VsSelectStyleSet extends CSSProperties {
 | `validate`     | -          | 유효성 검사 실행              |
 | `clear`        | -          | 선택 값 비우기               |
 | `reset`        | -          | 선택 값을 초기값으로 되돌리기 |
+
+## Cautions
+
+- `modelValue`에 `options`에 없는 값을 설정하면 (마운트 시 또는 프로그래매틱하게) 해당 값은 `null`로 초기화되거나 (단일 선택) 유효하지 않은 항목이 제거되며 (다중 선택) 콘솔 경고가 출력됩니다.
+- `options`가 변경되어 현재 `modelValue`가 더 이상 존재하지 않으면, 단일 선택 모드에서는 `null`로 초기화되고 다중 선택 모드에서는 없어진 항목이 제거되며 콘솔 경고가 출력됩니다.

--- a/packages/vlossom/src/components/vs-select/README.md
+++ b/packages/vlossom/src/components/vs-select/README.md
@@ -181,3 +181,9 @@ interface VsSelectStyleSet extends CSSProperties {
 | `validate`     | -          | Triggers validation                             |
 | `clear`        | -          | Clears the selected value                        |
 | `reset`        | -          | Resets the selected value to its initial value  |
+
+
+## Cautions
+
+- If `modelValue` is set to a value not present in `options` — either on mount or programmatically — the invalid value is reset to `null` (single) or the invalid entries are removed (multiple), and a console warning is printed.
+- If `options` changes and the current `modelValue` is no longer present, the value is reset to `null` (single) or the missing entries are removed (multiple), and a console warning is printed.

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -151,7 +151,7 @@ import {
     useClickOutside,
     useSizeClass,
 } from '@/composables';
-import { objectUtil } from '@/utils';
+import { logUtil, objectUtil } from '@/utils';
 import type { VsSelectStyleSet, VsSelectTriggerRef } from './types';
 import { useSelectRules } from './vs-select-rules';
 import { useSelectValue, useSelectSearch, useSelectKeyboard } from './composables';
@@ -279,6 +279,25 @@ export default defineComponent({
 
         useInputOption(inputValue, options, optionLabel, optionValue, multiple);
 
+        function warnIfInvalid(value: any) {
+            if (value === null || value === undefined) {
+                return;
+            }
+            const isArrayMultiple = multiple.value && Array.isArray(value);
+            const valueArray = isArrayMultiple ? value : [value];
+            const invalidValues = valueArray.filter(
+                (v: any) => !computedOptions.value.some((o) => objectUtil.isEqual(o.value, v)),
+            );
+            if (invalidValues.length > 0) {
+                const display = isArrayMultiple ? JSON.stringify(invalidValues) : `"${invalidValues[0]}"`;
+                logUtil.warning('VsSelect', `${display} not in options, ignored`);
+            }
+        }
+
+        watch(modelValue, (newValue) => {
+            warnIfInvalid(newValue);
+        });
+
         const {
             computedId,
             computedMessages,
@@ -310,6 +329,7 @@ export default defineComponent({
                 state,
                 callbacks: {
                     onMounted: () => {
+                        warnIfInvalid(modelValue.value);
                         inputValue.value = convertValue(inputValue.value);
                     },
                     onChange: () => {

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -279,25 +279,6 @@ export default defineComponent({
 
         useInputOption(inputValue, options, optionLabel, optionValue, multiple);
 
-        function warnIfInvalid(value: any) {
-            if (value === null || value === undefined) {
-                return;
-            }
-            const isArrayMultiple = multiple.value && Array.isArray(value);
-            const valueArray = isArrayMultiple ? value : [value];
-            const invalidValues = valueArray.filter(
-                (v: any) => !computedOptions.value.some((o) => objectUtil.isEqual(o.value, v)),
-            );
-            if (invalidValues.length > 0) {
-                const display = isArrayMultiple ? JSON.stringify(invalidValues) : `"${invalidValues[0]}"`;
-                logUtil.warning('VsSelect', `${display} not in options, reset`);
-            }
-        }
-
-        watch(modelValue, (newValue) => {
-            warnIfInvalid(newValue);
-        });
-
         const {
             computedId,
             computedMessages,
@@ -329,11 +310,10 @@ export default defineComponent({
                 state,
                 callbacks: {
                     onMounted: () => {
-                        warnIfInvalid(modelValue.value);
-                        inputValue.value = convertValue(inputValue.value);
+                        inputValue.value = sanitizeValue(modelValue.value);
                     },
                     onChange: () => {
-                        inputValue.value = convertValue(inputValue.value);
+                        inputValue.value = sanitizeValue(inputValue.value);
                     },
                     onClear: () => {
                         clearSelected();
@@ -353,6 +333,7 @@ export default defineComponent({
             isEmpty,
             selectedOptions,
             convertValue,
+            isExistingValue,
             deselectOption,
             toggleSelect,
             clearSelected,
@@ -364,6 +345,28 @@ export default defineComponent({
             filteredOptions,
             multiple,
         });
+
+        function sanitizeValue(value: any) {
+            if (value === null || value === undefined) {
+                return convertValue(value);
+            }
+            const isArrayMultiple = multiple.value && Array.isArray(value);
+            const valueArray = isArrayMultiple ? value : [value];
+            const removed = valueArray.filter((v: any) => !isExistingValue(v));
+            if (removed.length > 0) {
+                const attempted = JSON.stringify(value);
+                if (isArrayMultiple) {
+                    const missing = JSON.stringify(removed);
+                    logUtil.warning(
+                        'VsSelect',
+                        `Tried to set ${attempted}, but some values are not in options: ${missing}. Removed them.`,
+                    );
+                } else {
+                    logUtil.warning('VsSelect', `Tried to set ${attempted}, but it is not in options. Reset to null.`);
+                }
+            }
+            return convertValue(value);
+        }
 
         const { computedCallbacks } = useSelectKeyboard({
             isOpen,

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -290,7 +290,7 @@ export default defineComponent({
             );
             if (invalidValues.length > 0) {
                 const display = isArrayMultiple ? JSON.stringify(invalidValues) : `"${invalidValues[0]}"`;
-                logUtil.warning('VsSelect', `${display} not in options, ignored`);
+                logUtil.warning('VsSelect', `${display} not in options, reset`);
             }
         }
 

--- a/packages/vlossom/src/components/vs-select/VsSelectTrigger.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelectTrigger.vue
@@ -18,7 +18,6 @@
                         :color-scheme
                         :closable="closableChips"
                         :style-set="componentStyleSet.$chip"
-                        primary
                         size="xs"
                         @close="$emit('deselect', selectedOptions[0].id)"
                     >
@@ -33,7 +32,6 @@
                         :color-scheme
                         :closable="closableChips"
                         :style-set="componentStyleSet.$chip"
-                        primary
                         size="xs"
                         @close="$emit('deselect', option.id)"
                     >

--- a/packages/vlossom/src/components/vs-select/__tests__/vs-select.test.ts
+++ b/packages/vlossom/src/components/vs-select/__tests__/vs-select.test.ts
@@ -847,4 +847,81 @@ describe('VsSelect', () => {
             expect(wrapper.props('modelValue')).toEqual(['Banana']);
         });
     });
+
+    describe('invalid modelValue warning', () => {
+        it('단일 선택 모드에서 options에 없는 초기 modelValue를 설정하면 경고가 출력된다', async () => {
+            // given
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            // when
+            mount(VsSelect, {
+                props: {
+                    options: basicOptions,
+                    modelValue: 'invalid',
+                },
+            });
+            await nextTick();
+
+            // then
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"invalid" not in options'));
+            warnSpy.mockRestore();
+        });
+
+        it('다중 선택 모드에서 options에 없는 초기 modelValue가 있으면 경고가 출력된다', async () => {
+            // given
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            // when
+            mount(VsSelect, {
+                props: {
+                    options: basicOptions,
+                    modelValue: ['Apple', 'invalid'],
+                    multiple: true,
+                },
+            });
+            await nextTick();
+
+            // then
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('not in options'));
+            warnSpy.mockRestore();
+        });
+
+        it('options에 있는 유효한 초기 modelValue를 설정하면 경고가 출력되지 않는다', async () => {
+            // given
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            // when
+            mount(VsSelect, {
+                props: {
+                    options: basicOptions,
+                    modelValue: 'Apple',
+                },
+            });
+            await nextTick();
+
+            // then
+            expect(warnSpy).not.toHaveBeenCalled();
+            warnSpy.mockRestore();
+        });
+
+        it('프로그래매틱하게 options에 없는 값으로 변경하면 경고가 출력된다', async () => {
+            // given
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            const wrapper = mount(VsSelect, {
+                props: {
+                    options: basicOptions,
+                    modelValue: 'Apple',
+                    'onUpdate:modelValue': (e: any) => wrapper.setProps({ modelValue: e }),
+                },
+            });
+
+            // when
+            await wrapper.setProps({ modelValue: 'invalid' });
+            await nextTick();
+
+            // then
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"invalid" not in options'));
+            warnSpy.mockRestore();
+        });
+    });
 });

--- a/packages/vlossom/src/components/vs-select/__tests__/vs-select.test.ts
+++ b/packages/vlossom/src/components/vs-select/__tests__/vs-select.test.ts
@@ -863,7 +863,7 @@ describe('VsSelect', () => {
             await nextTick();
 
             // then
-            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"invalid" not in options'));
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Tried to set "invalid"'));
             warnSpy.mockRestore();
         });
 
@@ -920,7 +920,7 @@ describe('VsSelect', () => {
             await nextTick();
 
             // then
-            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"invalid" not in options'));
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Tried to set "invalid"'));
             warnSpy.mockRestore();
         });
     });

--- a/packages/vlossom/src/components/vs-select/composables/select-value-composable.ts
+++ b/packages/vlossom/src/components/vs-select/composables/select-value-composable.ts
@@ -142,6 +142,7 @@ export function useSelectValue({
         isEmpty,
         selectedOptions,
         convertValue,
+        isExistingValue,
         isSelected,
         selectOption,
         deselectOption,

--- a/packages/vlossom/src/composables/input-option/README.ko.md
+++ b/packages/vlossom/src/composables/input-option/README.ko.md
@@ -65,3 +65,4 @@ const { getOptionLabel, getOptionValue } = useInputOption(inputValue, options, o
 
 - `multiple`이 `false`이고 현재 값이 새 옵션에서 찾을 수 없는 경우, `inputValue`는 `null`로 설정됩니다.
 - `multiple`이 `true`인 경우, 새 옵션에 여전히 존재하는 값만 유지됩니다.
+- 값이 새 옵션에 없어서 제거될 때 콘솔 경고가 출력됩니다.

--- a/packages/vlossom/src/composables/input-option/README.md
+++ b/packages/vlossom/src/composables/input-option/README.md
@@ -65,3 +65,4 @@ No additional exported types.
 
 - When `multiple` is `false` and the current value is not found in the new options, `inputValue` is set to `null`.
 - When `multiple` is `true`, only values that still exist in the new options are retained.
+- When a value is cleared because it is no longer in the new options, a console warning is printed.

--- a/packages/vlossom/src/composables/input-option/__tests__/input-option-composable.test.ts
+++ b/packages/vlossom/src/composables/input-option/__tests__/input-option-composable.test.ts
@@ -152,7 +152,9 @@ describe('useInputOption', () => {
                 await nextTick();
 
                 // then
-                expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"A" not in options'));
+                expect(warnSpy).toHaveBeenCalledWith(
+                    expect.stringContaining('Current value "A" is no longer in options'),
+                );
                 warnSpy.mockRestore();
             });
 
@@ -207,7 +209,7 @@ describe('useInputOption', () => {
                 await nextTick();
 
                 // then
-                expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('not in options'));
+                expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('no longer in options'));
                 warnSpy.mockRestore();
             });
 

--- a/packages/vlossom/src/composables/input-option/__tests__/input-option-composable.test.ts
+++ b/packages/vlossom/src/composables/input-option/__tests__/input-option-composable.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { ref, nextTick } from 'vue';
 import { useInputOption } from './../input-option-composable';
 
@@ -134,6 +134,100 @@ describe('useInputOption', () => {
 
                 // then
                 expect(inputValue.value).toEqual([2]);
+            });
+        });
+
+        describe('options 변경 시 invalid value 경고', () => {
+            it('single 모드에서 options에 없는 값이 있으면 경고를 출력한다', async () => {
+                // given
+                const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+                const inputValue = ref('A');
+                const options = ref(['A', 'B', 'C']);
+                const optionLabel = ref('');
+                const optionValue = ref('');
+                useInputOption(inputValue, options, optionLabel, optionValue);
+
+                // when
+                options.value = ['D', 'E', 'F'];
+                await nextTick();
+
+                // then
+                expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"A" not in options'));
+                warnSpy.mockRestore();
+            });
+
+            it('single 모드에서 options에 값이 있으면 경고를 출력하지 않는다', async () => {
+                // given
+                const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+                const inputValue = ref('A');
+                const options = ref(['A', 'B', 'C']);
+                const optionLabel = ref('');
+                const optionValue = ref('');
+                useInputOption(inputValue, options, optionLabel, optionValue);
+
+                // when
+                options.value = ['A', 'D', 'E'];
+                await nextTick();
+
+                // then
+                expect(warnSpy).not.toHaveBeenCalled();
+                warnSpy.mockRestore();
+            });
+
+            it('single 모드에서 inputValue가 null이면 경고를 출력하지 않는다', async () => {
+                // given
+                const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+                const inputValue = ref(null);
+                const options = ref(['A', 'B', 'C']);
+                const optionLabel = ref('');
+                const optionValue = ref('');
+                useInputOption(inputValue, options, optionLabel, optionValue);
+
+                // when
+                options.value = ['D', 'E', 'F'];
+                await nextTick();
+
+                // then
+                expect(warnSpy).not.toHaveBeenCalled();
+                warnSpy.mockRestore();
+            });
+
+            it('multiple 모드에서 options에 없는 값이 있으면 경고를 출력한다', async () => {
+                // given
+                const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+                const inputValue = ref(['A', 'B', 'C']);
+                const options = ref(['A', 'B', 'C', 'D']);
+                const optionLabel = ref('');
+                const optionValue = ref('');
+                const multiple = ref(true);
+                useInputOption(inputValue, options, optionLabel, optionValue, multiple);
+
+                // when
+                options.value = ['B', 'D', 'E'];
+                await nextTick();
+
+                // then
+                expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('not in options'));
+                warnSpy.mockRestore();
+            });
+
+            it('multiple 모드에서 모든 값이 options에 있으면 경고를 출력하지 않는다', async () => {
+                // given
+                const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+                const inputValue = ref(['A', 'B']);
+                const options = ref(['A', 'B', 'C']);
+                const optionLabel = ref('');
+                const optionValue = ref('');
+                const multiple = ref(true);
+                useInputOption(inputValue, options, optionLabel, optionValue, multiple);
+
+                // when
+                options.value = ['A', 'B', 'D'];
+                await nextTick();
+
+                // then
+                expect(warnSpy).not.toHaveBeenCalled();
+                warnSpy.mockRestore();
             });
         });
 

--- a/packages/vlossom/src/composables/input-option/input-option-composable.ts
+++ b/packages/vlossom/src/composables/input-option/input-option-composable.ts
@@ -17,21 +17,30 @@ export function useInputOption(
         }
 
         if (multiple.value && Array.isArray(inputValue.value)) {
-            const removedValues = inputValue.value.filter((value) => {
-                return !newOptions.some((o) => objectUtil.isEqual(getOptionValue(o), value));
+            const removedValues: any[] = [];
+            const keptValues = inputValue.value.filter((value) => {
+                const found = newOptions.some((o) => objectUtil.isEqual(getOptionValue(o), value));
+                if (!found) {
+                    removedValues.push(value);
+                }
+                return found;
             });
             if (removedValues.length > 0) {
-                logUtil.warning('modelValue', `${JSON.stringify(removedValues)} not in options, removed`);
+                logUtil.warning(
+                    'modelValue',
+                    `Some selected values are no longer in options: ${JSON.stringify(removedValues)}. Removed them.`,
+                );
             }
-            inputValue.value = inputValue.value.filter((value) => {
-                return newOptions.some((o) => objectUtil.isEqual(getOptionValue(o), value));
-            });
+            inputValue.value = keptValues;
         } else {
             const option = newOptions.find((o) => objectUtil.isEqual(getOptionValue(o), inputValue.value));
 
             if (!option) {
                 if (inputValue.value !== null && inputValue.value !== undefined) {
-                    logUtil.warning('modelValue', `"${inputValue.value}" not in options, reset to null`);
+                    logUtil.warning(
+                        'modelValue',
+                        `Current value ${JSON.stringify(inputValue.value)} is no longer in options. Reset to null.`,
+                    );
                 }
                 inputValue.value = null;
             }

--- a/packages/vlossom/src/composables/input-option/input-option-composable.ts
+++ b/packages/vlossom/src/composables/input-option/input-option-composable.ts
@@ -1,5 +1,5 @@
 import { watch, ref, type Ref } from 'vue';
-import { objectUtil } from '@/utils';
+import { logUtil, objectUtil } from '@/utils';
 import { useOptionLabelValue } from '@/composables/option-label-value/option-label-value-composable';
 
 export function useInputOption(
@@ -17,6 +17,12 @@ export function useInputOption(
         }
 
         if (multiple.value && Array.isArray(inputValue.value)) {
+            const removedValues = inputValue.value.filter((value) => {
+                return !newOptions.some((o) => objectUtil.isEqual(getOptionValue(o), value));
+            });
+            if (removedValues.length > 0) {
+                logUtil.warning('modelValue', `${JSON.stringify(removedValues)} not in options, removed`);
+            }
             inputValue.value = inputValue.value.filter((value) => {
                 return newOptions.some((o) => objectUtil.isEqual(getOptionValue(o), value));
             });
@@ -24,6 +30,9 @@ export function useInputOption(
             const option = newOptions.find((o) => objectUtil.isEqual(getOptionValue(o), inputValue.value));
 
             if (!option) {
+                if (inputValue.value !== null && inputValue.value !== undefined) {
+                    logUtil.warning('modelValue', `"${inputValue.value}" not in options, reset to null`);
+                }
                 inputValue.value = null;
             }
         }


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
VsSelect, VsRadioSet, VsCheckboxSet에 option에 없는 유효하지 않은 값이 할당될 때 대응

## Description
- 유효하지 않은 값이 들어오면 warning 하도록 수정
- options가 변경될 때도 유효하지 않은 값이 있을 때는 정리하고, warning
- README에 Cautions 정리
- 테스트 코드 추가
- VsRadioSet, VsCheckboxSet
  - VsSelect와 다르게 값을 정제하는 부분이 없어서 추가함
<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
