### PR TITLE
fix(VsTable): search rendered cell values and add search.extraKeys

### DIFF
--- a/packages/vlossom/src/components/vs-search-input/README.ko.md
+++ b/packages/vlossom/src/components/vs-search-input/README.ko.md
@@ -74,7 +74,7 @@ const filteredItems = computed(() => items.filter(item => searchRef.value?.match
 | `width`            | `string \| number \| Breakpoints` | -     | -        | 반응형 너비                                          |
 | `grid`             | `string \| number \| Breakpoints` | -     | -        | 그리드 컬럼 스팬                                     |
 | `disabled`         | `boolean`                       | `false` | -        | 입력 비활성화                                        |
-| `placeholder`      | `string`                        | `''`    | -        | 플레이스홀더 텍스트                                  |
+| `placeholder`      | `string`                        | `'Search'` | -     | 플레이스홀더 텍스트                                  |
 | `readonly`         | `boolean`                       | `false` | -        | 입력을 읽기 전용으로 설정                            |
 | `size`             | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'` | -    | 입력 영역 높이 · 패딩 · 폰트 · 토글 버튼 크기 제어   |
 | `useCaseSensitive` | `boolean`                       | `false` | -        | 대소문자 구분 토글 버튼 표시                         |

--- a/packages/vlossom/src/components/vs-search-input/README.md
+++ b/packages/vlossom/src/components/vs-search-input/README.md
@@ -74,7 +74,7 @@ const filteredItems = computed(() => items.filter(item => searchRef.value?.match
 | `width`            | `string \| number \| Breakpoints` | -     | -        | Responsive width                                     |
 | `grid`             | `string \| number \| Breakpoints` | -     | -        | Grid column span                                     |
 | `disabled`         | `boolean`                       | `false` | -        | Disables the input                                   |
-| `placeholder`      | `string`                        | `''`    | -        | Placeholder text                                     |
+| `placeholder`      | `string`                        | `'Search'` | -     | Placeholder text                                     |
 | `readonly`         | `boolean`                       | `false` | -        | Makes the input read-only                            |
 | `size`             | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'` | -    | Input height, padding, font, and toggle button size  |
 | `useCaseSensitive` | `boolean`                       | `false` | -        | Shows the case-sensitive toggle button               |

--- a/packages/vlossom/src/components/vs-search-input/VsSearchInput.vue
+++ b/packages/vlossom/src/components/vs-search-input/VsSearchInput.vue
@@ -86,7 +86,7 @@ export default defineComponent({
         ...getStyleSetProps<VsSearchInputStyleSet>(),
         ...getResponsiveProps(),
         disabled: { type: Boolean, default: false },
-        placeholder: { type: String, default: '' },
+        placeholder: { type: String, default: 'Search' },
         readonly: { type: Boolean, default: false },
         size: { type: String as PropType<Size>, default: 'md' },
         useCaseSensitive: { type: Boolean, default: false },

--- a/packages/vlossom/src/components/vs-select/composables/__tests__/select-search-composable.test.ts
+++ b/packages/vlossom/src/components/vs-select/composables/__tests__/select-search-composable.test.ts
@@ -106,7 +106,6 @@ describe('useSelectSearch', () => {
             expect(searchProps.value).toEqual({
                 useRegex: true,
                 useCaseSensitive: true,
-                placeholder: '',
             });
         });
 
@@ -121,7 +120,6 @@ describe('useSelectSearch', () => {
             expect(searchProps.value).toEqual({
                 useRegex: true,
                 useCaseSensitive: true,
-                placeholder: '',
             });
         });
     });
@@ -182,7 +180,7 @@ describe('useSelectSearch', () => {
             expect(searchProps.value.placeholder).toBe('Search options...');
         });
 
-        it('placeholder가 명시되지 않으면 빈 문자열을 사용해야 한다', () => {
+        it('placeholder가 명시되지 않으면 VsSearchInput의 기본값에 맡긴다', () => {
             // given
             const search = ref<SearchProps>({});
 
@@ -190,7 +188,7 @@ describe('useSelectSearch', () => {
             const { searchProps } = useSelectSearch(search);
 
             // then
-            expect(searchProps.value.placeholder).toBe('');
+            expect(searchProps.value.placeholder).toBeUndefined();
         });
 
         it('모든 속성을 명시한 경우 해당 값들을 사용해야 한다', () => {
@@ -225,7 +223,6 @@ describe('useSelectSearch', () => {
             expect(searchProps.value).toEqual({
                 useRegex: false,
                 useCaseSensitive: true,
-                placeholder: '',
             });
         });
     });
@@ -239,7 +236,6 @@ describe('useSelectSearch', () => {
             expect(searchProps.value).toEqual({
                 useRegex: true,
                 useCaseSensitive: true,
-                placeholder: '',
             });
 
             // when
@@ -290,7 +286,6 @@ describe('useSelectSearch', () => {
             expect(searchProps.value).toEqual({
                 useRegex: true,
                 useCaseSensitive: true,
-                placeholder: '',
             });
 
             // when - search true로 변경
@@ -301,7 +296,6 @@ describe('useSelectSearch', () => {
             expect(searchProps.value).toEqual({
                 useRegex: true,
                 useCaseSensitive: true,
-                placeholder: '',
             });
 
             // when - search 객체로 변경
@@ -327,7 +321,6 @@ describe('useSelectSearch', () => {
             expect(searchProps.value).toEqual({
                 useRegex: true,
                 useCaseSensitive: true,
-                placeholder: '',
             });
         });
     });

--- a/packages/vlossom/src/components/vs-select/composables/select-search-composable.ts
+++ b/packages/vlossom/src/components/vs-select/composables/select-search-composable.ts
@@ -19,13 +19,12 @@ export function useSelectSearch(search: Ref<SearchProps>) {
             return {
                 useRegex: true,
                 useCaseSensitive: true,
-                placeholder: '',
             };
         }
         return {
             useRegex: search.value.useRegex ?? true,
             useCaseSensitive: search.value.useCaseSensitive ?? true,
-            placeholder: search.value.placeholder ?? '',
+            placeholder: search.value.placeholder,
         };
     });
 

--- a/packages/vlossom/src/components/vs-table/README.ko.md
+++ b/packages/vlossom/src/components/vs-table/README.ko.md
@@ -42,6 +42,30 @@ const items = [
 </template>
 ```
 
+### 검색 범위
+
+검색은 테이블 바디에 렌더링된 값을 대상으로 동작하므로, 컬럼의 `transform` 결과도 화면에 보이는 그대로 검색됩니다. 범위는 두 가지 옵션으로 조정합니다.
+
+- 컬럼의 `skipSearch`: 렌더링되는 컬럼을 검색 대상에서 제외합니다.
+- `search.extraKeys`: 어떤 컬럼으로도 렌더링되지 않는 아이템 필드를 검색 대상에 추가합니다. 슬롯으로 값을 다른 셀에 끌어와 보여주거나, 숨겨진 메타데이터로 필터링할 때 사용합니다.
+
+```html
+<template>
+    <vs-table :columns="columns" :items="items" :search="{ extraKeys: ['tags'] }">
+        <template #body-name="{ item }">{{ item.name }} ({{ item.tags }})</template>
+    </vs-table>
+</template>
+
+<script setup>
+const columns = [
+    { key: 'name', label: 'Name' },
+    { key: 'note', label: 'Note', skipSearch: true },
+];
+</script>
+```
+
+같은 키가 `skipSearch` 컬럼이면서 `extraKeys`에도 있으면 제외가 우선합니다.
+
 ### 행 선택
 
 ```html
@@ -123,7 +147,7 @@ const selected = ref([]);
 | `pagination`      | `boolean \| VsTablePaginationOptions`          | `false`  | 페이지네이션 활성화                     |
 | `primary`         | `boolean`                                      | `false`  | 헤더에 기본 색상 적용                   |
 | `responsive`      | `boolean`                                      | `false`  | 반응형(스택) 레이아웃 활성화            |
-| `search`          | `boolean \| SearchProps`                       | `false`  | 내장 검색 활성화                        |
+| `search`          | `boolean \| VsTableSearchOptions`              | `false`  | 내장 검색 활성화                        |
 | `selectable`      | `boolean \| (item, index?, items?) => boolean` | `false`  | 행 선택 활성화                          |
 | `selectedItems`   | `VsTableItem[]`                                | `[]`     | 선택된 행, v-model                      |
 | `serverMode`      | `boolean`                                      | `false`  | 서버 측 페이지네이션 모드로 전환        |
@@ -146,6 +170,13 @@ interface VsTableStyleSet extends CSSProperties {
     $cell?: CSSProperties;
     $pagination?: VsPaginationStyleSet;
     $pageSizeSelect?: VsSelectStyleSet;
+}
+
+interface VsTableSearchOptions<I = VsTableItem> {
+    useRegex?: boolean;
+    useCaseSensitive?: boolean;
+    placeholder?: string;
+    extraKeys?: VsTableColumnKey<I>[];
 }
 
 interface VsTableColumnDef<I = VsTableItem> {

--- a/packages/vlossom/src/components/vs-table/README.ko.md
+++ b/packages/vlossom/src/components/vs-table/README.ko.md
@@ -64,7 +64,7 @@ const columns = [
 </script>
 ```
 
-같은 키가 `skipSearch` 컬럼이면서 `extraKeys`에도 있으면 제외가 우선합니다.
+둘 다 컬럼 `key`와 동일하게 점 표기 경로(`'metadata.email'`)를 지원합니다. 어떤 키가 `skipSearch` 컬럼이거나 그 하위 경로이면, `extraKeys`에 있어도 제외가 우선합니다.
 
 ### 행 선택
 

--- a/packages/vlossom/src/components/vs-table/README.md
+++ b/packages/vlossom/src/components/vs-table/README.md
@@ -42,6 +42,30 @@ const items = [
 </template>
 ```
 
+### Search Scope
+
+Search matches against the values rendered in the table body, so a column's `transform` result is searched exactly as it is displayed. Two options adjust that scope:
+
+- `skipSearch` on a column excludes a rendered column from the search.
+- `search.extraKeys` adds item fields that no column renders — useful when a slot pulls the value into another cell, or when you want to filter on hidden metadata.
+
+```html
+<template>
+    <vs-table :columns="columns" :items="items" :search="{ extraKeys: ['tags'] }">
+        <template #body-name="{ item }">{{ item.name }} ({{ item.tags }})</template>
+    </vs-table>
+</template>
+
+<script setup>
+const columns = [
+    { key: 'name', label: 'Name' },
+    { key: 'note', label: 'Note', skipSearch: true },
+];
+</script>
+```
+
+If a key is both a `skipSearch` column and listed in `extraKeys`, it stays excluded.
+
 ### Selectable Rows
 
 ```html
@@ -123,7 +147,7 @@ Provide an `empty` slot to replace the default "NO DATA" placeholder when `items
 | `pagination`      | `boolean \| VsTablePaginationOptions`          | `false`  | Enables pagination                          |
 | `primary`         | `boolean`                                      | `false`  | Applies primary color to the header         |
 | `responsive`      | `boolean`                                      | `false`  | Enables responsive (stacked) layout         |
-| `search`          | `boolean \| SearchProps`                       | `false`  | Enables built-in search                     |
+| `search`          | `boolean \| VsTableSearchOptions`              | `false`  | Enables built-in search                     |
 | `selectable`      | `boolean \| (item, index?, items?) => boolean` | `false`  | Enables row selection                       |
 | `selectedItems`   | `VsTableItem[]`                                | `[]`     | Selected rows, v-model                      |
 | `serverMode`      | `boolean`                                      | `false`  | Switches to server-side pagination mode     |
@@ -146,6 +170,13 @@ interface VsTableStyleSet extends CSSProperties {
     $cell?: CSSProperties;
     $pagination?: VsPaginationStyleSet;
     $pageSizeSelect?: VsSelectStyleSet;
+}
+
+interface VsTableSearchOptions<I = VsTableItem> {
+    useRegex?: boolean;
+    useCaseSensitive?: boolean;
+    placeholder?: string;
+    extraKeys?: VsTableColumnKey<I>[];
 }
 
 interface VsTableColumnDef<I = VsTableItem> {

--- a/packages/vlossom/src/components/vs-table/README.md
+++ b/packages/vlossom/src/components/vs-table/README.md
@@ -64,7 +64,7 @@ const columns = [
 </script>
 ```
 
-If a key is both a `skipSearch` column and listed in `extraKeys`, it stays excluded.
+Both accept dot paths (`'metadata.email'`), same as a column `key`. If a key is a `skipSearch` column — or nested under one — it stays excluded even when listed in `extraKeys`.
 
 ### Selectable Rows
 

--- a/packages/vlossom/src/components/vs-table/VsTable.vue
+++ b/packages/vlossom/src/components/vs-table/VsTable.vue
@@ -87,8 +87,15 @@ import {
 } from 'vue';
 import { useIntersectionObserver, useResizeObserver } from '@vueuse/core';
 import type { SortableEvent } from 'sortablejs';
-import { type SearchProps, type UIState, VsComponent, type PropsOf, type ColorScheme, type Size } from '@/declaration';
-import { logUtil, stringUtil } from '@/utils';
+import {
+    type SearchOptions,
+    type UIState,
+    VsComponent,
+    type PropsOf,
+    type ColorScheme,
+    type Size,
+} from '@/declaration';
+import { logUtil, objectUtil, stringUtil } from '@/utils';
 import { getColorSchemeProps, getStyleSetProps, getSearchProps } from '@/props';
 import { useColorScheme, useSizeClass, useStyleSet } from '@/composables';
 
@@ -103,6 +110,7 @@ import {
     type VsTableStyleSet,
     type VsTablePaginationOptions,
     type VsTablePageSizeOptions,
+    type VsTableSearchOptions,
 } from './types';
 import {
     DEFAULT_PAGE_SIZE_OPTIONS,
@@ -128,7 +136,7 @@ export default defineComponent({
     props: {
         ...getColorSchemeProps(),
         ...getStyleSetProps<VsTableStyleSet>(),
-        ...getSearchProps(),
+        ...getSearchProps<VsTableSearchOptions>(),
         columns: {
             type: Array as PropType<VsTableColumnDef[] | string[]>,
             default: () => [],
@@ -316,7 +324,8 @@ export default defineComponent({
             'vs-primary': primary.value,
             [sizeClass.value]: !!sizeClass.value,
         }));
-        const searchOptions = computed<Exclude<SearchProps, boolean>>(() => table.search.value);
+
+        const searchOptions = computed<SearchOptions>(() => objectUtil.omit(table.search.value, ['extraKeys']));
         const tableColumnStyle = computed(() => ({ gridTemplateColumns: table.gridTemplateColumns.value }));
         const useStickyHeader = computed<boolean>(() => stickyHeader.value && isHeaderOutOfView.value);
 

--- a/packages/vlossom/src/components/vs-table/__stories__/vs-table.stories.ts
+++ b/packages/vlossom/src/components/vs-table/__stories__/vs-table.stories.ts
@@ -64,7 +64,7 @@ const meta: Meta<typeof VsTable> = {
         },
         search: {
             control: { type: 'object' },
-            description: '검색 입력 표시 여부 및 옵션(`useCaseSensitive`, `useRegex`).',
+            description: '검색 입력 표시 여부 및 옵션(`useCaseSensitive`, `useRegex`, `extraKeys`).',
         },
         pagination: {
             control: { type: 'object' },
@@ -269,12 +269,38 @@ export const Searchable: Story = {
             { key: 'metadata.email', label: 'Email', skipSearch: true },
         ],
         items: baseItems,
-        search: { placeholder: 'Search name only', useRegex: true, useCaseSensitive: false },
+        search: { placeholder: 'Search name/age', useRegex: true, useCaseSensitive: false },
     },
     parameters: {
         docs: {
             description: {
-                story: 'search prop을 켜면 검색 입력이 표시되고, `skipSearch`가 설정된 컬럼은 검색 대상에서 제외됩니다.',
+                story:
+                    '검색은 렌더링된 셀 값을 대상으로 동작합니다. `skipSearch`가 설정된 Email 컬럼은 ' +
+                    '화면에 보이지만 검색 대상에서 제외되므로, 이메일 문자열로는 걸러지지 않습니다.',
+            },
+        },
+    },
+};
+
+export const SearchExtraKeys: Story = {
+    args: {
+        columns: [
+            { key: 'name', label: 'Name' },
+            { key: 'age', label: 'Age' },
+        ],
+        items: baseItems.map((item, index) => ({
+            ...item,
+            department: index % 2 === 0 ? 'Engineering' : 'Design',
+        })),
+        search: { placeholder: 'Try "Design"', extraKeys: ['department'] },
+    },
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    '`search.extraKeys`에 지정한 키는 컬럼으로 렌더링되지 않아도 검색 대상에 포함됩니다. ' +
+                    '슬롯으로 값을 끌어와 보여주거나 숨겨진 메타데이터로 필터링할 때 사용합니다. ' +
+                    '이 예시에서 `department`는 화면에 없지만 "Design"으로 검색됩니다.',
             },
         },
     },

--- a/packages/vlossom/src/components/vs-table/__tests__/table-composable.test.ts
+++ b/packages/vlossom/src/components/vs-table/__tests__/table-composable.test.ts
@@ -10,6 +10,7 @@ import {
     type VsTableHeaderCell,
     type VsTableItem,
     type VsTablePaginationOptions,
+    type VsTableSearchOptions,
 } from './../types';
 import { DEFAULT_PAGE_SIZE } from './../constants';
 
@@ -20,6 +21,7 @@ function setupUseTable(
         selectable?: ((item: VsTableItem, index?: number, items?: VsTableItem[]) => boolean) | boolean;
         expandable?: ((item: VsTableItem, index?: number, items?: VsTableItem[]) => boolean) | boolean;
         pagination?: boolean | VsTablePaginationOptions;
+        search?: boolean | VsTableSearchOptions;
         page?: number;
         pageSize?: number;
         serverMode?: boolean;
@@ -172,26 +174,123 @@ describe('useTable', () => {
         expect(table.selectedAll.value).toBe(false);
     });
 
-    it('skipSearch가 지정된 컬럼은 검색 대상에서 제외된다', async () => {
-        const { table, searchInputRef } = setupUseTable({
-            columns: [
-                { key: 'id', label: 'ID', skipSearch: true },
-                { key: 'name', label: '이름' },
-            ],
-            items: [
-                { id: 'XYZ-1', name: 'Carol' },
-                { id: 'ABC-2', name: 'XYZ 사용자' },
-            ],
+    describe('search', () => {
+        function matchXYZ(searchInputRef: Ref<VsSearchInputRef | null>) {
+            searchInputRef.value = {
+                match: (value: string) => String(value).includes('XYZ'),
+            } as any;
+        }
+
+        it('skipSearch가 지정된 컬럼은 검색 대상에서 제외된다', async () => {
+            const { table, searchInputRef } = setupUseTable({
+                columns: [
+                    { key: 'id', label: 'ID', skipSearch: true },
+                    { key: 'name', label: '이름' },
+                ],
+                items: [
+                    { id: 'XYZ-1', name: 'Carol' },
+                    { id: 'ABC-2', name: 'XYZ 사용자' },
+                ],
+            });
+            await nextTick();
+
+            matchXYZ(searchInputRef);
+            await nextTick();
+
+            const filteredNames = table.bodyRows.value.map((row) => row.cells[1].value);
+            expect(filteredNames).toEqual(['XYZ 사용자']);
         });
-        await nextTick();
 
-        searchInputRef.value = {
-            match: (value: string) => String(value).includes('XYZ'),
-        } as any;
-        await nextTick();
+        it('중첩 키 컬럼에 지정된 skipSearch도 검색 대상에서 제외된다', async () => {
+            const { table, searchInputRef } = setupUseTable({
+                columns: [
+                    { key: 'name', label: '이름' },
+                    { key: 'metadata.email', label: '이메일', skipSearch: true },
+                ],
+                items: [
+                    { name: 'Carol', metadata: { email: 'XYZ@example.com' } },
+                    { name: 'XYZ 사용자', metadata: { email: 'bob@example.com' } },
+                ],
+            });
+            await nextTick();
 
-        const filteredNames = table.bodyRows.value.map((row) => row.cells[1].value);
-        expect(filteredNames).toEqual(['XYZ 사용자']);
+            matchXYZ(searchInputRef);
+            await nextTick();
+
+            expect(table.bodyRows.value.map((row) => row.cells[0].value)).toEqual(['XYZ 사용자']);
+        });
+
+        it('컬럼으로 정의되지 않은 필드는 검색 대상에 포함되지 않는다', async () => {
+            const { table, searchInputRef } = setupUseTable({
+                columns: [{ key: 'name', label: '이름' }],
+                items: [
+                    { name: 'Carol', memo: 'XYZ 메모' },
+                    { name: 'XYZ 사용자', memo: '' },
+                ],
+            });
+            await nextTick();
+
+            matchXYZ(searchInputRef);
+            await nextTick();
+
+            expect(table.bodyRows.value.map((row) => row.cells[0].value)).toEqual(['XYZ 사용자']);
+        });
+
+        it('search.extraKeys에 지정한 필드는 컬럼이 없어도 검색 대상에 포함된다', async () => {
+            const { table, searchInputRef } = setupUseTable({
+                columns: [{ key: 'name', label: '이름' }],
+                items: [
+                    { name: 'Carol', memo: 'XYZ 메모' },
+                    { name: 'Bob', memo: '' },
+                ],
+                search: { extraKeys: ['memo'] },
+            });
+            await nextTick();
+
+            matchXYZ(searchInputRef);
+            await nextTick();
+
+            expect(table.bodyRows.value.map((row) => row.cells[0].value)).toEqual(['Carol']);
+        });
+
+        it('skipSearch와 extraKeys가 같은 키를 가리키면 skipSearch가 우선한다', async () => {
+            const { table, searchInputRef } = setupUseTable({
+                columns: [
+                    { key: 'name', label: '이름' },
+                    { key: 'memo', label: '메모', skipSearch: true },
+                ],
+                items: [
+                    { name: 'Carol', memo: 'XYZ 메모' },
+                    { name: 'Bob', memo: '' },
+                ],
+                search: { extraKeys: ['memo'] },
+            });
+            await nextTick();
+
+            matchXYZ(searchInputRef);
+            await nextTick();
+
+            expect(table.bodyRows.value).toHaveLength(0);
+        });
+
+        it('transform이 적용된 렌더 값으로 검색한다', async () => {
+            const { table, searchInputRef } = setupUseTable({
+                columns: [
+                    { key: 'name', label: '이름' },
+                    { key: 'status', label: '상태', transform: (value: string) => (value === 'on' ? 'XYZ' : 'ABC') },
+                ],
+                items: [
+                    { name: 'Carol', status: 'on' },
+                    { name: 'Bob', status: 'off' },
+                ],
+            });
+            await nextTick();
+
+            matchXYZ(searchInputRef);
+            await nextTick();
+
+            expect(table.bodyRows.value.map((row) => row.cells[0].value)).toEqual(['Carol']);
+        });
     });
 
     describe('pagination', () => {

--- a/packages/vlossom/src/components/vs-table/__tests__/table-composable.test.ts
+++ b/packages/vlossom/src/components/vs-table/__tests__/table-composable.test.ts
@@ -273,6 +273,43 @@ describe('useTable', () => {
             expect(table.bodyRows.value).toHaveLength(0);
         });
 
+        it('extraKeys에 중첩 키를 지정하면 해당 경로의 값으로 검색한다', async () => {
+            const { table, searchInputRef } = setupUseTable({
+                columns: [{ key: 'name', label: '이름' }],
+                items: [
+                    { name: 'Carol', memo: { content: 'XYZ 메모' } },
+                    { name: 'Bob', memo: { content: '' } },
+                ],
+                search: { extraKeys: ['memo.content'] },
+            });
+            await nextTick();
+
+            matchXYZ(searchInputRef);
+            await nextTick();
+
+            expect(table.bodyRows.value.map((row) => row.cells[0].value)).toEqual(['Carol']);
+        });
+
+        it('skipSearch 컬럼의 하위 경로는 extraKeys로도 되살아나지 않는다', async () => {
+            const { table, searchInputRef } = setupUseTable({
+                columns: [
+                    { key: 'name', label: '이름' },
+                    { key: 'memo', label: '메모', skipSearch: true },
+                ],
+                items: [
+                    { name: 'Carol', memo: { content: 'XYZ 메모' } },
+                    { name: 'Bob', memo: { content: '' } },
+                ],
+                search: { extraKeys: ['memo.content'] },
+            });
+            await nextTick();
+
+            matchXYZ(searchInputRef);
+            await nextTick();
+
+            expect(table.bodyRows.value).toHaveLength(0);
+        });
+
         it('transform이 적용된 렌더 값으로 검색한다', async () => {
             const { table, searchInputRef } = setupUseTable({
                 columns: [

--- a/packages/vlossom/src/components/vs-table/composables/table-composable.ts
+++ b/packages/vlossom/src/components/vs-table/composables/table-composable.ts
@@ -9,7 +9,7 @@ import {
     type WritableComputedRef,
 } from 'vue';
 import { functionUtil, objectUtil, stringUtil } from '@/utils';
-import { type UIState, type VsComponent, type PropsOf, type SearchProps, type Size } from '@/declaration';
+import { type UIState, type VsComponent, type PropsOf, type Size } from '@/declaration';
 import type { VsSearchInputRef } from '@/components';
 
 import {
@@ -20,6 +20,7 @@ import {
     type VsTableItem,
     type VsTableRow,
     type VsTablePaginationOptions,
+    type VsTableSearchOptions,
 } from './../types';
 import { TableCellBuilder } from './../models/table-cell-builder';
 import { isVsTableColumnDefArray } from './../models/table-model';
@@ -95,7 +96,7 @@ export function useTable(
     const selectedItems = computed<VsTableItem[]>(() => {
         return rawSelectedItems?.value ?? [];
     });
-    const search = computed<Exclude<SearchProps, boolean>>(() => {
+    const search = computed<VsTableSearchOptions>(() => {
         if (!rawSearch?.value) {
             return {};
         }
@@ -165,7 +166,7 @@ export function useTable(
     const tableCellBuilder = new TableCellBuilder(tableId, items.value, columns.value);
     const { anyExpandable, isExpanded, toggleExpand, setExpand } = useTableExpand(expandable, items);
     const { sortType, sortColumn, compareRows, updateSortType } = useTableSort(columns);
-    const { matchBySearch } = useTableSearch(refs.searchInputRef, columns);
+    const { matchBySearch } = useTableSearch(refs.searchInputRef, columns, search);
     const {
         selectedItems: internalSelectedItems,
         selectedAll,
@@ -326,7 +327,7 @@ export type TableComposable = {
     draggable: Ref<boolean | undefined> | undefined;
     primary: Ref<boolean | undefined> | undefined;
     size: Ref<Size | undefined> | undefined;
-    search: ComputedRef<Exclude<SearchProps, boolean>>;
+    search: ComputedRef<VsTableSearchOptions>;
     pagination: ComputedRef<VsTablePaginationOptions>;
     page: WritableComputedRef<number>;
     pageSize: WritableComputedRef<number>;

--- a/packages/vlossom/src/components/vs-table/composables/table-search-composable.ts
+++ b/packages/vlossom/src/components/vs-table/composables/table-search-composable.ts
@@ -1,30 +1,45 @@
 import { computed, type ComputedRef, type Ref } from 'vue';
 import type { VsSearchInputRef } from '@/components';
 import { objectUtil } from '@/utils';
-import { type VsTableColumnDef, type VsTableRow } from './../types';
+import { type VsTableColumnDef, type VsTableRow, type VsTableSearchOptions } from './../types';
 
-export function useTableSearch(ref: Ref<VsSearchInputRef | null>, columns: ComputedRef<VsTableColumnDef[] | null>) {
-    const skipKeyList = computed<string[]>(() => {
-        if (!columns.value) {
-            return [];
-        }
-        return columns.value.filter((col) => col.skipSearch).map((column) => column.key);
+function toSearchText(value: unknown): string {
+    if (value === null || value === undefined) {
+        return '';
+    }
+    if (Array.isArray(value) || objectUtil.isObject(value)) {
+        return Object.values(objectUtil.crush(value)).map(toSearchText).filter(Boolean).join(' ');
+    }
+    return String(value);
+}
+
+export function useTableSearch(
+    ref: Ref<VsSearchInputRef | null>,
+    columns: ComputedRef<VsTableColumnDef[] | null>,
+    search: ComputedRef<VsTableSearchOptions>,
+) {
+    const skipKeys = computed<Set<string>>(() => {
+        const keys = (columns.value ?? []).filter((column) => column.skipSearch).map((column) => column.key);
+        return new Set(keys);
+    });
+
+    // 같은 키가 skipSearch 컬럼이면서 extraKeys에도 있으면, 노출 사고를 막기 위해 제외를 우선한다.
+    const extraKeys = computed<string[]>(() => {
+        return (search.value.extraKeys ?? []).filter((key) => !skipKeys.value.has(key));
     });
 
     function matchBySearch(row: VsTableRow): boolean {
         if (!ref.value) {
             return true;
         }
-        const item = row.item;
-        if (!item) {
-            return false;
-        }
-        const brushedItem = objectUtil.omit(item, skipKeyList.value);
-        const crushedItem = objectUtil.crush(brushedItem);
-        const search = ref.value.match;
 
-        const flattenedItemText = Object.values(crushedItem).join(' ');
-        return search(flattenedItemText);
+        const cellTexts = row.cells
+            .filter((cell) => !skipKeys.value.has(cell.colKey))
+            .map((cell) => toSearchText(cell.value));
+        const extraTexts = extraKeys.value.map((key) => toSearchText(objectUtil.get(row.item, key)));
+
+        const flattenedItemText = [...cellTexts, ...extraTexts].filter(Boolean).join(' ');
+        return ref.value.match(flattenedItemText);
     }
 
     return {

--- a/packages/vlossom/src/components/vs-table/composables/table-search-composable.ts
+++ b/packages/vlossom/src/components/vs-table/composables/table-search-composable.ts
@@ -24,8 +24,11 @@ export function useTableSearch(
     });
 
     // 같은 키가 skipSearch 컬럼이면서 extraKeys에도 있으면, 노출 사고를 막기 위해 제외를 우선한다.
+    // 부모 컬럼을 제외했는데 하위 경로가 extraKeys로 되살아나지 않도록 prefix까지 본다.
     const extraKeys = computed<string[]>(() => {
-        return (search.value.extraKeys ?? []).filter((key) => !skipKeys.value.has(key));
+        const isSkipped = (key: string) =>
+            [...skipKeys.value].some((skipKey) => key === skipKey || key.startsWith(`${skipKey}.`));
+        return (search.value.extraKeys ?? []).filter((key) => !isSkipped(key));
     });
 
     function matchBySearch(row: VsTableRow): boolean {

--- a/packages/vlossom/src/components/vs-table/constants.ts
+++ b/packages/vlossom/src/components/vs-table/constants.ts
@@ -1,9 +1,8 @@
-import type { SearchProps } from '@/declaration';
+import type { SearchOptions } from '@/declaration';
 import type { VsTablePageSizeOption, VsTablePageSizeOptions, VsTablePaginationOptions } from './types';
 import type { Options as SortableOptions } from 'sortablejs';
 
-export const TABLE_SEARCH_OPTIONS: Exclude<SearchProps, boolean> = {
-    placeholder: 'Search',
+export const TABLE_SEARCH_OPTIONS: SearchOptions = {
     useCaseSensitive: true,
     useRegex: true,
 } as const;

--- a/packages/vlossom/src/components/vs-table/types.ts
+++ b/packages/vlossom/src/components/vs-table/types.ts
@@ -1,5 +1,5 @@
 import type { ComponentPublicInstance, CSSProperties } from 'vue';
-import type { SizeProp, TextAlignment, VerticalAlignment } from '@/declaration';
+import type { SearchOptions, SizeProp, TextAlignment, VerticalAlignment } from '@/declaration';
 import type VsTable from './VsTable.vue';
 import type { VsSearchInputStyleSet } from '@/components/vs-search-input/types';
 import type { VsPaginationStyleSet } from '@/components/vs-pagination/types';
@@ -70,6 +70,10 @@ export enum VsTableSortType {
     NONE,
     ASCEND,
     DESCEND,
+}
+
+export interface VsTableSearchOptions<I = VsTableItem> extends SearchOptions {
+    extraKeys?: VsTableColumnKey<I>[];
 }
 
 export interface VsTableColumnDef<I = VsTableItem> {

--- a/packages/vlossom/src/declaration/types.ts
+++ b/packages/vlossom/src/declaration/types.ts
@@ -125,7 +125,13 @@ export interface StringModifiers {
     upper?: boolean;
 }
 
-export type SearchProps = boolean | { useRegex?: boolean; useCaseSensitive?: boolean; placeholder?: string };
+export interface SearchOptions {
+    useRegex?: boolean;
+    useCaseSensitive?: boolean;
+    placeholder?: string;
+}
+
+export type SearchProps = boolean | SearchOptions;
 
 export interface OptionItem {
     id: string;

--- a/packages/vlossom/src/props/search-props.ts
+++ b/packages/vlossom/src/props/search-props.ts
@@ -1,13 +1,13 @@
 import type { PropType } from 'vue';
-import type { SearchProps } from '@/declaration';
+import type { SearchOptions } from '@/declaration';
 import { objectUtil } from '@/utils';
 
-export function getSearchProps() {
+export function getSearchProps<T extends SearchOptions = SearchOptions>() {
     return {
         search: {
-            type: [Boolean, Object] as PropType<SearchProps>,
+            type: [Boolean, Object] as PropType<boolean | T>,
             default: false,
-            validator: (value: SearchProps) => {
+            validator: (value: boolean | T) => {
                 if (typeof value === 'boolean') {
                     return true;
                 }


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
vs-table의 검색 방식을 바꾸고, search prop에 extraKeys 옵션 추가

## Description
- vs-table이 기존에는 보이지 않는 값도 다 검색하고 있었음
  - 이러면 검색 의도와 결과가 오염될 수 있음
  - 기존에 key가 depth가 있는 경우에는 제대로 동작하지 않는 버그도 있었음
- transform 된 값을 기준으로 search 하도록 변경
- search.extraKeys를 추가해서 보이지 않는 column도 검색 대상으로 올리도록 수정함
- depth가 있는 key의 경우에도 검색이 동작하도록 수정함 (기존 버그 수정)
- skipSearch는 동일하게 유지
  - 대신 extraKeys보다 우선순위 높음
  - depth가 있는 key의 경우 skipSearch가 더 상위 key라면 extraKeys에서도 동작 안 함 (ex) memo, memo.content

### 기타
- vs-search-input placeholder 기본값을 'Search'로 설정
<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
