### PR TITLE
fix(VsSelect): add no options slot

### DIFF
--- a/packages/vlossom/src/components/vs-grouped-list/README.ko.md
+++ b/packages/vlossom/src/components/vs-grouped-list/README.ko.md
@@ -114,6 +114,7 @@ interface VsGroupedListStyleSet extends CSSProperties {
 | ---- | ---- |
 | `header` | 스크롤 가능한 목록 헤더의 콘텐츠 |
 | `footer` | 스크롤 가능한 목록 푸터의 콘텐츠 |
+| `empty` | `items`가 비어 있을 때 목록 본문에 표시되는 콘텐츠 |
 | `group` | 그룹 헤더의 사용자 정의 렌더링. `{ group: string, groupIndex: number, items: OptionItem[] }` 제공 |
 | `item` | 항목의 사용자 정의 렌더링. `OptionItem` 필드와 `{ groupedIndex, group, groupIndex }` 제공 |
 

--- a/packages/vlossom/src/components/vs-grouped-list/README.md
+++ b/packages/vlossom/src/components/vs-grouped-list/README.md
@@ -114,6 +114,7 @@ interface VsGroupedListStyleSet extends CSSProperties {
 | ---- | ----------- |
 | `header` | Content for the scrollable list header |
 | `footer` | Content for the scrollable list footer |
+| `empty` | Content shown in the list body when `items` is empty |
 | `group` | Custom render for a group header. Receives `{ group: string, groupIndex: number, items: OptionItem[] }` |
 | `item` | Custom render for an item. Receives the `OptionItem` fields plus `{ groupedIndex, group, groupIndex }` |
 

--- a/packages/vlossom/src/components/vs-grouped-list/VsGroupedList.vue
+++ b/packages/vlossom/src/components/vs-grouped-list/VsGroupedList.vue
@@ -39,6 +39,8 @@
             </template>
         </vs-visible-render>
 
+        <slot name="empty" v-if="items.length === 0" />
+
         <template #footer v-if="$slots.footer">
             <slot name="footer" />
         </template>

--- a/packages/vlossom/src/components/vs-grouped-list/__tests__/vs-grouped-list.test.ts
+++ b/packages/vlossom/src/components/vs-grouped-list/__tests__/vs-grouped-list.test.ts
@@ -341,6 +341,38 @@ describe('vs-grouped-list', () => {
         });
     });
 
+    describe('empty slot', () => {
+        it('빈 items 배열일 때 empty slot이 렌더링되어야 한다', () => {
+            // given, when
+            const wrapper = mount(VsGroupedList, {
+                props: {
+                    items: [],
+                },
+                slots: {
+                    empty: '<p class="custom-empty">데이터가 없습니다</p>',
+                },
+            });
+
+            // then
+            expect(wrapper.find('.custom-empty').exists()).toBe(true);
+        });
+
+        it('items가 있으면 empty slot이 렌더링되지 않아야 한다', () => {
+            // given, when
+            const wrapper = mount(VsGroupedList, {
+                props: {
+                    items: defaultItems,
+                },
+                slots: {
+                    empty: '<p class="custom-empty">데이터가 없습니다</p>',
+                },
+            });
+
+            // then
+            expect(wrapper.find('.custom-empty').exists()).toBe(false);
+        });
+    });
+
     describe('scrollToItem', () => {
         it('존재하지 않는 id로 호출해도 오류가 발생하지 않아야 한다', () => {
             // given

--- a/packages/vlossom/src/components/vs-select/README.ko.md
+++ b/packages/vlossom/src/components/vs-select/README.ko.md
@@ -70,43 +70,57 @@ const options = [
 </script>
 ```
 
+### 빈 옵션
+
+`options`가 비어 있거나 검색어에 일치하는 옵션이 없어서 표시할 옵션이 없으면 드롭다운에 기본 empty UI가 나타납니다. `empty` 슬롯으로 이 UI를 대체할 수 있습니다.
+
+```html
+<template>
+    <vs-select v-model="selected" :options="[]" label="과일 선택">
+        <template #empty>
+            <p>선택할 수 있는 과일이 없습니다.</p>
+        </template>
+    </vs-select>
+</template>
+```
+
 ## Props
 
-| Prop              | Type                                                             | Default               | Required | 설명                                                    |
-| ----------------- | ---------------------------------------------------------------- | --------------------- | -------- | ------------------------------------------------------- |
-| `colorScheme`     | `string`                                                         | -                     | -        | 컴포넌트의 색상 스킴                                    |
-| `styleSet`        | `string \| VsSelectStyleSet`                                     | -                     | -        | 컴포넌트에 적용할 커스텀 스타일 세트                    |
-| `disabled`        | `boolean`                                                        | `false`               | -        | 셀렉트 비활성화                                         |
-| `hidden`          | `boolean`                                                        | `false`               | -        | 컴포넌트 숨김                                           |
-| `id`              | `string`                                                         | `''`                  | -        | HTML id 속성                                            |
-| `label`           | `string`                                                         | `''`                  | -        | 셀렉트 레이블 텍스트                                    |
-| `noLabel`         | `boolean`                                                        | `false`               | -        | 레이블 숨김                                             |
-| `noMessages`      | `boolean`                                                        | `false`               | -        | 유효성 검사 메시지 숨김                                 |
-| `required`        | `boolean`                                                        | `false`               | -        | 필수 입력 필드로 지정                                   |
-| `messages`        | `Message[]`                                                      | `[]`                  | -        | 유효성 검사 메시지                                      |
-| `name`            | `string`                                                         | `''`                  | -        | HTML name 속성                                          |
-| `noDefaultRules`  | `boolean`                                                        | `false`               | -        | 내장 유효성 검사 규칙 비활성화                          |
-| `readonly`        | `boolean`                                                        | `false`               | -        | 셀렉트를 읽기 전용으로 설정                             |
-| `rules`           | `Rule[]`                                                         | `[]`                  | -        | 커스텀 유효성 검사 규칙                                 |
-| `state`           | `'idle' \| 'info' \| 'success' \| 'warning' \| 'error'`        | `'idle'`              | -        | 유효성 검사 상태                                        |
-| `width`           | `string \| number \| Breakpoints`                                | -                     | -        | 반응형 너비                                             |
-| `grid`            | `string \| number \| Breakpoints`                                | -                     | -        | 그리드 컬럼 스팬                                        |
-| `options`         | `any[]`                                                          | `[]`                  | -        | 옵션 값 또는 객체의 배열                                |
-| `optionLabel`     | `string`                                                         | `''`                  | -        | 옵션이 객체일 때 레이블에 사용할 키 이름                |
-| `optionValue`     | `string`                                                         | `''`                  | -        | 옵션이 객체일 때 값에 사용할 키 이름                    |
-| `groupBy`         | `(option: any, index: number) => string \| null`                 | `null`                | -        | 옵션을 그룹화하는 함수                                  |
-| `groupOrder`      | `string[]`                                                       | `[]`                  | -        | 그룹 순서                                               |
-| `min`             | `number \| string`                                               | `0`                   | -        | 최소 선택 수 (다중 선택 모드)                           |
-| `max`             | `number \| string`                                               | `Number.MAX_SAFE_INTEGER` | -    | 최대 선택 수 (다중 선택 모드)                           |
-| `search`          | `boolean \| SearchProps`                                         | `false`               | -        | 내장 검색 기능 활성화                                   |
-| `closableChips`   | `boolean`                                                        | `false`               | -        | 선택된 칩에 닫기 버튼 표시                              |
-| `collapseChips`   | `boolean`                                                        | `false`               | -        | 선택된 칩을 개수 표시로 접기                            |
-| `multiple`        | `boolean`                                                        | `false`               | -        | 다중 선택 모드 활성화                                   |
-| `noClear`         | `boolean`                                                        | `false`               | -        | 초기화 버튼 숨김                                        |
-| `optionsDisabled` | `boolean \| ((option: any, index: number, options: any[]) => boolean)` | `false`       | -        | 개별 옵션 비활성화                                      |
-| `selectAll`       | `boolean`                                                        | `false`               | -        | 전체 선택 체크박스 표시 (다중 선택 모드)                |
-| `size`            | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'`                           | `'md'`                | -        | 트리거 높이 · 패딩 · 폰트 · 모서리 반경 및 옵션 드롭다운(패딩 · 폰트 · 모서리 반경) 제어 |
-| `modelValue`      | `any`                                                            | `null`                | -        | 선택된 값 (v-model)                                     |
+| Prop              | Type                                                                   | Default                   | Required | 설명                                                                                     |
+| ----------------- | ---------------------------------------------------------------------- | ------------------------- | -------- | ---------------------------------------------------------------------------------------- |
+| `colorScheme`     | `string`                                                               | -                         | -        | 컴포넌트의 색상 스킴                                                                     |
+| `styleSet`        | `string \| VsSelectStyleSet`                                           | -                         | -        | 컴포넌트에 적용할 커스텀 스타일 세트                                                     |
+| `disabled`        | `boolean`                                                              | `false`                   | -        | 셀렉트 비활성화                                                                          |
+| `hidden`          | `boolean`                                                              | `false`                   | -        | 컴포넌트 숨김                                                                            |
+| `id`              | `string`                                                               | `''`                      | -        | HTML id 속성                                                                             |
+| `label`           | `string`                                                               | `''`                      | -        | 셀렉트 레이블 텍스트                                                                     |
+| `noLabel`         | `boolean`                                                              | `false`                   | -        | 레이블 숨김                                                                              |
+| `noMessages`      | `boolean`                                                              | `false`                   | -        | 유효성 검사 메시지 숨김                                                                  |
+| `required`        | `boolean`                                                              | `false`                   | -        | 필수 입력 필드로 지정                                                                    |
+| `messages`        | `Message[]`                                                            | `[]`                      | -        | 유효성 검사 메시지                                                                       |
+| `name`            | `string`                                                               | `''`                      | -        | HTML name 속성                                                                           |
+| `noDefaultRules`  | `boolean`                                                              | `false`                   | -        | 내장 유효성 검사 규칙 비활성화                                                           |
+| `readonly`        | `boolean`                                                              | `false`                   | -        | 셀렉트를 읽기 전용으로 설정                                                              |
+| `rules`           | `Rule[]`                                                               | `[]`                      | -        | 커스텀 유효성 검사 규칙                                                                  |
+| `state`           | `'idle' \| 'info' \| 'success' \| 'warning' \| 'error'`                | `'idle'`                  | -        | 유효성 검사 상태                                                                         |
+| `width`           | `string \| number \| Breakpoints`                                      | -                         | -        | 반응형 너비                                                                              |
+| `grid`            | `string \| number \| Breakpoints`                                      | -                         | -        | 그리드 컬럼 스팬                                                                         |
+| `options`         | `any[]`                                                                | `[]`                      | -        | 옵션 값 또는 객체의 배열                                                                 |
+| `optionLabel`     | `string`                                                               | `''`                      | -        | 옵션이 객체일 때 레이블에 사용할 키 이름                                                 |
+| `optionValue`     | `string`                                                               | `''`                      | -        | 옵션이 객체일 때 값에 사용할 키 이름                                                     |
+| `groupBy`         | `(option: any, index: number) => string \| null`                       | `null`                    | -        | 옵션을 그룹화하는 함수                                                                   |
+| `groupOrder`      | `string[]`                                                             | `[]`                      | -        | 그룹 순서                                                                                |
+| `min`             | `number \| string`                                                     | `0`                       | -        | 최소 선택 수 (다중 선택 모드)                                                            |
+| `max`             | `number \| string`                                                     | `Number.MAX_SAFE_INTEGER` | -        | 최대 선택 수 (다중 선택 모드)                                                            |
+| `search`          | `boolean \| SearchProps`                                               | `false`                   | -        | 내장 검색 기능 활성화                                                                    |
+| `closableChips`   | `boolean`                                                              | `false`                   | -        | 선택된 칩에 닫기 버튼 표시                                                               |
+| `collapseChips`   | `boolean`                                                              | `false`                   | -        | 선택된 칩을 개수 표시로 접기                                                             |
+| `multiple`        | `boolean`                                                              | `false`                   | -        | 다중 선택 모드 활성화                                                                    |
+| `noClear`         | `boolean`                                                              | `false`                   | -        | 초기화 버튼 숨김                                                                         |
+| `optionsDisabled` | `boolean \| ((option: any, index: number, options: any[]) => boolean)` | `false`                   | -        | 개별 옵션 비활성화                                                                       |
+| `selectAll`       | `boolean`                                                              | `false`                   | -        | 전체 선택 체크박스 표시 (다중 선택 모드)                                                 |
+| `size`            | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'`                                 | `'md'`                    | -        | 트리거 높이 · 패딩 · 폰트 · 모서리 반경 및 옵션 드롭다운(패딩 · 폰트 · 모서리 반경) 제어 |
+| `modelValue`      | `any`                                                                  | `null`                    | -        | 선택된 값 (v-model)                                                                      |
 
 ## Types
 
@@ -146,29 +160,30 @@ interface VsSelectStyleSet extends CSSProperties {
 
 ## Events
 
-| Event               | Payload       | 설명                                       |
-| ------------------- | ------------- | ------------------------------------------ |
-| `update:modelValue` | `any`         | 선택 값이 변경될 때 발생                   |
-| `update:changed`    | `boolean`     | changed 상태가 업데이트될 때 발생          |
-| `update:valid`      | `boolean`     | 유효성 검사 상태가 업데이트될 때 발생      |
-| `change`            | `any`         | 선택 값이 변경될 때 발생                   |
-| `focus`             | `FocusEvent`  | 트리거가 포커스를 받을 때 발생             |
-| `blur`              | `FocusEvent`  | 트리거가 포커스를 잃을 때 발생             |
-| `click-option`      | `OptionItem`  | 옵션이 클릭될 때 발생                      |
-| `open`              | -             | 드롭다운이 열릴 때 발생                    |
-| `close`             | -             | 드롭다운이 닫힐 때 발생                    |
-| `clear`             | `any`         | 선택 값이 초기화될 때 초기화 직전 값과 함께 발생 |
+| Event               | Payload      | 설명                                             |
+| ------------------- | ------------ | ------------------------------------------------ |
+| `update:modelValue` | `any`        | 선택 값이 변경될 때 발생                         |
+| `update:changed`    | `boolean`    | changed 상태가 업데이트될 때 발생                |
+| `update:valid`      | `boolean`    | 유효성 검사 상태가 업데이트될 때 발생            |
+| `change`            | `any`        | 선택 값이 변경될 때 발생                         |
+| `focus`             | `FocusEvent` | 트리거가 포커스를 받을 때 발생                   |
+| `blur`              | `FocusEvent` | 트리거가 포커스를 잃을 때 발생                   |
+| `click-option`      | `OptionItem` | 옵션이 클릭될 때 발생                            |
+| `open`              | -            | 드롭다운이 열릴 때 발생                          |
+| `close`             | -            | 드롭다운이 닫힐 때 발생                          |
+| `clear`             | `any`        | 선택 값이 초기화될 때 초기화 직전 값과 함께 발생 |
 
 ## Slots
 
-| Slot               | 설명                                                              |
-| ------------------ | ----------------------------------------------------------------- |
-| `label`            | 커스텀 레이블 콘텐츠                                              |
-| `options-header`   | 옵션 목록 위의 커스텀 콘텐츠                                      |
-| `options-footer`   | 옵션 목록 아래의 커스텀 콘텐츠                                    |
-| `group`            | 커스텀 그룹 헤더; 그룹 슬롯 props 수신                            |
-| `option`           | 커스텀 옵션 콘텐츠; `{ id, option, label, value, index, disabled, group, groupIndex, groupedIndex, selected }` 수신 |
-| `messages`         | 커스텀 유효성 검사 메시지                                         |
+| Slot             | 설명                                                                                                                |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `label`          | 커스텀 레이블 콘텐츠                                                                                                |
+| `options-header` | 옵션 목록 위의 커스텀 콘텐츠                                                                                        |
+| `options-footer` | 옵션 목록 아래의 커스텀 콘텐츠                                                                                      |
+| `group`          | 커스텀 그룹 헤더; 그룹 슬롯 props 수신                                                                              |
+| `option`         | 커스텀 옵션 콘텐츠; `{ id, option, label, value, index, disabled, group, groupIndex, groupedIndex, selected }` 수신 |
+| `empty`          | 표시할 옵션이 없을 때 보여줄 커스텀 콘텐츠                                                                          |
+| `messages`       | 커스텀 유효성 검사 메시지                                                                                           |
 
 ## Methods
 
@@ -179,7 +194,7 @@ interface VsSelectStyleSet extends CSSProperties {
 | `openOptions`  | -          | 옵션 드롭다운 열기            |
 | `closeOptions` | -          | 옵션 드롭다운 닫기            |
 | `validate`     | -          | 유효성 검사 실행              |
-| `clear`        | -          | 선택 값 비우기               |
+| `clear`        | -          | 선택 값 비우기                |
 | `reset`        | -          | 선택 값을 초기값으로 되돌리기 |
 
 ## Cautions

--- a/packages/vlossom/src/components/vs-select/README.md
+++ b/packages/vlossom/src/components/vs-select/README.md
@@ -70,43 +70,57 @@ const options = [
 </script>
 ```
 
+### Empty Options
+
+When there is no option to show — because `options` is empty or the search keyword matches nothing — the dropdown shows a default empty UI. Use the `empty` slot to replace it.
+
+```html
+<template>
+    <vs-select v-model="selected" :options="[]" label="Choose a fruit">
+        <template #empty>
+            <p>No fruit is available yet.</p>
+        </template>
+    </vs-select>
+</template>
+```
+
 ## Props
 
-| Prop              | Type                                                             | Default               | Required | Description                                             |
-| ----------------- | ---------------------------------------------------------------- | --------------------- | -------- | ------------------------------------------------------- |
-| `colorScheme`     | `string`                                                         | -                     | -        | Color scheme for the component                          |
-| `styleSet`        | `string \| VsSelectStyleSet`                                     | -                     | -        | Custom style set for the component                      |
-| `disabled`        | `boolean`                                                        | `false`               | -        | Disables the select                                     |
-| `hidden`          | `boolean`                                                        | `false`               | -        | Hides the component                                     |
-| `id`              | `string`                                                         | `''`                  | -        | HTML id attribute                                       |
-| `label`           | `string`                                                         | `''`                  | -        | Label text for the select                               |
-| `noLabel`         | `boolean`                                                        | `false`               | -        | Hides the label                                         |
-| `noMessages`      | `boolean`                                                        | `false`               | -        | Hides validation messages                               |
-| `required`        | `boolean`                                                        | `false`               | -        | Marks the field as required                             |
-| `messages`        | `Message[]`                                                      | `[]`                  | -        | Validation messages                                     |
-| `name`            | `string`                                                         | `''`                  | -        | HTML name attribute                                     |
-| `noDefaultRules`  | `boolean`                                                        | `false`               | -        | Disables built-in validation rules                      |
-| `readonly`        | `boolean`                                                        | `false`               | -        | Makes the select read-only                              |
-| `rules`           | `Rule[]`                                                         | `[]`                  | -        | Custom validation rules                                 |
-| `state`           | `'idle' \| 'info' \| 'success' \| 'warning' \| 'error'`        | `'idle'`              | -        | Validation state                                        |
-| `width`           | `string \| number \| Breakpoints`                                | -                     | -        | Responsive width                                        |
-| `grid`            | `string \| number \| Breakpoints`                                | -                     | -        | Grid column span                                        |
-| `options`         | `any[]`                                                          | `[]`                  | -        | Array of option values or objects                       |
-| `optionLabel`     | `string`                                                         | `''`                  | -        | Key name for the label when options are objects         |
-| `optionValue`     | `string`                                                         | `''`                  | -        | Key name for the value when options are objects         |
-| `groupBy`         | `(option: any, index: number) => string \| null`                 | `null`                | -        | Function to group options by a string key               |
-| `groupOrder`      | `string[]`                                                       | `[]`                  | -        | Order of groups                                         |
-| `min`             | `number \| string`                                               | `0`                   | -        | Minimum number of selections (multiple mode)            |
-| `max`             | `number \| string`                                               | `Number.MAX_SAFE_INTEGER` | -    | Maximum number of selections (multiple mode)            |
-| `search`          | `boolean \| SearchProps`                                         | `false`               | -        | Enables built-in search                                 |
-| `closableChips`   | `boolean`                                                        | `false`               | -        | Shows a close button on selected chips                  |
-| `collapseChips`   | `boolean`                                                        | `false`               | -        | Collapses selected chips into a count display           |
-| `multiple`        | `boolean`                                                        | `false`               | -        | Enables multiple selection mode                         |
-| `noClear`         | `boolean`                                                        | `false`               | -        | Hides the clear button                                  |
-| `optionsDisabled` | `boolean \| ((option: any, index: number, options: any[]) => boolean)` | `false`       | -        | Disables individual options                             |
-| `selectAll`       | `boolean`                                                        | `false`               | -        | Shows a select-all checkbox (multiple mode)             |
-| `size`            | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'`                           | `'md'`                | -        | Trigger height, padding, font, border-radius, and the options dropdown (padding/font/border-radius) |
-| `modelValue`      | `any`                                                            | `null`                | -        | Selected value (v-model)                                |
+| Prop              | Type                                                                   | Default                   | Required | Description                                                                                         |
+| ----------------- | ---------------------------------------------------------------------- | ------------------------- | -------- | --------------------------------------------------------------------------------------------------- |
+| `colorScheme`     | `string`                                                               | -                         | -        | Color scheme for the component                                                                      |
+| `styleSet`        | `string \| VsSelectStyleSet`                                           | -                         | -        | Custom style set for the component                                                                  |
+| `disabled`        | `boolean`                                                              | `false`                   | -        | Disables the select                                                                                 |
+| `hidden`          | `boolean`                                                              | `false`                   | -        | Hides the component                                                                                 |
+| `id`              | `string`                                                               | `''`                      | -        | HTML id attribute                                                                                   |
+| `label`           | `string`                                                               | `''`                      | -        | Label text for the select                                                                           |
+| `noLabel`         | `boolean`                                                              | `false`                   | -        | Hides the label                                                                                     |
+| `noMessages`      | `boolean`                                                              | `false`                   | -        | Hides validation messages                                                                           |
+| `required`        | `boolean`                                                              | `false`                   | -        | Marks the field as required                                                                         |
+| `messages`        | `Message[]`                                                            | `[]`                      | -        | Validation messages                                                                                 |
+| `name`            | `string`                                                               | `''`                      | -        | HTML name attribute                                                                                 |
+| `noDefaultRules`  | `boolean`                                                              | `false`                   | -        | Disables built-in validation rules                                                                  |
+| `readonly`        | `boolean`                                                              | `false`                   | -        | Makes the select read-only                                                                          |
+| `rules`           | `Rule[]`                                                               | `[]`                      | -        | Custom validation rules                                                                             |
+| `state`           | `'idle' \| 'info' \| 'success' \| 'warning' \| 'error'`                | `'idle'`                  | -        | Validation state                                                                                    |
+| `width`           | `string \| number \| Breakpoints`                                      | -                         | -        | Responsive width                                                                                    |
+| `grid`            | `string \| number \| Breakpoints`                                      | -                         | -        | Grid column span                                                                                    |
+| `options`         | `any[]`                                                                | `[]`                      | -        | Array of option values or objects                                                                   |
+| `optionLabel`     | `string`                                                               | `''`                      | -        | Key name for the label when options are objects                                                     |
+| `optionValue`     | `string`                                                               | `''`                      | -        | Key name for the value when options are objects                                                     |
+| `groupBy`         | `(option: any, index: number) => string \| null`                       | `null`                    | -        | Function to group options by a string key                                                           |
+| `groupOrder`      | `string[]`                                                             | `[]`                      | -        | Order of groups                                                                                     |
+| `min`             | `number \| string`                                                     | `0`                       | -        | Minimum number of selections (multiple mode)                                                        |
+| `max`             | `number \| string`                                                     | `Number.MAX_SAFE_INTEGER` | -        | Maximum number of selections (multiple mode)                                                        |
+| `search`          | `boolean \| SearchProps`                                               | `false`                   | -        | Enables built-in search                                                                             |
+| `closableChips`   | `boolean`                                                              | `false`                   | -        | Shows a close button on selected chips                                                              |
+| `collapseChips`   | `boolean`                                                              | `false`                   | -        | Collapses selected chips into a count display                                                       |
+| `multiple`        | `boolean`                                                              | `false`                   | -        | Enables multiple selection mode                                                                     |
+| `noClear`         | `boolean`                                                              | `false`                   | -        | Hides the clear button                                                                              |
+| `optionsDisabled` | `boolean \| ((option: any, index: number, options: any[]) => boolean)` | `false`                   | -        | Disables individual options                                                                         |
+| `selectAll`       | `boolean`                                                              | `false`                   | -        | Shows a select-all checkbox (multiple mode)                                                         |
+| `size`            | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'`                                 | `'md'`                    | -        | Trigger height, padding, font, border-radius, and the options dropdown (padding/font/border-radius) |
+| `modelValue`      | `any`                                                                  | `null`                    | -        | Selected value (v-model)                                                                            |
 
 ## Types
 
@@ -146,42 +160,42 @@ interface VsSelectStyleSet extends CSSProperties {
 
 ## Events
 
-| Event               | Payload       | Description                                      |
-| ------------------- | ------------- | ------------------------------------------------ |
-| `update:modelValue` | `any`         | Emitted when the selected value changes          |
-| `update:changed`    | `boolean`     | Emitted when the changed state updates           |
-| `update:valid`      | `boolean`     | Emitted when the validation state updates        |
-| `change`            | `any`         | Emitted when the selected value changes          |
-| `focus`             | `FocusEvent`  | Emitted when the trigger receives focus          |
-| `blur`              | `FocusEvent`  | Emitted when the trigger loses focus             |
-| `click-option`      | `OptionItem`  | Emitted when an option is clicked                |
-| `open`              | -             | Emitted when the dropdown opens                  |
-| `close`             | -             | Emitted when the dropdown closes                 |
-| `clear`             | `any`         | Emitted with the previously selected value when the value is cleared |
+| Event               | Payload      | Description                                                          |
+| ------------------- | ------------ | -------------------------------------------------------------------- |
+| `update:modelValue` | `any`        | Emitted when the selected value changes                              |
+| `update:changed`    | `boolean`    | Emitted when the changed state updates                               |
+| `update:valid`      | `boolean`    | Emitted when the validation state updates                            |
+| `change`            | `any`        | Emitted when the selected value changes                              |
+| `focus`             | `FocusEvent` | Emitted when the trigger receives focus                              |
+| `blur`              | `FocusEvent` | Emitted when the trigger loses focus                                 |
+| `click-option`      | `OptionItem` | Emitted when an option is clicked                                    |
+| `open`              | -            | Emitted when the dropdown opens                                      |
+| `close`             | -            | Emitted when the dropdown closes                                     |
+| `clear`             | `any`        | Emitted with the previously selected value when the value is cleared |
 
 ## Slots
 
-| Slot               | Description                                                          |
-| ------------------ | -------------------------------------------------------------------- |
-| `label`            | Custom label content                                                 |
-| `options-header`   | Custom content above the options list                                |
-| `options-footer`   | Custom content below the options list                                |
-| `group`            | Custom group header; receives group slot props                       |
-| `option`           | Custom option content; receives `{ id, option, label, value, index, disabled, group, groupIndex, groupedIndex, selected }` |
-| `messages`         | Custom validation messages                                           |
+| Slot             | Description                                                                                                                |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `label`          | Custom label content                                                                                                       |
+| `options-header` | Custom content above the options list                                                                                      |
+| `options-footer` | Custom content below the options list                                                                                      |
+| `group`          | Custom group header; receives group slot props                                                                             |
+| `option`         | Custom option content; receives `{ id, option, label, value, index, disabled, group, groupIndex, groupedIndex, selected }` |
+| `empty`          | Custom content shown when there is no option to display                                                                    |
+| `messages`       | Custom validation messages                                                                                                 |
 
 ## Methods
 
-| Method         | Parameters | Description                                     |
-| -------------- | ---------- | ----------------------------------------------- |
-| `focus`        | -          | Focuses the select trigger                      |
-| `blur`         | -          | Blurs the select trigger                        |
-| `openOptions`  | -          | Opens the options dropdown                       |
-| `closeOptions` | -          | Closes the options dropdown                      |
-| `validate`     | -          | Triggers validation                             |
-| `clear`        | -          | Clears the selected value                        |
-| `reset`        | -          | Resets the selected value to its initial value  |
-
+| Method         | Parameters | Description                                    |
+| -------------- | ---------- | ---------------------------------------------- |
+| `focus`        | -          | Focuses the select trigger                     |
+| `blur`         | -          | Blurs the select trigger                       |
+| `openOptions`  | -          | Opens the options dropdown                     |
+| `closeOptions` | -          | Closes the options dropdown                    |
+| `validate`     | -          | Triggers validation                            |
+| `clear`        | -          | Clears the selected value                      |
+| `reset`        | -          | Resets the selected value to its initial value |
 
 ## Cautions
 

--- a/packages/vlossom/src/components/vs-select/VsSelect.css
+++ b/packages/vlossom/src/components/vs-select/VsSelect.css
@@ -101,4 +101,16 @@
             }
         }
     }
+
+    .vs-select-empty {
+        @apply flex flex-col items-center justify-center gap-1 select-none;
+        padding: calc(var(--vs-size-padding, var(--vs-padding-md)) * 1.5);
+
+        color: var(--vs-cs-line);
+
+        .vs-select-empty-icon {
+            width: calc(var(--vs-size-font, var(--vs-font-size-md)) * 1.5);
+            height: calc(var(--vs-size-font, var(--vs-font-size-md)) * 1.5);
+        }
+    }
 }

--- a/packages/vlossom/src/components/vs-select/VsSelect.vue
+++ b/packages/vlossom/src/components/vs-select/VsSelect.vue
@@ -99,6 +99,14 @@
                             </slot>
                         </div>
                     </template>
+                    <template #empty>
+                        <div class="vs-select-empty" @keydown.stop>
+                            <slot name="empty">
+                                <BanIcon class="vs-select-empty-icon" />
+                                <p class="vs-select-empty-text">No Options</p>
+                            </slot>
+                        </div>
+                    </template>
                     <template #footer v-if="$slots['options-footer']">
                         <div class="vs-select-slot" @keydown.stop>
                             <slot name="options-footer" />
@@ -156,6 +164,7 @@ import type { VsSelectStyleSet, VsSelectTriggerRef } from './types';
 import { useSelectRules } from './vs-select-rules';
 import { useSelectValue, useSelectSearch, useSelectKeyboard } from './composables';
 
+import { BanIcon } from '@lucide/vue';
 import type { VsSearchInputRef } from '@/components/vs-search-input/types';
 import type { VsGroupedListRef } from '@/components/vs-grouped-list/types';
 import VsCheckbox from '@/components/vs-checkbox/VsCheckbox.vue';
@@ -168,7 +177,7 @@ import VsSelectTrigger from './VsSelectTrigger.vue';
 const componentName = VsComponent.VsSelect;
 export default defineComponent({
     name: componentName,
-    components: { VsFloating, VsInputWrapper, VsSearchInput, VsCheckbox, VsGroupedList, VsSelectTrigger },
+    components: { VsFloating, VsInputWrapper, VsSearchInput, VsCheckbox, VsGroupedList, VsSelectTrigger, BanIcon },
     props: {
         ...getInputProps<any>(),
         ...getResponsiveProps(),

--- a/packages/vlossom/src/components/vs-select/__tests__/vs-select.test.ts
+++ b/packages/vlossom/src/components/vs-select/__tests__/vs-select.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { nextTick } from 'vue';
 import VsSelect from './../VsSelect.vue';
@@ -120,6 +120,19 @@ describe('VsSelect', () => {
             expect(wrapper.vm.filteredOptions[0].value).toBe(1);
         });
 
+        it('빈 배열 옵션을 전달하면 표시할 옵션이 없다', () => {
+            // given
+            const wrapper = mount(VsSelect, {
+                props: {
+                    options: [],
+                    modelValue: null,
+                },
+            });
+
+            // then
+            expect(wrapper.vm.filteredOptions).toHaveLength(0);
+        });
+
         it('disabled 옵션이 있는 경우 disabled 속성이 설정되어야 한다', () => {
             // given
             const wrapper = mount(VsSelect, {
@@ -134,6 +147,81 @@ describe('VsSelect', () => {
 
             // then
             expect(wrapper.vm.filteredOptions[2].disabled).toBe(true);
+        });
+    });
+
+    describe('empty UI', () => {
+        async function mountAndOpen(options: Record<string, any>) {
+            const wrapper = mount(VsSelect, { attachTo: document.body, ...options });
+
+            wrapper.vm.openOptions();
+            await nextTick();
+            vi.advanceTimersByTime(100);
+            await nextTick();
+            await nextTick();
+
+            return wrapper;
+        }
+
+        beforeEach(() => {
+            vi.useFakeTimers();
+        });
+
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        it('options가 비어 있으면 기본 empty UI가 렌더링된다', async () => {
+            // given, when
+            const wrapper = await mountAndOpen({ props: { options: [], modelValue: null } });
+
+            // then
+            const empty = document.querySelector('.vs-select-empty');
+            expect(empty).not.toBeNull();
+            expect(empty?.textContent).toContain('No Options');
+
+            wrapper.unmount();
+        });
+
+        it('options가 있으면 empty UI가 렌더링되지 않는다', async () => {
+            // given, when
+            const wrapper = await mountAndOpen({ props: { options: basicOptions, modelValue: null } });
+
+            // then
+            expect(document.querySelector('.vs-select-empty')).toBeNull();
+
+            wrapper.unmount();
+        });
+
+        it('empty slot으로 기본 empty UI를 대체할 수 있다', async () => {
+            // given, when
+            const wrapper = await mountAndOpen({
+                props: { options: [], modelValue: null },
+                slots: { empty: '<p class="custom-empty">옵션이 없습니다</p>' },
+            });
+
+            // then
+            const empty = document.querySelector('.vs-select-empty');
+            expect(empty?.textContent).not.toContain('No Options');
+            expect(document.querySelector('.custom-empty')?.textContent).toBe('옵션이 없습니다');
+
+            wrapper.unmount();
+        });
+
+        it('검색 결과가 없으면 empty UI가 렌더링된다', async () => {
+            // given
+            const wrapper = await mountAndOpen({ props: { options: basicOptions, modelValue: null, search: true } });
+            expect(document.querySelector('.vs-select-empty')).toBeNull();
+
+            // when
+            (wrapper.vm.searchInputRef as any).searchText = 'Melon';
+            await nextTick();
+
+            // then
+            expect(wrapper.vm.filteredOptions).toHaveLength(0);
+            expect(document.querySelector('.vs-select-empty')).not.toBeNull();
+
+            wrapper.unmount();
         });
     });
 

--- a/packages/vlossom/stylelint.config.js
+++ b/packages/vlossom/stylelint.config.js
@@ -1,6 +1,21 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import { globSync } from 'glob';
 
 const cssFiles = globSync('./src/**/*.css', { cwd: import.meta.dirname, absolute: true });
+
+// color-scheme.scss는 @each 루프로 --vs-{color}(-soft|-strong)를 만들어서 파일에서 정적으로 추출할 수 없다.
+// $colors 목록만 읽어 SCSS와 같은 규칙으로 변수 이름을 다시 만든다.
+const colorSchemeScss = fs.readFileSync(path.join(import.meta.dirname, 'src/styles/color-scheme.scss'), 'utf-8');
+const colors = (colorSchemeScss.match(/\$colors:([^;]*);/)?.[1] ?? '')
+    .split(',')
+    .map((color) => color.trim().replaceAll("'", ''))
+    .filter(Boolean);
+const semanticColorProperties = Object.fromEntries(
+    colors.flatMap((color) =>
+        [`--vs-${color}-soft`, `--vs-${color}`, `--vs-${color}-strong`].map((name) => [name, '']),
+    ),
+);
 
 /** @type {import('stylelint').Config} */
 export default {
@@ -22,7 +37,7 @@ export default {
         'csstools/value-no-unknown-custom-properties': [
             true,
             {
-                importFrom: cssFiles,
+                importFrom: [...cssFiles, { customProperties: semanticColorProperties }],
             },
         ],
 

--- a/packages/vlossom/stylelint.config.js
+++ b/packages/vlossom/stylelint.config.js
@@ -26,9 +26,6 @@ export default {
         '**/*.vue',
         // SCSS files with dynamic variable interpolation
         '**/color-scheme.scss',
-        '**/state.css',
-        // Tailwind CSS color variables (--color-*) reference
-        '**/pallete.css',
         // Dynamic CSS variables set via inline styles from JS
         '**/vs-responsive/VsResponsive.css',
     ],


### PR DESCRIPTION
## Type of PR (check all applicable)

-   [x] Fix Bug (fix)

## Summary
vs-select empty slot 추가

## Description
empty 상황에서 options 영역이 짜부러짐
그래서 기본 empty UI 추가

<img width="827" height="198" alt="image" src="https://github.com/user-attachments/assets/80666599-3524-49d5-8fa5-ba88dd30ffe5" />
<img width="823" height="228" alt="image" src="https://github.com/user-attachments/assets/15ccc15f-4249-4746-8b8a-5877f0149540" />

#### 기타 작업
CSS stylelint에 색상 변수 추가

<!-- Uncomment below if necessary -->
<!-- ## Screenshots or Recordings -->

<!-- ## Related Tickets & Documents
- Related Issue #
- Closes #
-->
